### PR TITLE
chore: move some `dependencies` to `devDependencies`

### DIFF
--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -41,7 +41,6 @@
     "@metamask/utils": "^9.1.0",
     "@types/uuid": "^9.0.8",
     "bech32": "^2.0.0",
-    "deepmerge": "^4.2.2",
     "uuid": "^9.0.1"
   },
   "devDependencies": {
@@ -51,6 +50,7 @@
     "@metamask/providers": "^17.1.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
+    "deepmerge": "^4.2.2",
     "depcheck": "^1.4.7",
     "jest": "^28.1.3",
     "jest-it-up": "^3.1.0",

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -33,7 +33,6 @@
     "@metamask/eth-sig-util": "^7.0.0",
     "@metamask/scure-bip39": "^2.1.0",
     "@metamask/utils": "^8.1.0",
-    "deepmerge": "^4.2.2",
     "ethereum-cryptography": "^2.1.2"
   },
   "devDependencies": {
@@ -44,6 +43,7 @@
     "@metamask/bip39": "^4.0.0",
     "@metamask/eth-hd-keyring": "4.0.1",
     "@types/jest": "^29.4.0",
+    "deepmerge": "^4.2.2",
     "jest": "^29.4.3"
   },
   "engines": {

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -42,7 +42,6 @@
     "@ethereumjs/util": "^8.0.0",
     "@ledgerhq/hw-app-eth": "6.26.1",
     "@metamask/eth-sig-util": "^7.0.1",
-    "deepmerge": "^4.2.2",
     "hdkey": "^2.1.0"
   },
   "devDependencies": {
@@ -58,6 +57,7 @@
     "@types/jest": "^28.1.6",
     "@types/node": "^16.18.59",
     "@types/web": "^0.0.69",
+    "deepmerge": "^4.2.2",
     "depcheck": "^1.4.3",
     "ethereumjs-tx": "^1.3.4",
     "jest": "^28.1.3",

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -37,7 +37,6 @@
     "@ethereumjs/util": "^8.1.0",
     "@metamask/eth-sig-util": "^7.0.0",
     "@metamask/utils": "^9.0.0",
-    "deepmerge": "^4.2.2",
     "ethereum-cryptography": "^2.1.2",
     "randombytes": "^2.1.0"
   },
@@ -49,6 +48,7 @@
     "@types/jest": "^29.5.0",
     "@types/node": "^18.15.10",
     "@types/randombytes": "^2.0.0",
+    "deepmerge": "^4.2.2",
     "depcheck": "^1.4.3",
     "ethereumjs-tx": "^1.3.7",
     "jest": "^29.5.0",

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -42,7 +42,6 @@
     "@metamask/eth-sig-util": "^7.0.1",
     "@trezor/connect-plugin-ethereum": "^9.0.3",
     "@trezor/connect-web": "^9.1.11",
-    "deepmerge": "^4.2.2",
     "hdkey": "^2.1.0"
   },
   "devDependencies": {
@@ -55,6 +54,7 @@
     "@types/node": "^16.18.57",
     "@types/sinon": "^9.0.10",
     "@types/w3c-web-usb": "^1.0.6",
+    "deepmerge": "^4.2.2",
     "depcheck": "^1.4.3",
     "ethereumjs-tx": "^1.3.4",
     "jest": "^28.1.3",

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -43,8 +43,7 @@
     "@trezor/connect-plugin-ethereum": "^9.0.3",
     "@trezor/connect-web": "^9.1.11",
     "deepmerge": "^4.2.2",
-    "hdkey": "^2.1.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "hdkey": "^2.1.0"
   },
   "devDependencies": {
     "@ethereumjs/common": "^3.0.0",
@@ -59,6 +58,7 @@
     "depcheck": "^1.4.3",
     "ethereumjs-tx": "^1.3.4",
     "jest": "^28.1.3",
+    "jest-environment-jsdom": "^29.7.0",
     "jest-it-up": "^2.2.0",
     "rimraf": "^4.1.2",
     "sinon": "^9.2.3",

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -33,7 +33,6 @@
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^9.1.0",
     "@types/uuid": "^9.0.1",
-    "deepmerge": "^4.2.2",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
@@ -41,6 +40,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@types/jest": "^28.1.6",
     "@types/node": "^17.0.23",
+    "deepmerge": "^4.2.2",
     "depcheck": "^1.4.3",
     "jest": "^28.1.3",
     "jest-it-up": "^2.0.2",


### PR DESCRIPTION
Some dependencies have been wrongly set as `dependencies`, so moving them back to `devDependencies`. 