### PR TITLE
feat(keyring-eth-hd): allow passing native implementations of cryptography

### DIFF
--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
     "@metamask/eth-sig-util": "^8.0.0",
-    "@metamask/key-tree": "^9.1.2",
+    "@metamask/key-tree": "^10.0.0",
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/utils": "^9.2.1",
     "ethereum-cryptography": "^2.1.2"

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@ethereumjs/util": "^8.1.0",
     "@metamask/eth-sig-util": "^8.0.0",
+    "@metamask/key-tree": "^9.1.2",
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/utils": "^9.2.1",
     "ethereum-cryptography": "^2.1.2"

--- a/packages/keyring-eth-hd/src/index.js
+++ b/packages/keyring-eth-hd/src/index.js
@@ -27,13 +27,13 @@ const hdPathString = `m/44'/60'/0'/0`;
 const type = 'HD Key Tree';
 
 class HdKeyring {
-  #cryptographicFunctions;
+  _cryptographicFunctions;
 
   /* PUBLIC METHODS */
   constructor(opts = {}) {
     this.type = type;
     this._wallets = [];
-    this.#cryptographicFunctions = opts.cryptographicFunctions;
+    this._cryptographicFunctions = opts.cryptographicFunctions;
   }
 
   async generateRandomMnemonic() {
@@ -292,7 +292,7 @@ class HdKeyring {
     const seed = await mnemonicToSeed(
       this.mnemonic,
       '',
-      this.#cryptographicFunctions,
+      this._cryptographicFunctions,
     );
     this.hdWallet = HDKey.fromMasterSeed(seed);
     this.root = this.hdWallet.derive(this.hdPath);

--- a/packages/keyring-eth-hd/src/index.js
+++ b/packages/keyring-eth-hd/src/index.js
@@ -14,8 +14,8 @@ import {
   signTypedData,
   SignTypedDataVersion,
 } from '@metamask/eth-sig-util';
-import { generateMnemonic } from '@metamask/scure-bip39';
 import { mnemonicToSeed } from '@metamask/key-tree';
+import { generateMnemonic } from '@metamask/scure-bip39';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { assertIsHexString, remove0x } from '@metamask/utils';
 import { HDKey } from 'ethereum-cryptography/hdkey';
@@ -27,8 +27,6 @@ const hdPathString = `m/44'/60'/0'/0`;
 const type = 'HD Key Tree';
 
 class HdKeyring {
-  _cryptographicFunctions;
-
   /* PUBLIC METHODS */
   constructor(opts = {}) {
     this.type = type;

--- a/packages/keyring-eth-hd/src/index.js
+++ b/packages/keyring-eth-hd/src/index.js
@@ -31,6 +31,7 @@ class HdKeyring {
   constructor(opts = {}) {
     this.type = type;
     this._wallets = [];
+    // Cryptographic functions to be used by `@metamask/key-tree`. It will use built-in implementations if not provided here.
     this._cryptographicFunctions = opts.cryptographicFunctions;
   }
 
@@ -289,7 +290,7 @@ class HdKeyring {
 
     const seed = await mnemonicToSeed(
       this.mnemonic,
-      '',
+      '', // No passphrase
       this._cryptographicFunctions,
     );
     this.hdWallet = HDKey.fromMasterSeed(seed);

--- a/packages/keyring-eth-hd/test/index.js
+++ b/packages/keyring-eth-hd/test/index.js
@@ -191,7 +191,8 @@ describe('hd-keyring', () => {
     });
 
     it('deserializes using custom cryptography', async () => {
-      async function pbkdf2Sha512(password, salt, iterations, keyLength) {
+      const pbkdf2Sha512 = async (password, salt, iterations, keyLength) => {
+        /* eslint-disable no-restricted-globals */
         const key = await crypto.subtle.importKey(
           'raw',
           password,
@@ -210,9 +211,10 @@ describe('hd-keyring', () => {
           key,
           keyLength * 8,
         );
+        /* eslint-enable no-restricted-globals */
 
         return new Uint8Array(derivedBits);
-      }
+      };
 
       const cryptographicFunctions = {
         pbkdf2Sha512: jest.fn().mockImplementation(pbkdf2Sha512),

--- a/packages/keyring-eth-hd/test/index.js
+++ b/packages/keyring-eth-hd/test/index.js
@@ -18,6 +18,7 @@ import {
   encrypt,
 } from '@metamask/eth-sig-util';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
+import { webcrypto } from 'crypto';
 import { keccak256 } from 'ethereum-cryptography/keccak';
 
 import HdKeyring from '../src';
@@ -192,8 +193,7 @@ describe('hd-keyring', () => {
 
     it('deserializes using custom cryptography', async () => {
       const pbkdf2Sha512 = async (password, salt, iterations, keyLength) => {
-        /* eslint-disable no-restricted-globals */
-        const key = await crypto.subtle.importKey(
+        const key = await webcrypto.subtle.importKey(
           'raw',
           password,
           { name: 'PBKDF2' },
@@ -201,7 +201,7 @@ describe('hd-keyring', () => {
           ['deriveBits'],
         );
 
-        const derivedBits = await crypto.subtle.deriveBits(
+        const derivedBits = await webcrypto.subtle.deriveBits(
           {
             name: 'PBKDF2',
             salt,
@@ -211,7 +211,6 @@ describe('hd-keyring', () => {
           key,
           keyLength * 8,
         );
-        /* eslint-enable no-restricted-globals */
 
         return new Uint8Array(derivedBits);
       };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,6 +1875,7 @@ __metadata:
     "@metamask/bip39": "npm:^4.0.0"
     "@metamask/eth-hd-keyring": "npm:4.0.1"
     "@metamask/eth-sig-util": "npm:^8.0.0"
+    "@metamask/key-tree": "npm:^9.1.2"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/utils": "npm:^9.2.1"
     "@ts-bridge/cli": "npm:^0.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,7 +1875,7 @@ __metadata:
     "@metamask/bip39": "npm:^4.0.0"
     "@metamask/eth-hd-keyring": "npm:4.0.1"
     "@metamask/eth-sig-util": "npm:^8.0.0"
-    "@metamask/key-tree": "npm:^9.1.2"
+    "@metamask/key-tree": "npm:^10.0.0"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/utils": "npm:^9.2.1"
     "@ts-bridge/cli": "npm:^0.6.0"
@@ -2099,6 +2099,19 @@ __metadata:
     "@metamask/utils": "npm:^9.1.0"
     readable-stream: "npm:^3.6.2"
   checksum: 10/93c842e1ac8e624c65d888cb3539b38ade5b8415ea45f649d78dad91e7139f11fa96bbf89136998d21def7711b3f710939f8e4498ce31a6cf461892e3f4ba176
+  languageName: node
+  linkType: hard
+
+"@metamask/key-tree@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "@metamask/key-tree@npm:10.0.0"
+  dependencies:
+    "@metamask/scure-bip39": "npm:^2.1.1"
+    "@metamask/utils": "npm:^10.0.1"
+    "@noble/curves": "npm:^1.2.0"
+    "@noble/hashes": "npm:^1.3.2"
+    "@scure/base": "npm:^1.0.0"
+  checksum: 10/a9f1b3d28e41b84ab11a811abb3e0809b4919da642778136c3a9f67b035961920ee31546e7fcb452da2e0781c15fa2427da9de353e99bc83f56da10a2d35d0d3
   languageName: node
   linkType: hard
 
@@ -2412,6 +2425,23 @@ __metadata:
   version: 3.1.0
   resolution: "@metamask/superstruct@npm:3.1.0"
   checksum: 10/5066fe228d5f11da387606d7f9545de2b473ab5a9e0f1bb8aea2f52d3e2c9d25e427151acde61f4a2de80a07a9871fe9505ad06abca6a61b7c3b54ed5c403b01
+  languageName: node
+  linkType: hard
+
+"@metamask/utils@npm:^10.0.1":
+  version: 10.0.1
+  resolution: "@metamask/utils@npm:10.0.1"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@noble/hashes": "npm:^1.3.1"
+    "@scure/base": "npm:^1.1.3"
+    "@types/debug": "npm:^4.1.7"
+    debug: "npm:^4.3.4"
+    pony-cause: "npm:^2.1.10"
+    semver: "npm:^7.5.4"
+    uuid: "npm:^9.0.1"
+  checksum: 10/c8e3d7578d05a1da4abb6c6712ec78ef6990801269f6529f4bb237b7d6e228d10a40738ccab81ad554f2fd51670267d086dc5be1a31c6d1f7040d4c0469d9d13
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

Uses the latest version of `@metamask/keytree`, which allows passing `cryptographicFunctions` for derivation of the mnemonic seed. Also reintroduces constructor arguments to allow passing of `cryptographicFunctions` to `HdKeyring`.

Follow-up PR to https://github.com/MetaMask/accounts/pull/100
