### PR TITLE
chore: use workspace version of 'keyring-api'

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -23,7 +23,7 @@
     },
     {
       "label": "use workspace version of the keyring-api",
-      "dependencyTypes": ["dev", "peer"],
+      "dependencyTypes": ["!local"],
       "dependencies": ["@metamask/keyring-api"],
       "pinVersion": "workspace:^"
     }


### PR DESCRIPTION
This PR updates the `syncpack`'s configuration to use the `workspace:^` version of the `keyring-api` everywhere<sup>(1)</sup>, not only on `dev` and `peer` dependencies. See `syncpack`'s [documentation](https://jamiemason.github.io/syncpack/config/version-groups/banned/#dependencytypes) for more information.

1: except in the `version` element of the `keyring-api` `package.json` file.