### PR TITLE
ci: update actions, dependabot config, and internal dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,5 @@
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -7,13 +7,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-      time: '06:00'
     allow:
       - dependency-name: '@metamask/*'
-    target-branch: 'main'
     versioning-strategy: 'increase'
-    open-pull-requests-limit: 10
-    groups:
-      snaps:
-        patterns:
-          - '@metamask/snaps-*'

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -18,14 +18,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Yarn
-        run: corepack enable
-      - name: Restore Yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
           cache: yarn
-      - run: yarn --immutable
+      - run: yarn install --immutable
       - name: Fetch workspace package names
         id: workspace-package-names
         run: |
@@ -41,13 +35,13 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - run: yarn --immutable
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
       - run: yarn lint
       - name: Require clean working directory
         shell: bash
@@ -78,7 +72,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - run: yarn --immutable
+      - run: yarn install --immutable --immutable-cache
       - run: yarn workspace ${{ matrix.package-name }} changelog:validate
       - name: Require clean working directory
         shell: bash
@@ -97,13 +91,13 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - run: yarn --immutable
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
       - run: yarn build
       - name: Require clean working directory
         shell: bash
@@ -122,13 +116,13 @@ jobs:
       matrix:
         node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'yarn'
-      - run: yarn --immutable
+          cache: yarn
+      - run: yarn install --immutable --immutable-cache
       - run: yarn build
       - run: yarn test
       - name: Require clean working directory

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-      - run: yarn --immutable
+      - run: yarn install --immutable --immutable-cache
       - name: Get commit SHA
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: MetaMask/action-publish-release@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: yarn --immutable
+      - run: yarn install --immutable --immutable-cache
       - run: yarn build
 
   publish-npm-dry-run:

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^7.0.3",
-    "@metamask/keyring-api": "^8.1.0",
     "@metamask/snaps-controllers": "^9.6.0",
     "@metamask/snaps-sdk": "^6.4.0",
     "@metamask/snaps-utils": "^7.8.0",
@@ -50,6 +49,9 @@
     "ts-node": "^10.7.0",
     "typedoc": "^0.23.15",
     "typescript": "~4.8.4"
+  },
+  "peerDependencies": {
+    "@metamask/keyring-api": "^8.1.1"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2027,7 +2027,6 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.0.4"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^7.0.3"
-    "@metamask/keyring-api": "npm:^8.1.0"
     "@metamask/snaps-controllers": "npm:^9.6.0"
     "@metamask/snaps-sdk": "npm:^6.4.0"
     "@metamask/snaps-utils": "npm:^7.8.0"
@@ -2046,6 +2045,8 @@ __metadata:
     typedoc: "npm:^0.23.15"
     typescript: "npm:~4.8.4"
     uuid: "npm:^9.0.0"
+  peerDependencies:
+    "@metamask/keyring-api": ^8.1.1
   languageName: unknown
   linkType: soft
 
@@ -2131,7 +2132,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^8.1.0, @metamask/keyring-api@workspace:packages/keyring-api":
+"@metamask/keyring-api@workspace:packages/keyring-api":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-api@workspace:packages/keyring-api"
   dependencies:


### PR DESCRIPTION
The current Dependabot configuration is not working. This change copies the configuration from [MetaMask/core](https://github.com/MetaMask/core) to attempt to fix the issue.

It also updates some actions and adds the `--immutable-cache` flag to some `yarn install` invocations.

The `@metamask/keyring-api` dependency used by `@metamask/eth-snap-keyring` is moved to `peerDependencies` and bumped to 8.1.1.