### PR TITLE
chore(keyring-snap): update @metamask/keyring-api to ^8.1.0

### DIFF
--- a/packages/keyring-snap/package.json
+++ b/packages/keyring-snap/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^7.0.3",
-    "@metamask/keyring-api": "^8.0.2",
+    "@metamask/keyring-api": "^8.1.0",
     "@metamask/snaps-controllers": "^9.3.0",
     "@metamask/snaps-sdk": "^6.1.0",
     "@metamask/snaps-utils": "^7.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1967,7 +1967,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^7.0.3"
-    "@metamask/keyring-api": "npm:^8.0.2"
+    "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/snaps-controllers": "npm:^9.3.0"
     "@metamask/snaps-sdk": "npm:^6.1.0"
     "@metamask/snaps-utils": "npm:^7.8.0"
@@ -2071,7 +2071,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^8.0.2, @metamask/keyring-api@workspace:packages/keyring-api":
+"@metamask/keyring-api@npm:^8.1.0, @metamask/keyring-api@workspace:packages/keyring-api":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-api@workspace:packages/keyring-api"
   dependencies:


### PR DESCRIPTION
## Description

This will be required later on to avoid resolutions conflicts like this one:

```console
➤ YN0000: · Yarn 4.2.2
➤ YN0000: ┌ Resolution step
➤ YN0078: │ Invalid resolution @metamask/keyring-api@npm:^8.0.2 → npm:8.1.0
➤ YN0000: └ Completed
➤ YN0000: · Failed with errors in 0s 109ms
```

This error can be triggered when referencing some local (workspace) packages + using `yarn --check-resolutions`.