### PR TITLE
fix: export `JsonRpcRequest` + remove imports from `dist` folder

### DIFF
--- a/packages/keyring-api/src/index.ts
+++ b/packages/keyring-api/src/index.ts
@@ -5,6 +5,7 @@ export * from './eth';
 export * from './sol';
 export * from './events';
 export * from './internal';
+export * from './JsonRpcRequest';
 export * from './KeyringClient';
 export * from './KeyringSnapRpcClient';
 export * from './rpc-handler';

--- a/packages/keyring-snap-bridge/src/KeyringSnapControllerClient.ts
+++ b/packages/keyring-snap-bridge/src/KeyringSnapControllerClient.ts
@@ -1,5 +1,5 @@
 import { KeyringClient, type Sender } from '@metamask/keyring-api';
-import type { JsonRpcRequest } from '@metamask/keyring-api/dist/JsonRpcRequest';
+import type { JsonRpcRequest } from '@metamask/keyring-api';
 import type { SnapController } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { HandlerType } from '@metamask/snaps-utils';

--- a/packages/keyring-snap-bridge/src/KeyringSnapControllerClient.ts
+++ b/packages/keyring-snap-bridge/src/KeyringSnapControllerClient.ts
@@ -1,5 +1,5 @@
-import { KeyringClient, type Sender } from '@metamask/keyring-api';
-import type { JsonRpcRequest } from '@metamask/keyring-api';
+import { KeyringClient } from '@metamask/keyring-api';
+import type { JsonRpcRequest, Sender } from '@metamask/keyring-api';
 import type { SnapController } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { HandlerType } from '@metamask/snaps-utils';

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -14,8 +14,8 @@ import {
   EthMethod,
   SolAccountType,
   SolMethod,
+  KeyringEvent,
 } from '@metamask/keyring-api';
-import { KeyringEvent } from '@metamask/keyring-api';
 import type { SnapController } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import { KnownCaipNamespace, toCaipChainId } from '@metamask/utils';

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -15,7 +15,7 @@ import {
   SolAccountType,
   SolMethod,
 } from '@metamask/keyring-api';
-import { KeyringEvent } from '@metamask/keyring-api/dist/events';
+import { KeyringEvent } from '@metamask/keyring-api';
 import type { SnapController } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
 import { KnownCaipNamespace, toCaipChainId } from '@metamask/utils';


### PR DESCRIPTION
The `JsonRpcRequest` type was used in the bridge but not "officially" exported by the `keyring-api` (hence the import from the `dist` folder).

To avoid this pattern, we now export it properly.