### PR TITLE
fix(ci): fix release missing configuration

### DIFF
--- a/release.config.json
+++ b/release.config.json
@@ -1,0 +1,3 @@
+{
+  "versioningStrategy": "independent"
+}


### PR DESCRIPTION
## Description

This configuration was missing.

## Fixes

There is 2 strategies that can be handled by `MetaMask/action-publish-release` action:
- `fixed`: Meaning all packages sharing the same version than the "global" version get released together
  * This was the strategy being used for:
    - https://github.com/MetaMask/accounts/commit/e3522a2f8680e689fc70ce1d5534f4f68fa4c027
    - https://github.com/MetaMask/accounts/actions/runs/10905969009/job/30266281001
- `independent`: Meaning each packages got published with their own versions in a "independent" way
  * This is the strategy that we need for this monorepo