### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,13 +1,4 @@
 # Lines starting with '#' are comments.
 # Each line is a file pattern followed by one or more owners.
 
-*                                    @MetaMask/engineering
-
-/packages/keyring-api                @MetaMask/accounts-engineers
-
-/packages/keyring-snap               @MetaMask/accounts-engineers
-
-/packages/keyring-eth-hd             @MetaMask/accounts-engineers
-/packages/keyring-eth-ledger-bridge  @MetaMask/devs
-/packages/keyring-eth-simple         @MetaMask/accounts-engineers
-/packages/keyring-eth-trezor         @MetaMask/accounts-engineers
+*                                    @MetaMask/accounts-engineers


### PR DESCRIPTION
## Description

Make the accounts-team the code owners of this monorepo (so this would reduce the gh code owner notifications temporarily). We are actively reworking this repo for now, but we might want to revert/update the code owners in the future.