### PR TITLE
feat: add scripts/release.sh + update release docs

### DIFF
--- a/docs/how-to-release.md
+++ b/docs/how-to-release.md
@@ -6,7 +6,7 @@
 To start creating a new release, run:
 
 ```shell
-yarn create-release-branch
+yarn release
 ```
 
 You will then be prompted with your `$EDITOR` to select which packages you want to release:
@@ -53,14 +53,6 @@ Select your packages alongside their version specifier, then save and close your
 
 Update each package's CHANGELOGs (the one you selected) and update them the usual
 way and commit those changes.
-
-Finally, create your PR on [github](https://github.com/MetaMask/accounts/pulls) or use `gh` CLI:
-
-```shell
-VERSION=x.y.z gh pr create \
-  --title "release: $VERSION" \
-  --body "## Description\nThis is the release candidate for version $VERSION. See the changelogs for more details.
-```
 
 > [!IMPORTANT]
 > Your PR **HAS TO BE NAMED**: `release: x.y.z`

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "prepare:preview:local": "yarn prepare:preview @metamask-previews $(git rev-parse --short HEAD)",
     "publish:preview": "yarn workspaces foreach --all --no-private --parallel --verbose run publish:preview",
     "readme:update": "ts-node scripts/update-readme-content.ts",
+    "release": "./scripts/release.sh",
     "setup": "yarn install",
     "test": "yarn test:packages",
     "test:clean": "yarn workspaces foreach --all --parallel --verbose run test:clean && yarn test",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -euo pipefail
+
+get_release_version_from() {
+  version="$1"
+
+  # Extract major version
+  major="$(echo "${version}" | cut -d. -f1)"
+
+  # Replace current major by next major (# means ^ using bash notation)
+  echo "${version/#${major}/$((major + 1))}"
+}
+
+url_encode() {
+  echo -n "$@" | jq --slurp --raw-input --raw-output "@uri"
+}
+
+# Check if release branch already exists
+CURRENT_VERSION="$(jq '.version' package.json | tr -d '"')"
+RELEASE_VERSION="$(get_release_version_from "${CURRENT_VERSION}")"
+RELEASE_BRANCH="release/${RELEASE_VERSION}"
+readonly CURRENT_VERSION
+readonly RELEASE_VERSION
+readonly RELEASE_BRANCH
+if git show-ref "refs/heads/${RELEASE_BRANCH}" --quiet; then
+  echo "Release branch already exists: ${RELEASE_BRANCH}"
+  echo "Assuming the release is on-going, so nothing to be done here!"
+  exit 1
+fi
+
+# Create the release branch first:
+yarn create-release-branch
+
+# Then, create the PR:
+readonly RELEASE_PR_TITLE="release: ${RELEASE_VERSION}"
+readonly RELEASE_PR_BODY="## Description
+
+This is the release candidate for version ${RELEASE_VERSION}. See the changelogs for more details."
+if command -v gh &> /dev/null; then
+  # Check if `gh` exists and create the release branch automatically!
+  gh pr create --title "${RELEASE_PR_TITLE}" --body "${RELEASE_PR_BODY}"
+else
+  # As as fallback, we just output a link to create the PR manually
+  echo "https://github.com/MetaMask/accounts/compare/${RELEASE_BRANCH}?expand=1&title=$(url_encode "${RELEASE_PR_TITLE}")&body=$(url_encode "${RELEASE_PR_BODY}")"
+fi


### PR DESCRIPTION
Adding a small script to help doing release "automatically".

If `gh` is available, then the PR will be created automatically. If not available, then the script will output an URL that can be used to create the PR (with the right title and body).