### PR TITLE
ci: change dependabot strategy to 'increase'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
     allow:
       - dependency-name: '@metamask/*'
     target-branch: 'main'
-    versioning-strategy: 'increase-if-necessary'
+    versioning-strategy: 'increase'
     open-pull-requests-limit: 10
     groups:
       snaps:


### PR DESCRIPTION
Match the versioning strategy used by other MetaMask repos.