### PR TITLE
refactor(keyring-eth-hd)!: move seed generation to deserialization

### DIFF
--- a/packages/keyring-eth-hd/src/index.js
+++ b/packages/keyring-eth-hd/src/index.js
@@ -16,8 +16,7 @@ import {
 } from '@metamask/eth-sig-util';
 import {
   generateMnemonic,
-  // eslint-disable-next-line n/no-sync
-  mnemonicToSeedSync,
+  mnemonicToSeed,
   validateMnemonic,
 } from '@metamask/scure-bip39';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
@@ -32,14 +31,13 @@ const type = 'HD Key Tree';
 
 class HdKeyring {
   /* PUBLIC METHODS */
-  constructor(opts = {}) {
+  constructor() {
     this.type = type;
     this._wallets = [];
-    this.deserialize(opts);
   }
 
-  generateRandomMnemonic() {
-    this._initFromMnemonic(generateMnemonic(wordlist));
+  async generateRandomMnemonic() {
+    await this._initFromMnemonic(generateMnemonic(wordlist));
   }
 
   _uint8ArrayToString(mnemonic) {
@@ -84,20 +82,20 @@ class HdKeyring {
     return mnemonicData;
   }
 
-  serialize() {
+  async serialize() {
     const mnemonicAsString = this._uint8ArrayToString(this.mnemonic);
     const uint8ArrayMnemonic = new TextEncoder('utf-8').encode(
       mnemonicAsString,
     );
 
-    return Promise.resolve({
+    return {
       mnemonic: Array.from(uint8ArrayMnemonic),
       numberOfAccounts: this._wallets.length,
       hdPath: this.hdPath,
-    });
+    };
   }
 
-  deserialize(opts = {}) {
+  async deserialize(opts = {}) {
     if (opts.numberOfAccounts && !opts.mnemonic) {
       throw new Error(
         'Eth-Hd-Keyring: Deserialize method cannot be called with an opts value for numberOfAccounts and no menmonic',
@@ -116,14 +114,14 @@ class HdKeyring {
     this.hdPath = opts.hdPath || hdPathString;
 
     if (opts.mnemonic) {
-      this._initFromMnemonic(opts.mnemonic);
+      await this._initFromMnemonic(opts.mnemonic);
     }
 
     if (opts.numberOfAccounts) {
       return this.addAccounts(opts.numberOfAccounts);
     }
 
-    return Promise.resolve([]);
+    return [];
   }
 
   addAccounts(numberOfAccounts = 1) {
@@ -282,7 +280,7 @@ class HdKeyring {
    * as a string, an array of UTF-8 bytes, or a Buffer. Mnemonic input
    * passed as type buffer or array of UTF-8 bytes must be NFKD normalized.
    */
-  _initFromMnemonic(mnemonic) {
+  async _initFromMnemonic(mnemonic) {
     if (this.root) {
       throw new Error(
         'Eth-Hd-Keyring: Secret recovery phrase already provided',
@@ -299,8 +297,7 @@ class HdKeyring {
       );
     }
 
-    // eslint-disable-next-line n/no-sync
-    const seed = mnemonicToSeedSync(this.mnemonic, wordlist);
+    const seed = await mnemonicToSeed(this.mnemonic, wordlist);
     this.hdWallet = HDKey.fromMasterSeed(seed);
     this.root = this.hdWallet.derive(this.hdPath);
   }

--- a/packages/keyring-eth-hd/test/index.js
+++ b/packages/keyring-eth-hd/test/index.js
@@ -43,7 +43,11 @@ describe('hd-keyring', () => {
 
       await Promise.all(
         mnemonics.map(async (mnemonic) => {
-          const newHDKeyring = new HdKeyring({ mnemonic, numberOfAccounts: 3 });
+          const newHDKeyring = new HdKeyring();
+          await newHDKeyring.deserialize({
+            mnemonic,
+            numberOfAccounts: 3,
+          });
           const oldHDKeyring = new OldHdKeyring({
             mnemonic,
             numberOfAccounts: 3,
@@ -60,102 +64,29 @@ describe('hd-keyring', () => {
     });
   });
 
-  describe('constructor', () => {
-    it('constructs with a typeof string mnemonic', async () => {
-      const keyring = new HdKeyring({
-        mnemonic: sampleMnemonic,
-        numberOfAccounts: 2,
-      });
-
-      const accounts = await keyring.getAccounts();
-      expect(accounts[0]).toStrictEqual(firstAcct);
-      expect(accounts[1]).toStrictEqual(secondAcct);
-    });
-
-    it('constructs with a typeof buffer mnemonic', async () => {
-      const keyring = new HdKeyring({
-        mnemonic: Buffer.from(sampleMnemonic, 'utf8'),
-        numberOfAccounts: 2,
-      });
-
-      const accounts = await keyring.getAccounts();
-      expect(accounts[0]).toStrictEqual(firstAcct);
-      expect(accounts[1]).toStrictEqual(secondAcct);
-    });
-
-    it('constructs with a typeof Uint8Array mnemonic', async () => {
-      const indices = sampleMnemonic
-        .split(' ')
-        .map((word) => wordlist.indexOf(word));
-      const uInt8ArrayOfMnemonic = new Uint8Array(
-        new Uint16Array(indices).buffer,
-      );
-      const keyring = new HdKeyring({
-        mnemonic: uInt8ArrayOfMnemonic,
-        numberOfAccounts: 2,
-      });
-
-      const accounts = await keyring.getAccounts();
-      expect(accounts[0]).toStrictEqual(firstAcct);
-      expect(accounts[1]).toStrictEqual(secondAcct);
-    });
-
-    it('throws on invalid mnemonic', () => {
-      expect(
-        () =>
-          new HdKeyring({
-            mnemonic: 'abc xyz',
-            numberOfAccounts: 2,
-          }),
-      ).toThrow('Eth-Hd-Keyring: Invalid secret recovery phrase provided');
-    });
-
-    it('throws when numberOfAccounts is passed with no mnemonic', () => {
-      expect(
-        () =>
-          new HdKeyring({
-            numberOfAccounts: 2,
-          }),
-      ).toThrow(
-        'Eth-Hd-Keyring: Deserialize method cannot be called with an opts value for numberOfAccounts and no menmonic',
-      );
-    });
-  });
-
   describe('re-initialization protection', () => {
     const alreadyProvidedError =
       'Eth-Hd-Keyring: Secret recovery phrase already provided';
-    it('double generateRandomMnemonic', () => {
+    it('double generateRandomMnemonic', async () => {
       const keyring = new HdKeyring();
-      keyring.generateRandomMnemonic();
-      expect(() => {
-        keyring.generateRandomMnemonic();
-      }).toThrow(alreadyProvidedError);
+      await keyring.deserialize();
+      await keyring.generateRandomMnemonic();
+      await expect(keyring.generateRandomMnemonic()).rejects.toThrow(
+        alreadyProvidedError,
+      );
     });
 
-    it('constructor + generateRandomMnemonic', () => {
-      const keyring = new HdKeyring({
+    it('deserialize + generateRandomMnemonic', async () => {
+      const keyring = new HdKeyring();
+
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 2,
       });
 
-      expect(() => {
-        keyring.generateRandomMnemonic();
-      }).toThrow(alreadyProvidedError);
-    });
-
-    it('constructor + deserialize', () => {
-      const keyring = new HdKeyring({
-        mnemonic: sampleMnemonic,
-        numberOfAccounts: 2,
-      });
-
-      expect(() => {
-        keyring.deserialize({
-          mnemonic: sampleMnemonic,
-          numberOfAccounts: 1,
-        });
-      }).toThrow(alreadyProvidedError);
+      await expect(keyring.generateRandomMnemonic()).rejects.toThrow(
+        alreadyProvidedError,
+      );
     });
   });
 
@@ -178,9 +109,8 @@ describe('hd-keyring', () => {
 
   describe('#serialize mnemonic.', () => {
     it('serializes the mnemonic in the same format as previous version (an array of utf8 encoded bytes)', async () => {
-      const keyring = new HdKeyring({
-        mnemonic: sampleMnemonic,
-      });
+      const keyring = new HdKeyring();
+      await keyring.deserialize({ mnemonic: sampleMnemonic });
       // uses previous version of eth-hd-keyring to ensure backwards compatibility
       const oldHDKeyring = new OldHdKeyring({ mnemonic: sampleMnemonic });
       const { mnemonic: oldKeyringSerializedMnemonic } =
@@ -191,9 +121,8 @@ describe('hd-keyring', () => {
     });
 
     it('serializes mnemonic passed in as a string to an array of utf8 encoded bytes', async () => {
-      const keyring = new HdKeyring({
-        mnemonic: sampleMnemonic,
-      });
+      const keyring = new HdKeyring();
+      await keyring.deserialize({ mnemonic: sampleMnemonic });
       const output = await keyring.serialize();
       // this Buffer.from(...).toString() is the method of converting from an array of utf8 encoded bytes back to a string
       const mnemonicAsString = Buffer.from(output.mnemonic).toString();
@@ -203,7 +132,8 @@ describe('hd-keyring', () => {
     it('serializes mnemonic passed in as a an array of utf8 encoded bytes in the same format', async () => {
       const uint8Array = new TextEncoder('utf-8').encode(sampleMnemonic);
       const mnemonicAsArrayOfUtf8EncodedBytes = Array.from(uint8Array);
-      const keyring = new HdKeyring({
+      const keyring = new HdKeyring();
+      await keyring.deserialize({
         mnemonic: mnemonicAsArrayOfUtf8EncodedBytes,
       });
 
@@ -214,7 +144,77 @@ describe('hd-keyring', () => {
     });
   });
 
-  describe('#deserialize a private key', () => {
+  describe('#deserialize mnemonics', () => {
+    it('deserializes with a typeof string mnemonic', async () => {
+      const keyring = new HdKeyring();
+
+      await keyring.deserialize({
+        mnemonic: sampleMnemonic,
+        numberOfAccounts: 2,
+      });
+
+      const accounts = await keyring.getAccounts();
+      expect(accounts[0]).toStrictEqual(firstAcct);
+      expect(accounts[1]).toStrictEqual(secondAcct);
+    });
+
+    it('deserializes with a typeof buffer mnemonic', async () => {
+      const keyring = new HdKeyring();
+
+      await keyring.deserialize({
+        mnemonic: Buffer.from(sampleMnemonic, 'utf8'),
+        numberOfAccounts: 2,
+      });
+
+      const accounts = await keyring.getAccounts();
+      expect(accounts[0]).toStrictEqual(firstAcct);
+      expect(accounts[1]).toStrictEqual(secondAcct);
+    });
+
+    it('deserializes with a typeof Uint8Array mnemonic', async () => {
+      const indices = sampleMnemonic
+        .split(' ')
+        .map((word) => wordlist.indexOf(word));
+      const uInt8ArrayOfMnemonic = new Uint8Array(
+        new Uint16Array(indices).buffer,
+      );
+      const keyring = new HdKeyring();
+
+      await keyring.deserialize({
+        mnemonic: uInt8ArrayOfMnemonic,
+        numberOfAccounts: 2,
+      });
+
+      const accounts = await keyring.getAccounts();
+      expect(accounts[0]).toStrictEqual(firstAcct);
+      expect(accounts[1]).toStrictEqual(secondAcct);
+    });
+
+    it('throws on invalid mnemonic', async () => {
+      const keyring = new HdKeyring();
+
+      await expect(
+        keyring.deserialize({
+          mnemonic: 'abc xyz',
+          numberOfAccounts: 2,
+        }),
+      ).rejects.toThrow(
+        'Eth-Hd-Keyring: Invalid secret recovery phrase provided',
+      );
+    });
+
+    it('throws when numberOfAccounts is passed with no mnemonic', async () => {
+      const keyring = new HdKeyring();
+
+      await expect(
+        keyring.deserialize({
+          numberOfAccounts: 2,
+        }),
+      ).rejects.toThrow(
+        'Eth-Hd-Keyring: Deserialize method cannot be called with an opts value for numberOfAccounts and no menmonic',
+      );
+    });
+
     it('serializes what it deserializes', async () => {
       const keyring = new HdKeyring();
       await keyring.deserialize({
@@ -240,7 +240,8 @@ describe('hd-keyring', () => {
     describe('with no arguments', () => {
       it('creates a single wallet', async () => {
         const keyring = new HdKeyring();
-        keyring.generateRandomMnemonic();
+        await keyring.deserialize();
+        await keyring.generateRandomMnemonic();
         await keyring.addAccounts();
         const accounts = await keyring.getAccounts();
         expect(accounts).toHaveLength(1);
@@ -257,7 +258,8 @@ describe('hd-keyring', () => {
     describe('with a numeric argument', () => {
       it('creates that number of wallets', async () => {
         const keyring = new HdKeyring();
-        keyring.generateRandomMnemonic();
+        await keyring.deserialize();
+        await keyring.generateRandomMnemonic();
         await keyring.addAccounts(3);
         const accounts = await keyring.getAccounts();
         expect(accounts).toHaveLength(3);
@@ -299,7 +301,8 @@ describe('hd-keyring', () => {
           value: 'Hi, Alice!',
         },
       ];
-      keyring.generateRandomMnemonic();
+      await keyring.deserialize();
+      await keyring.generateRandomMnemonic();
       await keyring.addAccounts(1);
       const addresses = await keyring.getAccounts();
       const address = addresses[0];
@@ -324,7 +327,8 @@ describe('hd-keyring', () => {
 
     it('signs in a compliant and recoverable way', async () => {
       const keyring = new HdKeyring();
-      keyring.generateRandomMnemonic();
+      await keyring.deserialize();
+      await keyring.generateRandomMnemonic();
       await keyring.addAccounts(1);
       const addresses = await keyring.getAccounts();
       const address = addresses[0];
@@ -411,7 +415,8 @@ describe('hd-keyring', () => {
         },
       };
 
-      keyring.generateRandomMnemonic();
+      await keyring.deserialize();
+      await keyring.generateRandomMnemonic();
       await keyring.addAccounts(1);
       const addresses = await keyring.getAccounts();
       const address = addresses[0];
@@ -431,7 +436,7 @@ describe('hd-keyring', () => {
     it('can deserialize with an hdPath param and generate the same accounts.', async () => {
       const keyring = new HdKeyring();
       const hdPathString = `m/44'/60'/0'/0`;
-      keyring.deserialize({
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
         hdPath: hdPathString,
@@ -445,7 +450,7 @@ describe('hd-keyring', () => {
     it('can deserialize with an hdPath param and generate different accounts.', async () => {
       const keyring = new HdKeyring();
       const hdPathString = `m/44'/60'/0'/1`;
-      keyring.deserialize({
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
         hdPath: hdPathString,
@@ -638,8 +643,10 @@ describe('hd-keyring', () => {
 
   describe('#removeAccount', function () {
     let keyring;
-    beforeEach(() => {
-      keyring = new HdKeyring({
+    beforeEach(async () => {
+      keyring = new HdKeyring();
+
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
       });
@@ -667,8 +674,10 @@ describe('hd-keyring', () => {
 
   describe('getAppKeyAddress', function () {
     let keyring;
-    beforeEach(() => {
-      keyring = new HdKeyring({
+    beforeEach(async () => {
+      keyring = new HdKeyring();
+
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
       });
@@ -733,8 +742,10 @@ describe('hd-keyring', () => {
 
   describe('exportAccount', function () {
     let keyring;
-    beforeEach(() => {
-      keyring = new HdKeyring({
+    beforeEach(async () => {
+      keyring = new HdKeyring();
+
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
       });
@@ -758,8 +769,10 @@ describe('hd-keyring', () => {
   describe('#encryptionPublicKey', function () {
     const publicKey = 'LV7lWhd0mUDcvxkMU2o6uKXftu25zq4bMYdmMqppXic=';
     let keyring;
-    beforeEach(() => {
-      keyring = new HdKeyring({
+    beforeEach(async () => {
+      keyring = new HdKeyring();
+
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
       });
@@ -787,8 +800,10 @@ describe('hd-keyring', () => {
 
   describe('#signTypedData V4 signature verification', function () {
     let keyring;
-    beforeEach(() => {
-      keyring = new HdKeyring({
+    beforeEach(async () => {
+      keyring = new HdKeyring();
+
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
       });
@@ -870,7 +885,9 @@ describe('hd-keyring', () => {
     let encryptedMessage, keyring;
 
     beforeEach(async () => {
-      keyring = new HdKeyring({
+      keyring = new HdKeyring();
+
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
       });
@@ -908,8 +925,10 @@ describe('hd-keyring', () => {
 
   describe('#signTransaction', function () {
     let keyring;
-    beforeEach(() => {
-      keyring = new HdKeyring({
+    beforeEach(async () => {
+      keyring = new HdKeyring();
+
+      await keyring.deserialize({
         mnemonic: sampleMnemonic,
         numberOfAccounts: 1,
       });


### PR DESCRIPTION
This PR refactors the `eth-hd-keyring` constructor to remove the deserialization step directly in the constructor. This lets us turn `deserialize` into a proper async function and use an async version of `mnemonicToSeed` (which should be swapped out for something faster in the future). 

This is a breaking change and requires that all usage of `eth-hd-keyring` calls `deserialize` with the arguments previously passed into the constructor. This seems to already be the case in the `KeyringController`, but may deserve a more thorough look.

This PR also changes the function signature of `generateRandomMnemonic`, making this an async function as well.

Appreciate any feedback and/or sanity checks on this!