### PR TITLE
fix(ci): remove --immutable-cache when installing packages

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable
       - run: yarn lint
       - name: Require clean working directory
         shell: bash
@@ -78,7 +78,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable
       - run: yarn workspace ${{ matrix.package-name }} changelog:validate
       - name: Require clean working directory
         shell: bash
@@ -103,7 +103,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -128,7 +128,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'yarn'
-      - run: yarn --immutable --immutable-cache
+      - run: yarn --immutable
       - run: yarn build
       - run: yarn test
       - name: Require clean working directory


### PR DESCRIPTION
## Description

The CI complained about entries that could not be removed from the cache even though they are no longer required, see:

- https://github.com/MetaMask/accounts/actions/runs/10900174593/job/30247230364

We do remove the `--immutable-cache` here, but we do keep the `--immutable` to avoid having any unintended modification to our lockfile.