### PR TITLE
docs: update how-to-release.md

### DIFF
--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -57,9 +57,10 @@ way and commit those changes.
 Finally, create your PR on [github](https://github.com/MetaMask/accounts/pulls) or use `gh` CLI:
 
 ```shell
-VERSION=x.y.z gh pr create \
+VERSION=x.y.z; gh pr create \
   --title "release: $VERSION" \
-  --body "## Description\nThis is the release candidate for version $VERSION. See the changelogs for more details.
+  --body "## Description
+This is the release candidate for version $VERSION. See the changelogs for more details."
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
The command-line was wrong:
- `\n` was not interpreted by `gh`
- `VERSION=x.y.z <command>` is not being interpreted by the `<command>` and cannot be expanded, thus adding a `;` to first declare the variable and then use it