### PR TITLE
ci: add workflow to close stale issues and pull requests

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,25 @@
+name: Close stale issues and PRs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '30 1 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale issues and PRs
+        uses: actions/stale@v9
+        with:
+          stale-issue-message: This issue is marked as stale because it has been open for 60 days with no activity. Please remove the stale label or leave a comment, or it will be closed in 14 days.
+          close-issue-message: This issue was closed due to no follow-up activity in the last 14 days. If you believe it was closed in error, please reopen it and provide evidence that it is still relevant. Thank you for your contributions.
+          stale-pr-message: This PR is marked as stale because it has been open for 60 days with no activity. Please remove the stale label or leave a comment, or it will be closed in 14 days.
+          close-pr-message: This PR was closed due to no follow-up activity in the last 14 days. Thank you for your contributions.
+          days-before-stale: 60
+          days-before-close: 14
+          exempt-issue-labels: type-security


### PR DESCRIPTION
Adds a workflow to check for stale PRs and issues. After 60 days of inactivity, the issue or PR will be marked as stale and will be closed 14 days later if there is no follow-up.