### PR TITLE
feat: adds Solana account type to keyring API

### DIFF
--- a/packages/keyring-api/src/api/account.ts
+++ b/packages/keyring-api/src/api/account.ts
@@ -21,12 +21,20 @@ export enum BtcAccountType {
 }
 
 /**
+ * Supported Solana account types.
+ */
+export enum SolAccountType {
+  DataAccount = 'solana:data-account',
+}
+
+/**
  * Supported account types.
  */
 export type KeyringAccountType =
   | `${EthAccountType.Eoa}`
   | `${EthAccountType.Erc4337}`
-  | `${BtcAccountType.P2wpkh}`;
+  | `${BtcAccountType.P2wpkh}`
+  | `${SolAccountType.DataAccount}`;
 
 /**
  * A struct which represents a Keyring account object. It is abstract enough to
@@ -48,6 +56,7 @@ export const KeyringAccountStruct = object({
     `${EthAccountType.Eoa}`,
     `${EthAccountType.Erc4337}`,
     `${BtcAccountType.P2wpkh}`,
+    `${SolAccountType.DataAccount}`,
   ]),
 
   /**

--- a/packages/keyring-api/src/eth/utils.test.ts
+++ b/packages/keyring-api/src/eth/utils.test.ts
@@ -1,11 +1,12 @@
 import { isEvmAccountType } from './utils';
-import { BtcAccountType, EthAccountType } from '../api';
+import { BtcAccountType, EthAccountType, SolAccountType } from '../api';
 
 describe('isEvmAccountType', () => {
   it.each([
     [EthAccountType.Eoa, true],
     [EthAccountType.Erc4337, true],
     [BtcAccountType.P2wpkh, false],
+    [SolAccountType.DataAccount, false],
     [{}, false],
     [null, false],
     ['bitcoin', false],

--- a/packages/keyring-api/src/index.ts
+++ b/packages/keyring-api/src/index.ts
@@ -2,6 +2,7 @@ export * from './api';
 export * from './btc';
 export type * from './contexts';
 export * from './eth';
+export * from './sol';
 export * from './events';
 export * from './internal';
 export * from './KeyringClient';

--- a/packages/keyring-api/src/internal/types.ts
+++ b/packages/keyring-api/src/internal/types.ts
@@ -1,12 +1,21 @@
 import type { Infer, Struct } from '@metamask/superstruct';
 import { boolean, string, number } from '@metamask/superstruct';
 
-import { BtcAccountType, EthAccountType, KeyringAccountStruct } from '../api';
+import {
+  BtcAccountType,
+  EthAccountType,
+  KeyringAccountStruct,
+  SolAccountType,
+} from '../api';
 import { BtcP2wpkhAccountStruct } from '../btc/types';
 import { EthEoaAccountStruct, EthErc4337AccountStruct } from '../eth/types';
+import { SolDataAccountStruct } from '../sol/types';
 import { exactOptional, object } from '../superstruct';
 
-export type InternalAccountType = EthAccountType | BtcAccountType;
+export type InternalAccountType =
+  | EthAccountType
+  | BtcAccountType
+  | SolAccountType;
 
 export const InternalAccountMetadataStruct = object({
   metadata: object({
@@ -42,6 +51,11 @@ export const InternalBtcP2wpkhAccountStruct = object({
   ...InternalAccountMetadataStruct.schema,
 });
 
+export const InternalSolDataAccountStruct = object({
+  ...SolDataAccountStruct.schema,
+  ...InternalAccountMetadataStruct.schema,
+});
+
 export type InternalEthEoaAccount = Infer<typeof InternalEthEoaAccountStruct>;
 
 export type InternalEthErc4337Account = Infer<
@@ -52,21 +66,26 @@ export type InternalBtcP2wpkhAccount = Infer<
   typeof InternalBtcP2wpkhAccountStruct
 >;
 
+export type InternalSolDataAccount = Infer<typeof InternalSolDataAccountStruct>;
+
 export const InternalAccountStructs: Record<
   string,
   | Struct<InternalEthEoaAccount>
   | Struct<InternalEthErc4337Account>
   | Struct<InternalBtcP2wpkhAccount>
+  | Struct<InternalSolDataAccount>
 > = {
   [`${EthAccountType.Eoa}`]: InternalEthEoaAccountStruct,
   [`${EthAccountType.Erc4337}`]: InternalEthErc4337AccountStruct,
   [`${BtcAccountType.P2wpkh}`]: InternalBtcP2wpkhAccountStruct,
+  [`${SolAccountType.DataAccount}`]: InternalSolDataAccountStruct,
 };
 
 export type InternalAccountTypes =
   | InternalEthEoaAccount
   | InternalEthErc4337Account
-  | InternalBtcP2wpkhAccount;
+  | InternalBtcP2wpkhAccount
+  | InternalSolDataAccount;
 
 export const InternalAccountStruct = object({
   ...KeyringAccountStruct.schema,

--- a/packages/keyring-api/src/sol/index.ts
+++ b/packages/keyring-api/src/sol/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/keyring-api/src/sol/types.test-d.ts
+++ b/packages/keyring-api/src/sol/types.test-d.ts
@@ -1,0 +1,7 @@
+import type { SolDataAccount } from './types';
+import type { KeyringAccount } from '../api';
+import type { Extends } from '../utils';
+import { expectTrue } from '../utils';
+
+// `SolDataAccount` extends `KeyringAccount`
+expectTrue<Extends<SolDataAccount, KeyringAccount>>();

--- a/packages/keyring-api/src/sol/types.test.ts
+++ b/packages/keyring-api/src/sol/types.test.ts
@@ -1,0 +1,28 @@
+import { SolAddressStruct } from './types';
+
+describe('types', () => {
+  describe('SolAddressStruct', () => {
+    it.each([
+      '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV',
+      'A5R99q8qeyUhgwYAdp5h8pAD1iteVjCzpCv7G6JRZLaQ',
+    ])('is valid address: %s', (address) => {
+      expect(() => SolAddressStruct.assert(address)).not.toThrow();
+    });
+
+    it.each([
+      // Invalid lengths, too long (45 chars)
+      '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV11',
+      // Too short (31 chars)
+      '7EcDhSYGxXyscszYEp35KHN8vvw',
+      // Empty or invalid input
+      '',
+      // Eth style address
+      '0x1234',
+      'not-an-address',
+    ])('rejects invalid address: %s', (address) => {
+      expect(() => SolAddressStruct.assert(address)).toThrow(
+        `Expected a value of type \`SolAddress\`, but received: \`"${address}"\``,
+      );
+    });
+  });
+});

--- a/packages/keyring-api/src/sol/types.ts
+++ b/packages/keyring-api/src/sol/types.ts
@@ -1,0 +1,44 @@
+import type { Infer } from '@metamask/superstruct';
+import { array, enums, literal } from '@metamask/superstruct';
+
+import { KeyringAccountStruct, SolAccountType } from '../api';
+import { object, definePattern } from '../superstruct';
+
+/**
+ * Solana addresses are represented in the format of a 256-bit ed25519 public key and
+ * are encoded using base58.
+ * They are usually 32 to 44 characters long.
+ */
+export const SolAddressStruct = definePattern(
+  'SolAddress',
+  /^[1-9A-HJ-NP-Za-km-z]{32,44}$/iu,
+);
+
+/**
+ * Supported Solana methods.
+ */
+export enum SolMethod {
+  // General transaction methods
+  SendAndConfirmTransaction = 'sendAndConfirmTransaction',
+}
+
+export const SolDataAccountStruct = object({
+  ...KeyringAccountStruct.schema,
+
+  /**
+   * Account address.
+   */
+  address: SolAddressStruct,
+
+  /**
+   * Account type.
+   */
+  type: literal(`${SolAccountType.DataAccount}`),
+
+  /**
+   * Account supported methods.
+   */
+  methods: array(enums([`${SolMethod.SendAndConfirmTransaction}`])),
+});
+
+export type SolDataAccount = Infer<typeof SolDataAccountStruct>;


### PR DESCRIPTION
We are adding the `SolAccountType` to support Solana account creation.
