### PR TITLE
ci: allow mutable cache for preview builds

### DIFF
--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: yarn
-      - run: yarn install --immutable --immutable-cache
+      - run: yarn install --immutable
       - name: Get commit SHA
         id: commit-sha
         run: echo "COMMIT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Preview builds change the cache to use a different package name of the local dependencies, so the build needs to be able to change the local cache that is build during the preparation phase.