### PR TITLE
feat(scripts): add packages-checksum-diff.sh to compare checksums between old builds and new builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ node_modules/
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+# Scripts temporary files
+/_*.txt

--- a/scripts/packages-checksum-diff.sh
+++ b/scripts/packages-checksum-diff.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -euo pipefail
+
+readonly REFERENCE_PATH_FILE=_reference_path.txt
+readonly REFERENCE_YARN=4.2.2
+readonly REFERENCE_PACKAGES=(
+  @metamask/eth-hd-keyring@7.0.1
+  @metamask/eth-ledger-bridge-keyring@3.0.1
+  @metamask/eth-simple-keyring@6.0.1
+  @metamask/eth-snap-keyring@4.3.2
+  @metamask/eth-trezor-keyring@3.1.0
+  @metamask/keyring-api@8.1.0
+)
+readonly MONOREPO_PACKAGES_PATH=./packages
+
+# Compute the checksum of every packages from a given workspace
+checksum_of_pkg() {
+  local prefix="$1"
+  local pkg="$2"
+  local path="${prefix}/${pkg}"
+
+  # Some packages uses a "dist" folder
+  local dist_path="${path}/dist"
+  if [ -d "${dist_path}" ]; then
+    path="${dist_path}"
+  fi
+
+  # Look for all "code files" by excluding:
+  # - spurrious config files
+  # - internal node_modules folder
+  find -L "${path}" -type f -name "*.js" -o -name "*.ts" -o -name "*.d.ts" \
+    | grep -v "${pkg}/node_modules" \
+    | grep -v ".eslintrc.js" \
+    | grep -v ".prettierrc.js" \
+    | grep -v "jest.config.js" \
+    | xargs sha3-256sum \
+    | sed "s#${prefix}/##"
+}
+
+# Compute the checksum of every packages from a given workspace
+checksum_of_workspace() {
+  local workspace="$1"
+
+  checksum_of_pkg "${workspace}" keyring-api
+  checksum_of_pkg "${workspace}" eth-snap-keyring
+  checksum_of_pkg "${workspace}" eth-hd-keyring
+  checksum_of_pkg "${workspace}" eth-simple-keyring
+  checksum_of_pkg "${workspace}" eth-ledger-bridge-keyring
+  checksum_of_pkg "${workspace}" eth-trezor-keyring
+}
+
+# Install reference packages in an external folder, so we can compare them
+setup_reference_project() {
+  # This is required in order to have a node_modules folder
+  echo "nodeLinker: node-modules" > .yarnrc.yml
+
+  # Init only once
+  [ -e package.json ] || yarn init -i="${REFERENCE_YARN}"
+
+  # Install all "reference" packages
+  yarn add "${REFERENCE_PACKAGES[@]}"
+  yarn
+}
+
+# Monorepo does use different folder names for some packages, so we use symlink to
+# match the original path
+setup_monorepo_packages_symlinks() {
+  ln -sf keyring-snap ./eth-snap-keyring
+  ln -sf keyring-eth-simple ./eth-simple-keyring
+  ln -sf keyring-eth-hd ./eth-hd-keyring
+  ln -sf keyring-eth-trezor ./eth-trezor-keyring
+  ln -sf keyring-eth-ledger-bridge ./eth-ledger-bridge-keyring
+}
+
+# Get reference project path (either generate a new temporary folder, or use the existing one)
+get_reference_project_path() {
+  # If it does not exists, generate a new temporary folder
+  [ ! -e "${REFERENCE_PATH_FILE}" ] && mktemp -d > "${REFERENCE_PATH_FILE}"
+  cat "${REFERENCE_PATH_FILE}"
+}
+
+# Setup reference project
+REFERENCE_PROJECT_PATH="$(get_reference_project_path)"
+readonly REFERENCE_PROJECT_PATH
+(cd "${REFERENCE_PROJECT_PATH}" && setup_reference_project)
+
+# Setup monorepo + build packages
+rm -f ${MONOREPO_PACKAGES_PATH}/eth-* # Remove symlinks
+yarn build
+(cd "${MONOREPO_PACKAGES_PATH}" && setup_monorepo_packages_symlinks)
+
+# Compare
+diff --color \
+  <(checksum_of_workspace "${REFERENCE_PROJECT_PATH}/node_modules/@metamask") \
+  <(checksum_of_workspace packages)


### PR DESCRIPTION
## Description

This is a small shell script that can be used to compare and `diff` the checksums of each built file between the original packages and the ones being built in the monorepo.

We would like to make sure the new "build system setup" has no real sife-effects that could impact the behavior of each packages.

## How to


The script is going to create a temporary folder and install the original packages in there. It will also build the current packages and then run a `diff` on `dist` generated files.

You can use it like so:

```console
# ./scripts/packages-checksum-diff.sh
```

Here's the current output:
```diff
88c88
< 0f655d07200ab6ee77c3e6b5bfc1e5e02ee6a08bef52f103f4bb35d7ecb2c8b7  eth-hd-keyring/index.js
---
> 8f7680ca2c73eb050f52b4f48a77cecc37a1df8f3a6210ad6a20b79154c3509d  eth-hd-keyring/index.js
93,95c93,101
< cd3bec3312eb0c22b06cf895c1becaa80645039866bdc921e9fafa52c95f26a1  eth-ledger-bridge-keyring/dist/ledger-iframe-bridge.js
< 6bab32e7d7f0abff8dbdf77f6d705d440b8f4f088672f68785a6d8f6674fc981  eth-ledger-bridge-keyring/dist/index.js
< 3a6894635592771fa27d8727cc23e2585994c00de4773f99527fbb253e4725e4  eth-ledger-bridge-keyring/dist/ledger-keyring.d.ts
---
> 3ec475fcd4c7920cff9d8539a8c92077febb4794c76ec77c5b382db685c45a2c  eth-ledger-bridge-keyring/dist/ledger-iframe-bridge.js
> 815746f4d2111f0378c58a0d8809520a368fc28d134a16bded8a2531d48e4133  eth-ledger-bridge-keyring/dist/ledger-hw-app.js
> f43b12f084cc1db8c65c06c72b239f99603155684c04c351441c4c034645463b  eth-ledger-bridge-keyring/dist/type.js
> 2ff2c653b02eb34286b33ff2361810a9ea825badf90f3d0868ebb293427049de  eth-ledger-bridge-keyring/dist/ledger-hw-app.d.ts
> 544ea8a410147fd1bde05edcf380cfce1dced58b3170cbbf9f3524ddfdc3c897  eth-ledger-bridge-keyring/dist/index.js
> 4a13999898ed3c51116f8eaf8f6d2af2bab876091ad39a3a6bafdd652e73f369  eth-ledger-bridge-keyring/dist/ledger-keyring.d.ts
> 714f7fc117fb87c663c95e84a2877a4f82ec9ba5c22230f3d19ccbe93d0dedc1  eth-ledger-bridge-keyring/dist/ledger-transport-middleware.js
> 5f4e97d154741d8f5db48ae11b918089d98e42687f395fa710946b8f73882afd  eth-ledger-bridge-keyring/dist/ledger-mobile-bridge.js
> 7439bb7f093757869da6847908c923ee914d4e3da5c9593e155fb381fe92d22d  eth-ledger-bridge-keyring/dist/ledger-mobile-bridge.d.ts
97,100c103,108
< 3ccae0f41671cc8087b9366242d1b059d5ba8f6f795f113346a98b8240bd19dc  eth-ledger-bridge-keyring/dist/ledger-bridge.d.ts
< a55dbd0ae699a56e76d743d8f35db3d7283549deaf2ae85832fc09811707266e  eth-ledger-bridge-keyring/dist/ledger-iframe-bridge.d.ts
< 016113f1f4805aa499868c226f6ca834015008b88a396d2d7b654544a37eb422  eth-ledger-bridge-keyring/dist/index.d.ts
< 72535e05cefed4cd9fecdad855f17502a5fc886a13fc1596792c716e061a0327  eth-ledger-bridge-keyring/dist/ledger-keyring.js
---
> 0711571868b5d6849d00a55e8112648cc038d61bd6fd9106c7f763b70e208e33  eth-ledger-bridge-keyring/dist/ledger-bridge.d.ts
> f14d75cfda8cddc639e203e2d85a8c2cb3c537b8096269c87ca2a92b80aa5f54  eth-ledger-bridge-keyring/dist/ledger-iframe-bridge.d.ts
> 02b0661da4b51c53305a85a8e0c90bb32c24acd2914866d0c3c7033edae4187c  eth-ledger-bridge-keyring/dist/type.d.ts
> 8f543599ebfd6d994718aa41a4c48f3374aefe17501337e196b0ff61d5c76ae6  eth-ledger-bridge-keyring/dist/index.d.ts
> 18415aff2564d894d6bca9a78f9ed5fcc1af55157390e3941b548ba46c136a68  eth-ledger-bridge-keyring/dist/ledger-keyring.js
> 93a3c64a0d6eb6633ef07953b92a219a27fb93f1ea90554bce7b8a55921f5c49  eth-ledger-bridge-keyring/dist/ledger-transport-middleware.d.ts
106c114
< 08c5438985fd47a69b8c1b7302fd4ef05233a70d05465b1d9895edb04e65e854  eth-trezor-keyring/dist/trezor-connect-bridge.d.ts
---
> 48401d14c9771f39c3ffef1eaba3506a3a5a372f8bb21e2eb1b7c038b87efc2e  eth-trezor-keyring/dist/trezor-connect-bridge.d.ts
```