### PR TITLE
feat(keyring-eth-ledger-bridge)!: enable ledger clear signing

### DIFF
--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -23,10 +23,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 90.14,
-      functions: 95.95,
-      lines: 94.77,
-      statements: 94.83,
+      branches: 91.91,
+      functions: 96,
+      lines: 95.02,
+      statements: 95.07,
     },
   },
 });

--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -23,7 +23,7 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 91.91,
+      branches: 90.97,
       functions: 96,
       lines: 95.02,
       statements: 95.07,

--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -23,10 +23,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 90.97,
+      branches: 90.9,
       functions: 96,
-      lines: 95.02,
-      statements: 95.07,
+      lines: 95.03,
+      statements: 95.09,
     },
   },
 });

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -61,7 +61,7 @@
     "@ledgerhq/hw-transport": "^6.31.3",
     "@ledgerhq/types-cryptoassets": "^7.15.1",
     "@ledgerhq/types-devices": "^6.25.3",
-    "@ledgerhq/types-live": "^6.52.0",
+    "@ledgerhq/types-live": "^6.54.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/utils": "^9.3.0",
     "@ts-bridge/cli": "^0.6.0",

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -61,6 +61,7 @@
     "@ledgerhq/hw-transport": "^6.31.3",
     "@ledgerhq/types-cryptoassets": "^7.15.1",
     "@ledgerhq/types-devices": "^6.25.3",
+    "@ledgerhq/types-live": "^6.53.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/utils": "^9.3.0",
     "@ts-bridge/cli": "^0.6.0",

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -61,7 +61,7 @@
     "@ledgerhq/hw-transport": "^6.31.3",
     "@ledgerhq/types-cryptoassets": "^7.15.1",
     "@ledgerhq/types-devices": "^6.25.3",
-    "@ledgerhq/types-live": "^6.54.0",
+    "@ledgerhq/types-live": "^6.52.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/utils": "^9.3.0",
     "@ts-bridge/cli": "^0.6.0",

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -61,7 +61,7 @@
     "@ledgerhq/hw-transport": "^6.31.3",
     "@ledgerhq/types-cryptoassets": "^7.15.1",
     "@ledgerhq/types-devices": "^6.25.3",
-    "@ledgerhq/types-live": "^6.53.0",
+    "@ledgerhq/types-live": "^6.52.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/utils": "^9.3.0",
     "@ts-bridge/cli": "^0.6.0",

--- a/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
@@ -1,5 +1,6 @@
 import type LedgerHwAppEth from '@ledgerhq/hw-app-eth';
 import type Transport from '@ledgerhq/hw-transport';
+import { EIP712Message } from '@ledgerhq/types-live';
 
 export type GetPublicKeyParams = { hdPath: string };
 export type GetPublicKeyResponse = Awaited<
@@ -18,8 +19,7 @@ export type LedgerSignMessageResponse = Awaited<
 
 export type LedgerSignTypedDataParams = {
   hdPath: string;
-  domainSeparatorHex: string;
-  hashStructMessageHex: string;
+  message: EIP712Message;
 };
 export type LedgerSignTypedDataResponse = Awaited<
   ReturnType<LedgerHwAppEth['signEIP712HashedMessage']>

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
@@ -458,26 +458,27 @@ describe('LedgerIframeBridge', function () {
   });
 
   describe('deviceSignTypedData', function () {
+    const params = {
+      hdPath: "m/44'/60'/0'/0",
+      message: {
+        domain: {
+          chainId: 1,
+          verifyingContract: '0xdsf',
+        },
+        primaryType: 'string',
+        types: {
+          EIP712Domain: [],
+          string: [],
+        },
+        message: { test: 'test' },
+      },
+    };
+
     it('sends and processes a successful ledger-sign-typed-data message', async function () {
       const payload = {
         v: 0,
         r: '',
         s: '',
-      };
-      const params = {
-        hdPath: "m/44'/60'/0'/0",
-        message: {
-          domain: {
-            chainId: 1,
-            verifyingContract: '0xdsf',
-          },
-          primaryType: 'string',
-          types: {
-            EIP712Domain: [],
-            string: [],
-          },
-          message: { test: 'test' },
-        },
       };
 
       stubKeyringIFramePostMessage(bridge, (message) => {
@@ -506,21 +507,6 @@ describe('LedgerIframeBridge', function () {
 
     it('throws an error when a ledger-sign-typed-data message is not successful', async function () {
       const errorMessage = 'Ledger Error';
-      const params = {
-        hdPath: "m/44'/60'/0'/0",
-        message: {
-          domain: {
-            chainId: 1,
-            verifyingContract: '0xdsf',
-          },
-          primaryType: 'string',
-          types: {
-            EIP712Domain: [],
-            string: [],
-          },
-          message: { test: 'test' },
-        },
-      };
 
       stubKeyringIFramePostMessage(bridge, (message) => {
         expect(message).toStrictEqual({

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
@@ -443,8 +443,18 @@ describe('LedgerIframeBridge', function () {
       };
       const params = {
         hdPath: "m/44'/60'/0'/0",
-        domainSeparatorHex: '',
-        hashStructMessageHex: '',
+        message: {
+          domain: {
+            chainId: 1,
+            verifyingContract: '0xdsf',
+          },
+          primaryType: 'string',
+          types: {
+            EIP712Domain: [],
+            string: [],
+          },
+          message: { test: 'test' },
+        },
       };
 
       stubKeyringIFramePostMessage(bridge, (message) => {
@@ -475,8 +485,18 @@ describe('LedgerIframeBridge', function () {
       const errorMessage = 'Ledger Error';
       const params = {
         hdPath: "m/44'/60'/0'/0",
-        domainSeparatorHex: '',
-        hashStructMessageHex: '',
+        message: {
+          domain: {
+            chainId: 1,
+            verifyingContract: '0xdsf',
+          },
+          primaryType: 'string',
+          types: {
+            EIP712Domain: [],
+            string: [],
+          },
+          message: { test: 'test' },
+        },
       };
 
       stubKeyringIFramePostMessage(bridge, (message) => {

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
@@ -177,6 +177,29 @@ describe('LedgerIframeBridge', function () {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(bridge.iframe?.contentWindow?.postMessage).toHaveBeenCalled();
     });
+
+    it('throws an error when unknown error occur', async function () {
+      const errorMessage = 'Unknown error occurred';
+
+      stubKeyringIFramePostMessage(bridge, (message) => {
+        expect(message).toStrictEqual({
+          action: IFrameMessageAction.LedgerMakeApp,
+          messageId: 1,
+          target: LEDGER_IFRAME_ID,
+        });
+
+        bridge.messageCallbacks[message.messageId]?.({
+          action: IFrameMessageAction.LedgerMakeApp,
+          messageId: 1,
+          success: false,
+        });
+      });
+
+      await expect(bridge.attemptMakeApp()).rejects.toThrow(errorMessage);
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(bridge.iframe?.contentWindow?.postMessage).toHaveBeenCalled();
+    });
   });
 
   describe('updateTransportMethod', function () {

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
@@ -117,7 +117,7 @@ export class LedgerIframeBridge
   ) {
     this.#validateConfiguration(opts);
     this.#opts = {
-      bridgeUrl: opts?.bridgeUrl,
+      bridgeUrl: opts.bridgeUrl,
     };
   }
 
@@ -141,7 +141,7 @@ export class LedgerIframeBridge
 
   async setOptions(opts: LedgerIframeBridgeOptions): Promise<void> {
     this.#validateConfiguration(opts);
-    if (this.#opts?.bridgeUrl !== opts.bridgeUrl) {
+    if (this.#opts.bridgeUrl !== opts.bridgeUrl) {
       this.#opts.bridgeUrl = opts.bridgeUrl;
       await this.destroy();
       await this.init();

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
@@ -117,7 +117,7 @@ export class LedgerIframeBridge
   ) {
     this.#validateConfiguration(opts);
     this.#opts = {
-      bridgeUrl: opts.bridgeUrl,
+      bridgeUrl: opts?.bridgeUrl,
     };
   }
 
@@ -141,7 +141,7 @@ export class LedgerIframeBridge
 
   async setOptions(opts: LedgerIframeBridgeOptions): Promise<void> {
     this.#validateConfiguration(opts);
-    if (this.#opts.bridgeUrl !== opts.bridgeUrl) {
+    if (this.#opts?.bridgeUrl !== opts.bridgeUrl) {
       this.#opts.bridgeUrl = opts.bridgeUrl;
       await this.destroy();
       await this.init();

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
@@ -928,6 +928,7 @@ describe('LedgerKeyring', function () {
           name: 'Ether Mail',
           verifyingContract: '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC',
           version: '1',
+          salt: new TextEncoder().encode('hello'),
         },
         message: {
           contents: 'Hello, Bob!',
@@ -993,6 +994,33 @@ describe('LedgerKeyring', function () {
         const result = await keyring.signTypedData(
           fakeAccounts[15],
           fixtureData,
+          options,
+        );
+        expect(result).toBe(
+          '0x72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b946759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e321b',
+        );
+      });
+
+      it('resolves properly when message domain salt is undefined', async function () {
+        const fixtureDataWithoutSalt = {
+          ...fixtureData,
+          domain: {
+            ...fixtureData.domain,
+            salt: undefined,
+          },
+        };
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignTypedData')
+          .mockImplementation(async () => ({
+            v: 27,
+            r: '72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b9',
+            s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
+          }));
+
+        const result = await keyring.signTypedData(
+          fakeAccounts[15],
+          fixtureDataWithoutSalt,
           options,
         );
         expect(result).toBe(

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -520,7 +520,7 @@ export class LedgerKeyring extends EventEmitter {
               : undefined,
           },
           types,
-          primaryType: pt,
+          primaryType: primaryType.toString(),
           message,
         },
       });

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -501,8 +501,6 @@ export class LedgerKeyring extends EventEmitter {
       throw new Error('Ledger: Unknown error while signing message');
     }
 
-    const pt = primaryType.toString();
-
     let payload;
     try {
       payload = await this.bridge.deviceSignTypedData({
@@ -513,11 +511,7 @@ export class LedgerKeyring extends EventEmitter {
             chainId: domain.chainId,
             version: domain.version,
             verifyingContract: domain.verifyingContract,
-            salt: domain.salt
-              // We convert this to a plain string to avoid encoding issue on the
-              // mobile side (to avoid using `TextDecoder`).
-              ? this.#arrayBufferToString(domain.salt)
-              : undefined,
+            salt: this.#convertSaltIfAny(domain.salt),
           },
           types,
           primaryType: primaryType.toString(),
@@ -564,9 +558,15 @@ export class LedgerKeyring extends EventEmitter {
     this.hdk = new HDKey();
   }
 
-  #arrayBufferToString(buffer: ArrayBuffer): string {
-    const uint8Array = new Uint8Array(buffer);
-    return String.fromCharCode(...uint8Array);
+  #convertSaltIfAny(salt: ArrayBuffer | undefined): string | undefined {
+    if (!salt) {
+      return undefined;
+    }
+
+    // We convert this to a plain string to avoid encoding issue on the
+    // mobile side (to avoid using `TextDecoder`).
+    const saltBytes = new Uint8Array(salt);
+    return String.fromCharCode(...saltBytes);
   }
 
   /* PRIVATE METHODS */

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -513,7 +513,9 @@ export class LedgerKeyring extends EventEmitter {
             chainId: domain.chainId,
             version: domain.version,
             verifyingContract: domain.verifyingContract,
-            salt: domain.salt? new TextDecoder().decode(domain.salt): undefined,
+            salt: domain.salt
+              ? new TextDecoder().decode(domain.salt)
+              : undefined,
           },
           types,
           primaryType: pt,

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -514,7 +514,7 @@ export class LedgerKeyring extends EventEmitter {
             version: domain.version,
             verifyingContract: domain.verifyingContract,
             salt: domain.salt
-              ? new TextDecoder().decode(domain.salt)
+              ? this.#arrayBufferToString(domain.salt)
               : undefined,
           },
           types,
@@ -560,6 +560,11 @@ export class LedgerKeyring extends EventEmitter {
     this.paths = {};
     this.accountDetails = {};
     this.hdk = new HDKey();
+  }
+
+  #arrayBufferToString(buffer: ArrayBuffer): string {
+    const uint8Array = new Uint8Array(buffer);
+    return String.fromCharCode(...uint8Array);
   }
 
   /* PRIVATE METHODS */

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -514,6 +514,8 @@ export class LedgerKeyring extends EventEmitter {
             version: domain.version,
             verifyingContract: domain.verifyingContract,
             salt: domain.salt
+              // We convert this to a plain string to avoid encoding issue on the
+              // mobile side (to avoid using `TextDecoder`).
               ? this.#arrayBufferToString(domain.salt)
               : undefined,
           },

--- a/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.test.ts
@@ -168,18 +168,18 @@ describe('LedgerMobileBridge', function () {
       });
     });
 
-    // it('throws an error when tx format is not correct', async function () {
-    //   const hdPath = "m/44'/60'/0'/0/0";
-    //   const tx = '';
-    //   await expect(
-    //     bridge.deviceSignTransaction({
-    //       hdPath,
-    //       tx,
-    //     }),
-    //   ).rejects.toThrow(Error);
-    //   expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(0);
-    //   expect(mockEthApp.clearSignTransaction).toHaveBeenCalledTimes(0);
-    // });
+    it('returns undefined when tx format is not correct', async function () {
+      const hdPath = "m/44'/60'/0'/0/0";
+      const tx = '';
+      expect(
+        await bridge.deviceSignTransaction({
+          hdPath,
+          tx,
+        }),
+      ).toBeUndefined();
+      expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.clearSignTransaction).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('deviceSignTypedData', function () {

--- a/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.test.ts
@@ -1,4 +1,3 @@
-import ledgerService from '@ledgerhq/hw-app-eth/lib/services/ledger';
 import Transport from '@ledgerhq/hw-transport';
 import { EIP712Message } from '@ledgerhq/types-live';
 
@@ -21,7 +20,7 @@ describe('LedgerMobileBridge', function () {
 
   const mockEthApp = {
     signEIP712Message: jest.fn(),
-    clearSignTransaction : jest.fn(),
+    clearSignTransaction: jest.fn(),
     getAddress: jest.fn(),
     signPersonalMessage: jest.fn(),
     openEthApp: jest.fn(),

--- a/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.test.ts
@@ -179,6 +179,11 @@ describe('LedgerMobileBridge', function () {
       ).toBeUndefined();
       expect(transportMiddlewareGetEthAppSpy).toHaveBeenCalledTimes(1);
       expect(mockEthApp.clearSignTransaction).toHaveBeenCalledTimes(1);
+      expect(mockEthApp.clearSignTransaction).toHaveBeenCalledWith(hdPath, tx, {
+        externalPlugins: true,
+        erc20: true,
+        nft: true,
+      });
     });
   });
 

--- a/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.ts
@@ -112,9 +112,7 @@ export class LedgerMobileBridge implements MobileBridge {
     tx,
     hdPath,
   }: LedgerSignTransactionParams): Promise<LedgerSignTransactionResponse> {
-    const ethApp = this.#getEthApp();
-
-    return ethApp.clearSignTransaction(hdPath, tx, {
+    return this.#getEthApp().clearSignTransaction(hdPath, tx, {
       externalPlugins: true,
       erc20: true,
       nft: true,

--- a/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.ts
@@ -1,4 +1,3 @@
-import ledgerService from '@ledgerhq/hw-app-eth/lib/services/ledger';
 import type Transport from '@ledgerhq/hw-transport';
 
 import {
@@ -90,20 +89,14 @@ export class LedgerMobileBridge implements MobileBridge {
    *
    * @param params - An object contains hdPath, domainSeparatorHex and hashStructMessageHex.
    * @param params.hdPath - The BIP 32 path of the account.
-   * @param params.domainSeparatorHex - The domain separator.
-   * @param params.hashStructMessageHex - The hashed struct message.
+   * @param params.message - The EIP712 message to sign.
    * @returns Retrieve v, r, s from the signed message.
    */
   async deviceSignTypedData({
     hdPath,
-    domainSeparatorHex,
-    hashStructMessageHex,
+    message,
   }: LedgerSignTypedDataParams): Promise<LedgerSignTypedDataResponse> {
-    return this.#getEthApp().signEIP712HashedMessage(
-      hdPath,
-      domainSeparatorHex,
-      hashStructMessageHex,
-    );
+    return this.#getEthApp().signEIP712Message(hdPath, message);
   }
 
   /**
@@ -119,8 +112,13 @@ export class LedgerMobileBridge implements MobileBridge {
     tx,
     hdPath,
   }: LedgerSignTransactionParams): Promise<LedgerSignTransactionResponse> {
-    const resolution = await ledgerService.resolveTransaction(tx, {}, {});
-    return this.#getEthApp().signTransaction(hdPath, tx, resolution);
+    const ethApp = this.#getEthApp();
+
+    return ethApp.clearSignTransaction(hdPath, tx, {
+      externalPlugins: true,
+      erc20: true,
+      nft: true,
+    });
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,16 +1626,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/types-live@npm:^6.53.0":
-  version: 6.53.0
-  resolution: "@ledgerhq/types-live@npm:6.53.0"
-  dependencies:
-    bignumber.js: "npm:^9.1.2"
-    rxjs: "npm:^7.8.1"
-  checksum: 10/aeb4881f994b86ff5e284c8b24b81ad2fae21b87769639fd55b266f3979f6d66f0690ef1b76c51aeebb6238c3c780062d0b8e2e6d91a1860fc4827a3c4194b55
-  languageName: node
-  linkType: hard
-
 "@metamask/abi-utils@npm:^2.0.4":
   version: 2.0.4
   resolution: "@metamask/abi-utils@npm:2.0.4"
@@ -1910,7 +1900,7 @@ __metadata:
     "@ledgerhq/hw-transport": "npm:^6.31.3"
     "@ledgerhq/types-cryptoassets": "npm:^7.15.1"
     "@ledgerhq/types-devices": "npm:^6.25.3"
-    "@ledgerhq/types-live": "npm:^6.53.0"
+    "@ledgerhq/types-live": "npm:^6.52.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.0.0"
     "@metamask/utils": "npm:^9.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,17 +1616,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/types-live@npm:^6.52.0":
-  version: 6.52.0
-  resolution: "@ledgerhq/types-live@npm:6.52.0"
-  dependencies:
-    bignumber.js: "npm:^9.1.2"
-    rxjs: "npm:^7.8.1"
-  checksum: 10/c410f02159538d66f59956512fc5bab2cb17edee7f6a15a517c31d89d6c730e52691666bb2e1d98718c701e94306dd7498544ea3d7772ff0b5ad6522fb2c335c
-  languageName: node
-  linkType: hard
-
-"@ledgerhq/types-live@npm:^6.54.0":
+"@ledgerhq/types-live@npm:^6.52.0, @ledgerhq/types-live@npm:^6.54.0":
   version: 6.54.0
   resolution: "@ledgerhq/types-live@npm:6.54.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,6 +1626,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ledgerhq/types-live@npm:^6.54.0":
+  version: 6.54.0
+  resolution: "@ledgerhq/types-live@npm:6.54.0"
+  dependencies:
+    bignumber.js: "npm:^9.1.2"
+    rxjs: "npm:^7.8.1"
+  checksum: 10/90cf2207d10ab4f8db8461670fe53b74d56b19eb67b9f868e3159aba2fc77ca3b015a6f67af316cf3bd0711db395af11218dc845194c05f193a106a44730fcda
+  languageName: node
+  linkType: hard
+
 "@metamask/abi-utils@npm:^2.0.4":
   version: 2.0.4
   resolution: "@metamask/abi-utils@npm:2.0.4"
@@ -1900,7 +1910,7 @@ __metadata:
     "@ledgerhq/hw-transport": "npm:^6.31.3"
     "@ledgerhq/types-cryptoassets": "npm:^7.15.1"
     "@ledgerhq/types-devices": "npm:^6.25.3"
-    "@ledgerhq/types-live": "npm:^6.52.0"
+    "@ledgerhq/types-live": "npm:^6.54.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.0.0"
     "@metamask/utils": "npm:^9.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1626,6 +1626,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ledgerhq/types-live@npm:^6.53.0":
+  version: 6.53.0
+  resolution: "@ledgerhq/types-live@npm:6.53.0"
+  dependencies:
+    bignumber.js: "npm:^9.1.2"
+    rxjs: "npm:^7.8.1"
+  checksum: 10/aeb4881f994b86ff5e284c8b24b81ad2fae21b87769639fd55b266f3979f6d66f0690ef1b76c51aeebb6238c3c780062d0b8e2e6d91a1860fc4827a3c4194b55
+  languageName: node
+  linkType: hard
+
 "@metamask/abi-utils@npm:^2.0.4":
   version: 2.0.4
   resolution: "@metamask/abi-utils@npm:2.0.4"
@@ -1900,6 +1910,7 @@ __metadata:
     "@ledgerhq/hw-transport": "npm:^6.31.3"
     "@ledgerhq/types-cryptoassets": "npm:^7.15.1"
     "@ledgerhq/types-devices": "npm:^6.25.3"
+    "@ledgerhq/types-live": "npm:^6.53.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.0.0"
     "@metamask/utils": "npm:^9.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,13 +1616,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/types-live@npm:^6.52.0, @ledgerhq/types-live@npm:^6.54.0":
-  version: 6.54.0
-  resolution: "@ledgerhq/types-live@npm:6.54.0"
+"@ledgerhq/types-live@npm:^6.52.0":
+  version: 6.52.0
+  resolution: "@ledgerhq/types-live@npm:6.52.0"
   dependencies:
     bignumber.js: "npm:^9.1.2"
     rxjs: "npm:^7.8.1"
-  checksum: 10/90cf2207d10ab4f8db8461670fe53b74d56b19eb67b9f868e3159aba2fc77ca3b015a6f67af316cf3bd0711db395af11218dc845194c05f193a106a44730fcda
+  checksum: 10/c410f02159538d66f59956512fc5bab2cb17edee7f6a15a517c31d89d6c730e52691666bb2e1d98718c701e94306dd7498544ea3d7772ff0b5ad6522fb2c335c
   languageName: node
   linkType: hard
 
@@ -1900,7 +1900,7 @@ __metadata:
     "@ledgerhq/hw-transport": "npm:^6.31.3"
     "@ledgerhq/types-cryptoassets": "npm:^7.15.1"
     "@ledgerhq/types-devices": "npm:^6.25.3"
-    "@ledgerhq/types-live": "npm:^6.54.0"
+    "@ledgerhq/types-live": "npm:^6.52.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.0.0"
     "@metamask/utils": "npm:^9.3.0"


### PR DESCRIPTION
The original feature requirement is listed here:
- https://github.com/MetaMask/accounts-planning/issues/544

This PR will enable clear signing feature in `signTransaction` and `signEIP712` typed data in `@metamask/eth-ledger-keyring-bridge` library. please refer to ledger official document for detail: https://developers.ledger.com/docs/clear-signing/getting-started



This PR has done following changes:
1. change the `deviceSignTypedData` and `deviceSignTransaction` method to use new API suggested by ledger team which support clear signing.
2. change `ledger-keyring.ts` to adapt new API format for `deviceSignTypedData`.
3. fix all unit tests issue.
