### PR TITLE
chore(deps): use workspace version of `keyring-api`

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -20,6 +20,12 @@
       "packages": ["@metamask/eth-hd-keyring"],
       "dependencies": ["@metamask/eth-hd-keyring"],
       "pinVersion": "4.0.1"
+    },
+    {
+      "label": "use workspace version of the keyring-api",
+      "dependencyTypes": ["dev", "peer"],
+      "dependencies": ["@metamask/keyring-api"],
+      "pinVersion": "workspace:^"
     }
   ]
 }

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -51,7 +51,7 @@
     "typescript": "~4.8.4"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "^8.1.2"
+    "@metamask/keyring-api": "workspace:^"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2011,7 +2011,7 @@ __metadata:
     typescript: "npm:~4.8.4"
     uuid: "npm:^9.0.1"
   peerDependencies:
-    "@metamask/keyring-api": ^8.1.2
+    "@metamask/keyring-api": "workspace:^"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Use `workspace:^` for internal use of `@metamask/keyring-api`.