### PR TITLE
chore: bump typescript to version 5.6.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
     "typedoc": "^0.25.13",
-    "typescript": "~5.4.5"
+    "typescript": "~5.6.3"
   },
   "packageManager": "yarn@4.5.0",
   "engines": {

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -71,7 +71,7 @@
     "ts-node": "^10.9.2",
     "tsd": "^0.31.0",
     "typedoc": "^0.25.13",
-    "typescript": "~5.4.5"
+    "typescript": "~5.6.3"
   },
   "peerDependencies": {
     "@metamask/providers": "^18.1.0"

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -77,7 +77,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
     "typedoc": "^0.25.13",
-    "typescript": "~5.4.5"
+    "typescript": "~5.6.3"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -67,7 +67,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
     "typedoc": "^0.25.13",
-    "typescript": "~5.4.5"
+    "typescript": "~5.6.3"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -77,7 +77,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
     "typedoc": "^0.25.13",
-    "typescript": "~5.4.5"
+    "typescript": "~5.6.3"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -59,7 +59,7 @@
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
     "typedoc": "^0.25.13",
-    "typescript": "~5.4.5"
+    "typescript": "~5.6.3"
   },
   "peerDependencies": {
     "@metamask/keyring-api": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1672,7 +1672,7 @@ __metadata:
     ts-jest: "npm:^29.0.5"
     ts-node: "npm:^10.9.2"
     typedoc: "npm:^0.25.13"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.6.3"
   languageName: unknown
   linkType: soft
 
@@ -1917,7 +1917,7 @@ __metadata:
     ts-jest: "npm:^29.0.5"
     ts-node: "npm:^10.9.2"
     typedoc: "npm:^0.25.13"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.6.3"
   languageName: unknown
   linkType: soft
 
@@ -1983,7 +1983,7 @@ __metadata:
     ts-jest: "npm:^29.0.5"
     ts-node: "npm:^10.9.2"
     typedoc: "npm:^0.25.13"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.6.3"
   languageName: unknown
   linkType: soft
 
@@ -2012,7 +2012,7 @@ __metadata:
     ts-jest: "npm:^29.0.5"
     ts-node: "npm:^10.9.2"
     typedoc: "npm:^0.25.13"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.6.3"
     uuid: "npm:^9.0.1"
   peerDependencies:
     "@metamask/keyring-api": "workspace:^"
@@ -2051,7 +2051,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     tslib: "npm:^2.6.2"
     typedoc: "npm:^0.25.13"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.6.3"
   languageName: unknown
   linkType: soft
 
@@ -2139,7 +2139,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     tsd: "npm:^0.31.0"
     typedoc: "npm:^0.25.13"
-    typescript: "npm:~5.4.5"
+    typescript: "npm:~5.6.3"
     uuid: "npm:^9.0.1"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
@@ -11200,23 +11200,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~5.4.5":
-  version: 5.4.5
-  resolution: "typescript@npm:5.4.5"
+"typescript@npm:~5.6.3":
+  version: 5.6.3
+  resolution: "typescript@npm:5.6.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/d04a9e27e6d83861f2126665aa8d84847e8ebabcea9125b9ebc30370b98cb38b5dff2508d74e2326a744938191a83a69aa9fddab41f193ffa43eabfdf3f190a5
+  checksum: 10/c328e418e124b500908781d9f7b9b93cf08b66bf5936d94332b463822eea2f4e62973bfb3b8a745fdc038785cb66cf59d1092bac3ec2ac6a3e5854687f7833f1
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~5.4.5#optional!builtin<compat/typescript>":
-  version: 5.4.5
-  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
+"typescript@patch:typescript@npm%3A~5.6.3#optional!builtin<compat/typescript>":
+  version: 5.6.3
+  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/760f7d92fb383dbf7dee2443bf902f4365db2117f96f875cf809167f6103d55064de973db9f78fe8f31ec08fff52b2c969aee0d310939c0a3798ec75d0bca2e1
+  checksum: 10/00504c01ee42d470c23495426af07512e25e6546bce7e24572e72a9ca2e6b2e9bea63de4286c3cfea644874da1467dcfca23f4f98f7caf20f8b03c0213bb6837
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Just upgrading to the latest stable TypeScript version.

This is also related to this comment: https://github.com/MetaMask/accounts/pull/40#issuecomment-2423429098.
