### PR TITLE
chore: update jest config + include coverage for `yarn test` command

### DIFF
--- a/jest.config.packages.js
+++ b/jest.config.packages.js
@@ -22,7 +22,7 @@ module.exports = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
-  collectCoverageFrom: ['./src/**/*.ts'],
+  collectCoverageFrom: ['./src/**/*.ts', '!./src/**/*.test-d.ts'],
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "release": "./scripts/release.sh",
     "setup": "yarn install",
     "test": "yarn workspaces foreach --all --parallel --verbose run test",
-    "test:clean": "yarn workspaces foreach --all --parallel --verbose run test:clean && yarn test"
+    "test:clean": "yarn workspaces foreach --all --parallel --verbose run test:clean"
   },
   "resolutions": {
     "@types/node": "^20.12.12",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,8 @@
     "readme:update": "ts-node scripts/update-readme-content.ts",
     "release": "./scripts/release.sh",
     "setup": "yarn install",
-    "test": "yarn test:packages",
-    "test:clean": "yarn workspaces foreach --all --parallel --verbose run test:clean && yarn test",
-    "test:packages": "yarn test:verbose --silent --collectCoverage=false --reporters=jest-silent-reporter",
-    "test:verbose": "yarn workspaces foreach --all --parallel --verbose run test:verbose"
+    "test": "yarn workspaces foreach --all --parallel --verbose run test",
+    "test:clean": "yarn workspaces foreach --all --parallel --verbose run test:clean && yarn test"
   },
   "resolutions": {
     "@types/node": "^20.12.12",

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -32,7 +32,6 @@
     "test:clean": "jest --clearCache",
     "test:source": "jest && jest-it-up",
     "test:types": "tsd",
-    "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -25,8 +25,7 @@
     "changelog:validate": "../../scripts/validate-changelog.sh @metamask/eth-hd-keyring",
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest",
-    "test:clean": "jest --clearCache",
-    "test:verbose": "jest --verbose"
+    "test:clean": "jest --clearCache"
   },
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",

--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -23,7 +23,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 90.64,
+      branches: 90.14,
       functions: 95.95,
       lines: 94.76,
       statements: 94.81,

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -33,7 +33,6 @@
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest && jest-it-up",
     "test:clean": "jest --clearCache",
-    "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/keyring-eth-simple/jest.config.js
+++ b/packages/keyring-eth-simple/jest.config.js
@@ -17,6 +17,9 @@ module.exports = merge(baseConfig, {
   // An array of regexp pattern strings used to skip coverage collection
   coveragePathIgnorePatterns: ['./src/tests'],
 
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  collectCoverageFrom: ['./src/**/*.ts', '!./src/sample.ts'],
+
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -30,7 +30,6 @@
     "sample": "ts-node src/sample.ts",
     "test": "jest",
     "test:clean": "jest --clearCache",
-    "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/keyring-eth-trezor/jest.config.js
+++ b/packages/keyring-eth-trezor/jest.config.js
@@ -25,8 +25,8 @@ module.exports = merge(baseConfig, {
     global: {
       branches: 48.27,
       functions: 91.22,
-      lines: 89.89,
-      statements: 90.1,
+      lines: 89.94,
+      statements: 90.15,
     },
   },
 });

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -33,7 +33,6 @@
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest && jest-it-up",
     "test:clean": "jest --clearCache",
-    "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },
   "dependencies": {

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -21,7 +21,6 @@
     "publish:preview": "yarn npm publish --tag preview",
     "test": "jest && jest-it-up",
     "test:clean": "jest --clearCache",
-    "test:verbose": "jest --verbose",
     "test:watch": "jest --watch"
   },
   "dependencies": {


### PR DESCRIPTION
Cleaning up jest config files + thresholds.

Also the coverage will now be enabled by default when running `yarn test`.