### PR TITLE
refactor: make `KeyringAccount` generic

### DIFF
--- a/packages/keyring-api/src/api/account.ts
+++ b/packages/keyring-api/src/api/account.ts
@@ -1,5 +1,5 @@
 import type { Infer } from '@metamask/superstruct';
-import { array, enums, record, string } from '@metamask/superstruct';
+import { array, record, string } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
 
 import { object } from '../superstruct';
@@ -44,11 +44,7 @@ export const KeyringAccountStruct = object({
   /**
    * Account type.
    */
-  type: enums([
-    `${EthAccountType.Eoa}`,
-    `${EthAccountType.Erc4337}`,
-    `${BtcAccountType.P2wpkh}`,
-  ]),
+  type: string(),
 
   /**
    * Account main address.

--- a/packages/keyring-api/src/btc/types.ts
+++ b/packages/keyring-api/src/btc/types.ts
@@ -1,8 +1,9 @@
-import type { Infer } from '@metamask/superstruct';
 import { string, array, enums, refine, literal } from '@metamask/superstruct';
 import { bech32 } from 'bech32';
 
+import type { KeyringAccount } from '../api';
 import { KeyringAccountStruct, BtcAccountType } from '../api';
+import type { InferExtends } from '../superstruct';
 import { object } from '../superstruct';
 
 export const BtcP2wpkhAddressStruct = refine(
@@ -47,4 +48,7 @@ export const BtcP2wpkhAccountStruct = object({
   methods: array(enums([`${BtcMethod.SendBitcoin}`])),
 });
 
-export type BtcP2wpkhAccount = Infer<typeof BtcP2wpkhAccountStruct>;
+export type BtcP2wpkhAccount = InferExtends<
+  typeof BtcP2wpkhAccountStruct,
+  KeyringAccount
+>;

--- a/packages/keyring-api/src/eth/types.ts
+++ b/packages/keyring-api/src/eth/types.ts
@@ -1,7 +1,8 @@
-import type { Infer } from '@metamask/superstruct';
 import { array, enums, literal } from '@metamask/superstruct';
 
+import type { KeyringAccount } from '../api';
 import { EthAccountType, KeyringAccountStruct } from '../api';
+import type { InferExtends } from '../superstruct';
 import { object, definePattern } from '../superstruct';
 
 export const EthBytesStruct = definePattern('EthBytes', /^0x[0-9a-f]*$/iu);
@@ -61,7 +62,10 @@ export const EthEoaAccountStruct = object({
   ),
 });
 
-export type EthEoaAccount = Infer<typeof EthEoaAccountStruct>;
+export type EthEoaAccount = InferExtends<
+  typeof EthEoaAccountStruct,
+  KeyringAccount
+>;
 
 export const EthErc4337AccountStruct = object({
   ...KeyringAccountStruct.schema,
@@ -93,4 +97,7 @@ export const EthErc4337AccountStruct = object({
   ),
 });
 
-export type EthErc4337Account = Infer<typeof EthErc4337AccountStruct>;
+export type EthErc4337Account = InferExtends<
+  typeof EthErc4337AccountStruct,
+  KeyringAccount
+>;

--- a/packages/keyring-api/src/superstruct.ts
+++ b/packages/keyring-api/src/superstruct.ts
@@ -152,3 +152,15 @@ export function strictMask<Type, Schema>(
   assert(value, struct, message);
   return value;
 }
+
+/**
+ * Extracts the type from a struct definition and asserts that it extends the
+ * expected type. If the types do not match, the type `never` is returned.
+ *
+ * @param StructType - The struct type to infer.
+ * @param ExpectedType - The expected type.
+ */
+export type InferExtends<
+  StructType extends Struct<any, any>,
+  SuperType,
+> = Infer<StructType> extends SuperType ? Infer<StructType> : never;


### PR DESCRIPTION
## Description

This PR makes the `KeyringAccount` type generic, not requiring the Keyring API to be updated to support new account types in the future.

This PR also enforces that the existing known account types extend the `KeyringAccount` type.