### PR TITLE
feat!: rename `btc_sendmany` to `sendBitcoin`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["bech32", "p2wpkh", "sendmany", "syncpack"]
+  "cSpell.words": ["bech32", "p2wpkh", "syncpack"]
 }

--- a/packages/keyring-api/docs/btc-methods.md
+++ b/packages/keyring-api/docs/btc-methods.md
@@ -3,11 +3,9 @@
 Here we document the Bitcoin methods that an account Snap may implement to
 support requests originated from dapps.
 
-## sendTransaction
+## sendBitcoin
 
-This method is similar to the `sendmany` RPC method from Bitcoin Core, but its
-parameters are passed in an object instead of an array, and are named in
-camelCase. Also, dummy values aren't allowed.
+Send bitcoins to one or more recipients.
 
 ### Parameters
 
@@ -19,22 +17,12 @@ camelCase. Also, dummy values aren't allowed.
       - Type: `object`
       - Properties:
         - `[key]: string`: Address of the recipient
-        - `[value]: string`: Amount to send to the recipient in BTC
-    - `comment` (optional)
-      - Description: A comment.
-      - Type: `string`
-    - `subtractFeeFrom` (optional)
-      - Description: The fee will be equally deducted from the amount of each
-        selected address. Those recipients will receive less bitcoins than you
-        enter in their corresponding amount field. If no addresses are specified
-        here, the sender pays the fee.
-      - Type: `array`
-      - Items:
-        - Type: `string`
+        - `[value]: string`: Amount to send to the recipient in **BTC**
     - `replaceable` (optional)
       - Description: Allow this transaction to be replaced by a transaction
         with higher fees via BIP 125.
       - Type: `boolean`
+      - Default: `true`
 
 ### Returns
 
@@ -51,15 +39,13 @@ camelCase. Also, dummy values aren't allowed.
 
 ```json
 {
-  "method": "sendTransaction",
+  "method": "sendBitcoin",
   "params": {
     "amounts": {
       "bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl": "0.01",
       "bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3": "0.02"
     },
-    "comment": "testing",
-    "subtractFeeFrom": ["bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl"],
-    "replaceable": false
+    "replaceable": true
   }
 }
 ```

--- a/packages/keyring-api/docs/btc-methods.md
+++ b/packages/keyring-api/docs/btc-methods.md
@@ -12,7 +12,7 @@ Send bitcoins to one or more recipients.
 - **Transaction intent (required)**
   - Type: `object`
   - Properties:
-    - `amounts`
+    - `recipients`
       - Description: A JSON object with recipient addresses and amounts.
       - Type: `object`
       - Properties:
@@ -41,7 +41,7 @@ Send bitcoins to one or more recipients.
 {
   "method": "sendBitcoin",
   "params": {
-    "amounts": {
+    "recipients": {
       "bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl": "0.01",
       "bc1q02ad21edsxd23d32dfgqqsz4vv4nmtfzuklhy3": "0.02"
     },

--- a/packages/keyring-api/docs/btc-methods.md
+++ b/packages/keyring-api/docs/btc-methods.md
@@ -16,8 +16,8 @@ Send bitcoins to one or more recipients.
       - Description: A JSON object with recipient addresses and amounts.
       - Type: `object`
       - Properties:
-        - `[key]: string`: Address of the recipient
-        - `[value]: string`: Amount to send to the recipient in **BTC**
+        - `[key]: string`: Address of the recipient.
+        - `[value]: string`: Amount to send to the recipient in **BTC**.
     - `replaceable` (optional)
       - Description: Allow this transaction to be replaced by a transaction
         with higher fees via BIP 125.

--- a/packages/keyring-api/docs/btc-methods.md
+++ b/packages/keyring-api/docs/btc-methods.md
@@ -3,7 +3,7 @@
 Here we document the Bitcoin methods that an account Snap may implement to
 support requests originated from dapps.
 
-## btc_sendmany
+## sendTransaction
 
 This method is similar to the `sendmany` RPC method from Bitcoin Core, but its
 parameters are passed in an object instead of an array, and are named in
@@ -51,7 +51,7 @@ camelCase. Also, dummy values aren't allowed.
 
 ```json
 {
-  "method": "btc_sendmany",
+  "method": "sendTransaction",
   "params": {
     "amounts": {
       "bc1q09vm5lfy0j5reeulh4x5752q25uqqvz34hufdl": "0.01",

--- a/packages/keyring-api/src/btc/types.ts
+++ b/packages/keyring-api/src/btc/types.ts
@@ -25,7 +25,7 @@ export const BtcP2wpkhAddressStruct = refine(
  */
 export enum BtcMethod {
   // General transaction methods
-  SendTransaction = 'sendTransaction',
+  SendBitcoin = 'sendBitcoin',
 }
 
 export const BtcP2wpkhAccountStruct = object({
@@ -44,7 +44,7 @@ export const BtcP2wpkhAccountStruct = object({
   /**
    * Account supported methods.
    */
-  methods: array(enums([`${BtcMethod.SendTransaction}`])),
+  methods: array(enums([`${BtcMethod.SendBitcoin}`])),
 });
 
 export type BtcP2wpkhAccount = Infer<typeof BtcP2wpkhAccountStruct>;

--- a/packages/keyring-api/src/btc/types.ts
+++ b/packages/keyring-api/src/btc/types.ts
@@ -25,7 +25,7 @@ export const BtcP2wpkhAddressStruct = refine(
  */
 export enum BtcMethod {
   // General transaction methods
-  SendMany = 'btc_sendmany',
+  SendTransaction = 'sendTransaction',
 }
 
 export const BtcP2wpkhAccountStruct = object({
@@ -44,7 +44,7 @@ export const BtcP2wpkhAccountStruct = object({
   /**
    * Account supported methods.
    */
-  methods: array(enums([`${BtcMethod.SendMany}`])),
+  methods: array(enums([`${BtcMethod.SendTransaction}`])),
 });
 
 export type BtcP2wpkhAccount = Infer<typeof BtcP2wpkhAccountStruct>;


### PR DESCRIPTION
**BREAKING:** This PR renames the Bitcoin `btc_sendmany` method to `sendBitcoin`.

This change aims to differentiate the existing method from the `sendmany` method defined by the Bitcoin Core RPC API. It also removes unused parameters.

Issue: https://github.com/MetaMask/accounts-planning/issues/641