### PR TITLE
release: 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/accounts-monorepo",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Monorepo for MetaMask accounts related packages",
   "repository": {

--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -9,32 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.1.1]
 
-### Uncategorized
+### Changed
 
-- fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
-- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
-- refactor: update all changelogs to use monorepo links
-- build: add changelog:{validate,update} for each packages
-- build(keyring-api): also produces .js during build (required to run keyring-snap tests)
-- build: add yarn build:force command
-- build: use tsc --build rather than tsc --project
-- refactor: update global jest.config.js in packages + use it in packages
-- refactor: remove packages/\*/.gitattributes
-- refactor: remove packages/\*/.editorconfig
-- refactor: move packages/keyring-api/.vscode -> .vscode + remove .vscode from other packages
-- refactor: remove .nvmrc from all packages
-- refactor: migrate depcheck to the top-level
-- chore: run prettier for all package.json
-- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
-- refactor: remove use of constraints.pro
-- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
-- refactor: remove packages/_/.yarn_
-- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
-- refactor: remove packageManager from packages
-- build: re-organize tsconfig.\* + force resolutions
-- build: add new build/test commands for all packages
-- refactor: remove packages/\*/yarn.lock
-- refactor(keyring-api): \* -> packages/keyring-api
+- Convert to monorepo
+  - Package name does not change (`@metamask/keyring-api`) and sources have been moved to: `packages/keyring-api`.
+  - You can find all the changes [here](https://github.com/MetaMask/accounts/compare/6da58b4...38794aa).
 
 ## [8.1.0]
 

--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
+- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
+- refactor: update all changelogs to use monorepo links
+- build: add changelog:{validate,update} for each packages
+- build(keyring-api): also produces .js during build (required to run keyring-snap tests)
+- build: add yarn build:force command
+- build: use tsc --build rather than tsc --project
+- refactor: update global jest.config.js in packages + use it in packages
+- refactor: remove packages/\*/.gitattributes
+- refactor: remove packages/\*/.editorconfig
+- refactor: move packages/keyring-api/.vscode -> .vscode + remove .vscode from other packages
+- refactor: remove .nvmrc from all packages
+- refactor: migrate depcheck to the top-level
+- chore: run prettier for all package.json
+- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
+- refactor: remove use of constraints.pro
+- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
+- refactor: remove packages/_/.yarn_
+- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
+- refactor: remove packageManager from packages
+- build: re-organize tsconfig.\* + force resolutions
+- build: add new build/test commands for all packages
+- refactor: remove packages/\*/yarn.lock
+- refactor(keyring-api): \* -> packages/keyring-api
+
 ## [8.1.0]
 
 ### Added

--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.1]
+
 ### Uncategorized
 
 - fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
@@ -417,7 +419,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SnapController keyring client. It is intended to be used by MetaMask to talk to the snap.
 - Helper functions to create keyring handler in the snap.
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@8.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@8.1.1...HEAD
+[8.1.1]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@8.1.0...@metamask/keyring-api@8.1.1
 [8.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@8.0.2...@metamask/keyring-api@8.1.0
 [8.0.2]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@8.0.1...@metamask/keyring-api@8.0.2
 [8.0.1]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@8.0.0...@metamask/keyring-api@8.0.1

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-api",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "MetaMask Keyring API",
   "keywords": [
     "metamask",

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.2]
+
 ### Uncategorized
 
 - refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
@@ -128,7 +130,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Deserialize method (and `HdKeyring` constructor by extension) can no longer be passed an options object containing a value for `numberOfAccounts` if it is not also containing a value for `mnemonic`.
 - Package name changed from `eth-hd-keyring` to `@metamask/eth-hd-keyring`.
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-hd-keyring@7.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-hd-keyring@7.0.2...HEAD
+[7.0.2]: https://github.com/MetaMask/accounts/compare/@metamask/eth-hd-keyring@7.0.1...@metamask/eth-hd-keyring@7.0.2
 [7.0.1]: https://github.com/MetaMask/accounts/compare/@metamask/eth-hd-keyring@7.0.0...@metamask/eth-hd-keyring@7.0.1
 [7.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-hd-keyring@6.0.2...@metamask/eth-hd-keyring@7.0.0
 [6.0.2]: https://github.com/MetaMask/accounts/compare/@metamask/eth-hd-keyring@6.0.1...@metamask/eth-hd-keyring@6.0.2

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
+- feat: preview builds ([#15](https://github.com/MetaMask/accounts/pull/15))
+- refactor: update all changelogs to use monorepo links
+- chore(keyring-eth-hd): update @metamask/auto-changelog to ^3.4.4
+- build: add changelog:{validate,update} for each packages
+- build: add yarn build:force command
+- refactor: update global jest.config.js in packages + use it in packages
+- refactor: remove .nvmrc from all packages
+- fix(prettier): update changelogs for kerying-eth-{hd,ledger-bridge,simple,trezor}
+- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
+- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
+- refactor: remove packages/_/.yarn_
+- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
+- refactor: remove packageManager from packages
+- build: add new build/test commands for all packages
+- refactor: remove packages/\*/yarn.lock
+- refactor(eth-hd-keyring): \* -> packages/keyring-eth-hd
+
 ## [7.0.1]
 
 ### Changed

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -9,25 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.2]
 
-### Uncategorized
+### Changed
 
-- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
-- feat: preview builds ([#15](https://github.com/MetaMask/accounts/pull/15))
-- refactor: update all changelogs to use monorepo links
-- chore(keyring-eth-hd): update @metamask/auto-changelog to ^3.4.4
-- build: add changelog:{validate,update} for each packages
-- build: add yarn build:force command
-- refactor: update global jest.config.js in packages + use it in packages
-- refactor: remove .nvmrc from all packages
-- fix(prettier): update changelogs for kerying-eth-{hd,ledger-bridge,simple,trezor}
-- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
-- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
-- refactor: remove packages/_/.yarn_
-- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
-- refactor: remove packageManager from packages
-- build: add new build/test commands for all packages
-- refactor: remove packages/\*/yarn.lock
-- refactor(eth-hd-keyring): \* -> packages/keyring-eth-hd
+- Convert to monorepo
+  - Package name does not change (`@metamask/eth-hd-keyring`) and sources have been moved to: `packages/keyring-eth-hd`.
+  - You can find all the changes [here](https://github.com/MetaMask/accounts/compare/6da58b4...38794aa).
 
 ## [7.0.1]
 

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-hd-keyring",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "A simple standard interface for a seed phrase generated set of Ethereum accounts.",
   "keywords": [
     "ethereum",

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
+- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
+- feat: preview builds ([#15](https://github.com/MetaMask/accounts/pull/15))
+- refactor: update all changelogs to use monorepo links
+- build: add changelog:{validate,update} for each packages
+- build: add yarn build:force command
+- build(keyring-eth-ledger-bridge): add @types/web to provide DOM type definitions
+- build: use tsc --build rather than tsc --project
+- refactor: update global jest.config.js in packages + use it in packages
+- refactor: remove packages/\*/.gitattributes
+- refactor: remove packages/\*/.editorconfig
+- refactor: remove .nvmrc from all packages
+- refactor: migrate depcheck to the top-level
+- fix(prettier): update changelogs for kerying-eth-{hd,ledger-bridge,simple,trezor}
+- chore: run prettier for all package.json
+- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
+- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
+- refactor: remove packages/_/.yarn_
+- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
+- refactor: remove packageManager from packages
+- build: re-organize tsconfig.\* + force resolutions
+- build: add new build/test commands for all packages
+- refactor: remove packages/\*/yarn.lock
+- refactor(eth-ledger-bridge-keyring): \* -> packages/keyring-eth-ledger-bridge
+
 ## [4.1.1]
 
 ### Fixed

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -9,32 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.1.2]
 
-### Uncategorized
+### Changed
 
-- fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
-- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
-- feat: preview builds ([#15](https://github.com/MetaMask/accounts/pull/15))
-- refactor: update all changelogs to use monorepo links
-- build: add changelog:{validate,update} for each packages
-- build: add yarn build:force command
-- build(keyring-eth-ledger-bridge): add @types/web to provide DOM type definitions
-- build: use tsc --build rather than tsc --project
-- refactor: update global jest.config.js in packages + use it in packages
-- refactor: remove packages/\*/.gitattributes
-- refactor: remove packages/\*/.editorconfig
-- refactor: remove .nvmrc from all packages
-- refactor: migrate depcheck to the top-level
-- fix(prettier): update changelogs for kerying-eth-{hd,ledger-bridge,simple,trezor}
-- chore: run prettier for all package.json
-- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
-- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
-- refactor: remove packages/_/.yarn_
-- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
-- refactor: remove packageManager from packages
-- build: re-organize tsconfig.\* + force resolutions
-- build: add new build/test commands for all packages
-- refactor: remove packages/\*/yarn.lock
-- refactor(eth-ledger-bridge-keyring): \* -> packages/keyring-eth-ledger-bridge
+- Convert to monorepo
+  - Package name does not change (`@metamask/eth-ledger-bridge-keyring`) and sources have been moved to: `packages/keyring-eth-ledger-bridge`.
+  - You can find all the changes [here](https://github.com/MetaMask/accounts/compare/6da58b4...38794aa).
 
 ## [4.1.1]
 

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.2]
+
 ### Uncategorized
 
 - fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
@@ -189,7 +191,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support new versions of ethereumjs/tx ([#68](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/68))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@4.1.1...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@4.1.2...HEAD
+[4.1.2]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@4.1.1...@metamask/eth-ledger-bridge-keyring@4.1.2
 [4.1.1]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@4.1.0...@metamask/eth-ledger-bridge-keyring@4.1.1
 [4.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@4.0.0...@metamask/eth-ledger-bridge-keyring@4.1.0
 [4.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@3.0.0...@metamask/eth-ledger-bridge-keyring@4.0.0

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-ledger-bridge-keyring",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "A MetaMask compatible keyring, for ledger hardware wallets",
   "keywords": [
     "ethereum",

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
+- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
+- feat: preview builds ([#15](https://github.com/MetaMask/accounts/pull/15))
+- refactor: update all changelogs to use monorepo links
+- build: add changelog:{validate,update} for each packages
+- build: add yarn build:force command
+- build: use tsc --build rather than tsc --project
+- refactor: update global jest.config.js in packages + use it in packages
+- refactor: remove packages/\*/.gitattributes
+- refactor: remove packages/\*/.editorconfig
+- refactor: move packages/keyring-api/.vscode -> .vscode + remove .vscode from other packages
+- refactor: remove .nvmrc from all packages
+- refactor: migrate depcheck to the top-level
+- fix(prettier): update changelogs for kerying-eth-{hd,ledger-bridge,simple,trezor}
+- chore: run prettier for all package.json
+- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
+- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
+- refactor: remove packages/_/.yarn_
+- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
+- refactor: remove packageManager from packages
+- build: re-organize tsconfig.\* + force resolutions
+- build: add new build/test commands for all packages
+- refactor: remove packages/\*/yarn.lock
+- refactor(eth-simple-keyring): \* -> packages/keyring-eth-simple
+
 ## [6.0.2]
 
 ### Changed

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -9,32 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [6.0.3]
 
-### Uncategorized
+### Changed
 
-- fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
-- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
-- feat: preview builds ([#15](https://github.com/MetaMask/accounts/pull/15))
-- refactor: update all changelogs to use monorepo links
-- build: add changelog:{validate,update} for each packages
-- build: add yarn build:force command
-- build: use tsc --build rather than tsc --project
-- refactor: update global jest.config.js in packages + use it in packages
-- refactor: remove packages/\*/.gitattributes
-- refactor: remove packages/\*/.editorconfig
-- refactor: move packages/keyring-api/.vscode -> .vscode + remove .vscode from other packages
-- refactor: remove .nvmrc from all packages
-- refactor: migrate depcheck to the top-level
-- fix(prettier): update changelogs for kerying-eth-{hd,ledger-bridge,simple,trezor}
-- chore: run prettier for all package.json
-- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
-- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
-- refactor: remove packages/_/.yarn_
-- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
-- refactor: remove packageManager from packages
-- build: re-organize tsconfig.\* + force resolutions
-- build: add new build/test commands for all packages
-- refactor: remove packages/\*/yarn.lock
-- refactor(eth-simple-keyring): \* -> packages/keyring-eth-simple
+- Convert to monorepo
+  - Package name does not change (`@metamask/eth-simple-keyring`) and sources have been moved to: `packages/keyring-eth-simple`.
+  - You can find all the changes [here](https://github.com/MetaMask/accounts/compare/6da58b4...38794aa).
 
 ## [6.0.2]
 

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.3]
+
 ### Uncategorized
 
 - fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
@@ -90,7 +92,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Remove redundant `newGethSignMessage` method ([#72](https://github.com/MetaMask/eth-simple-keyring/pull/72))
   - Consumers can use `signPersonalMessage` method as a replacement for `newGethSignMessage`.
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-simple-keyring@6.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-simple-keyring@6.0.3...HEAD
+[6.0.3]: https://github.com/MetaMask/accounts/compare/@metamask/eth-simple-keyring@6.0.2...@metamask/eth-simple-keyring@6.0.3
 [6.0.2]: https://github.com/MetaMask/accounts/compare/@metamask/eth-simple-keyring@6.0.1...@metamask/eth-simple-keyring@6.0.2
 [6.0.1]: https://github.com/MetaMask/accounts/compare/@metamask/eth-simple-keyring@6.0.0...@metamask/eth-simple-keyring@6.0.1
 [6.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-simple-keyring@5.1.1...@metamask/eth-simple-keyring@6.0.0

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-simple-keyring",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "A simple standard interface for a series of Ethereum private keys.",
   "keywords": [
     "ethereum",

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.1]
+
 ### Uncategorized
 
 - fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
@@ -126,7 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support new versions of ethereumjs/tx ([#88](https://github.com/metamask/eth-trezor-keyring/pull/88))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-trezor-keyring@3.1.0...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-trezor-keyring@3.1.1...HEAD
+[3.1.1]: https://github.com/MetaMask/accounts/compare/@metamask/eth-trezor-keyring@3.1.0...@metamask/eth-trezor-keyring@3.1.1
 [3.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-trezor-keyring@3.0.0...@metamask/eth-trezor-keyring@3.1.0
 [3.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-trezor-keyring@2.0.0...@metamask/eth-trezor-keyring@3.0.0
 [2.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-trezor-keyring@1.1.0...@metamask/eth-trezor-keyring@2.0.0

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -9,33 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.1]
 
-### Uncategorized
+### Changed
 
-- fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
-- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
-- feat: preview builds ([#15](https://github.com/MetaMask/accounts/pull/15))
-- refactor: update all changelogs to use monorepo links
-- build: add changelog:{validate,update} for each packages
-- build: add yarn build:force command
-- build(keyring-eth-trezor): use nohoist alternative with installConfig
-- build: use tsc --build rather than tsc --project
-- refactor: update global jest.config.js in packages + use it in packages
-- refactor: remove packages/\*/.gitattributes
-- refactor: remove packages/\*/.editorconfig
-- refactor: remove .nvmrc from all packages
-- refactor: migrate depcheck to the top-level
-- fix(prettier): update changelogs for kerying-eth-{hd,ledger-bridge,simple,trezor}
-- chore: run prettier for all package.json
-- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
-- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
-- refactor: remove packages/_/.yarn_
-- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
-- test(keyring-eth-trezor): use jsdom test environment for some tests
-- refactor: remove packageManager from packages
-- build: re-organize tsconfig.\* + force resolutions
-- build: add new build/test commands for all packages
-- refactor: remove packages/\*/yarn.lock
-- refactor(eth-trezor-keyring): \* -> packages/keyring-eth-trezor
+- Convert to monorepo
+  - Package name does not change (`@metamask/eth-trezor-keyring`) and sources have been moved to: `packages/keyring-eth-trezor`.
+  - You can find all the changes [here](https://github.com/MetaMask/accounts/compare/6da58b4...38794aa).
 
 ## [3.1.0]
 

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- fix: fix preview builds artifacts ([#17](https://github.com/MetaMask/accounts/pull/17))
+- refactor: remove nested .gitignores + use the top-level one ([#18](https://github.com/MetaMask/accounts/pull/18))
+- feat: preview builds ([#15](https://github.com/MetaMask/accounts/pull/15))
+- refactor: update all changelogs to use monorepo links
+- build: add changelog:{validate,update} for each packages
+- build: add yarn build:force command
+- build(keyring-eth-trezor): use nohoist alternative with installConfig
+- build: use tsc --build rather than tsc --project
+- refactor: update global jest.config.js in packages + use it in packages
+- refactor: remove packages/\*/.gitattributes
+- refactor: remove packages/\*/.editorconfig
+- refactor: remove .nvmrc from all packages
+- refactor: migrate depcheck to the top-level
+- fix(prettier): update changelogs for kerying-eth-{hd,ledger-bridge,simple,trezor}
+- chore: run prettier for all package.json
+- refactor: remove packages/\*/.prettierrc.js + remove prettier from packages
+- refactor: use top-level eslint + cleanup packages lint commands/files + adapt rules to match previous linting rules
+- refactor: remove packages/_/.yarn_
+- refactor: migrate .github folder to the top-level (without publish-\*docs.yml for now)
+- test(keyring-eth-trezor): use jsdom test environment for some tests
+- refactor: remove packageManager from packages
+- build: re-organize tsconfig.\* + force resolutions
+- build: add new build/test commands for all packages
+- refactor: remove packages/\*/yarn.lock
+- refactor(eth-trezor-keyring): \* -> packages/keyring-eth-trezor
+
 ## [3.1.0]
 
 ### Changed

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-trezor-keyring",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "A MetaMask compatible keyring, for trezor hardware wallets",
   "keywords": [
     "ethereum",

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -9,9 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.3.4]
 
-### Uncategorized
+### Changed
 
-- refactor(keyring-snap): keyring-snap -> keyring-snap-bridge ([#34](https://github.com/MetaMask/accounts/pull/34))
+- Convert to monorepo
+  - Package name does not change (`@metamask/eth-snap-keyring`) and sources have been moved to: `packages/keyring-snap-bridge`.
+  - You can find all the changes [here](https://github.com/MetaMask/accounts/compare/6da58b4...38794aa).
 
 ## [4.3.3]
 

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.3.4]
+
 ### Uncategorized
 
 - refactor(keyring-snap): keyring-snap -> keyring-snap-bridge ([#34](https://github.com/MetaMask/accounts/pull/34))
@@ -324,7 +326,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@4.3.3...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@4.3.4...HEAD
+[4.3.4]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@4.3.3...@metamask/eth-snap-keyring@4.3.4
 [4.3.3]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@4.3.2...@metamask/eth-snap-keyring@4.3.3
 [4.3.2]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@4.3.1...@metamask/eth-snap-keyring@4.3.2
 [4.3.1]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@4.3.0...@metamask/eth-snap-keyring@4.3.1

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- refactor(keyring-snap): keyring-snap -> keyring-snap-bridge ([#34](https://github.com/MetaMask/accounts/pull/34))
+
 ## [4.3.3]
 
 ### Changed

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-snap-keyring",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Snaps keyring bridge.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

This is the release candidate for version . See the changelogs for more details.

## Related PRs

1. This was the 3rd attempt for this release, it did not work because the commit name was wrong (`release:  1.0.0` instead of `release: 1.0.0`). We might wanna relax this "strict" check in the future, or maybe have more CI tooling to verify PRs title (at least for releases).
  - https://github.com/MetaMask/accounts/pull/38
  - https://github.com/MetaMask/accounts/actions/runs/10919514167/job/30307460716

## Git

The previous PR has been removed from the history to avoid having multiple `release: 1.0.0` commits.