### PR TITLE
build: use `ts-bridge/cli@0.6.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@metamask/eslint-config-nodejs": "^13.0.0",
     "@metamask/eslint-config-typescript": "^13.0.0",
     "@npmcli/package-json": "^5.0.0",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "@typescript-eslint/eslint-plugin": "^8.5.0",

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -56,7 +56,7 @@
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-utils": "workspace:^",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "@types/webextension-polyfill": "^0.12.1",

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -58,7 +58,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/bip39": "^4.0.0",
     "@metamask/eth-hd-keyring": "4.0.1",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "deepmerge": "^4.2.2",
     "jest": "^29.5.0"

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -63,7 +63,7 @@
     "@ledgerhq/types-devices": "^6.25.3",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/utils": "^9.3.0",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/hdkey": "^2.0.1",
     "@types/jest": "^29.5.12",

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -55,7 +55,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -60,7 +60,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/hdkey": "^2.0.1",
     "@types/jest": "^29.5.12",

--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -54,7 +54,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -53,7 +53,7 @@
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/providers": "^18.1.0",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -58,7 +58,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/providers": "^18.1.0",
     "@metamask/utils": "^9.3.0",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-snap-internal-client/package.json
+++ b/packages/keyring-snap-internal-client/package.json
@@ -62,7 +62,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/providers": "^18.1.0",
     "@metamask/utils": "^9.3.0",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -56,7 +56,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^18.1.0",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-utils/package.json
+++ b/packages/keyring-utils/package.json
@@ -52,7 +52,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@ts-bridge/cli": "^0.6.0",
+    "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1648,7 +1648,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^13.0.0"
     "@metamask/eslint-config-typescript": "npm:^13.0.0"
     "@npmcli/package-json": "npm:^5.0.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@typescript-eslint/eslint-plugin": "npm:^8.5.0"
@@ -1878,7 +1878,7 @@ __metadata:
     "@metamask/key-tree": "npm:^10.0.0"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     deepmerge: "npm:^4.2.2"
     ethereum-cryptography: "npm:^2.1.2"
@@ -1903,7 +1903,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.0.0"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/ethereumjs-tx": "npm:^1.0.1"
     "@types/hdkey": "npm:^2.0.1"
     "@types/jest": "npm:^29.5.12"
@@ -1970,7 +1970,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.0.0"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/ethereumjs-tx": "npm:^1.0.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
@@ -2006,7 +2006,7 @@ __metadata:
     "@metamask/snaps-utils": "npm:^8.3.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/uuid": "npm:^9.0.8"
@@ -2038,7 +2038,7 @@ __metadata:
     "@metamask/eth-sig-util": "npm:^8.0.0"
     "@trezor/connect-plugin-ethereum": "npm:^9.0.3"
     "@trezor/connect-web": "npm:^9.1.11"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/ethereumjs-tx": "npm:^1.0.1"
     "@types/hdkey": "npm:^2.0.1"
     "@types/jest": "npm:^29.5.12"
@@ -2143,7 +2143,7 @@ __metadata:
     "@metamask/keyring-utils": "workspace:^"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/webextension-polyfill": "npm:^0.12.1"
@@ -2171,7 +2171,7 @@ __metadata:
     "@metamask/keyring-utils": "workspace:^"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     deepmerge: "npm:^4.2.2"
@@ -2199,7 +2199,7 @@ __metadata:
     "@metamask/providers": "npm:^18.1.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/uuid": "npm:^9.0.8"
@@ -2236,7 +2236,7 @@ __metadata:
     "@metamask/snaps-utils": "npm:^8.3.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/uuid": "npm:^9.0.8"
@@ -2270,7 +2270,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^6.7.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     deepmerge: "npm:^4.2.2"
@@ -2297,7 +2297,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^9.3.0"
-    "@ts-bridge/cli": "npm:^0.6.0"
+    "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     deepmerge: "npm:^4.2.2"
@@ -3277,9 +3277,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ts-bridge/cli@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@ts-bridge/cli@npm:0.6.0"
+"@ts-bridge/cli@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@ts-bridge/cli@npm:0.6.1"
   dependencies:
     "@ts-bridge/resolver": "npm:^0.2.0"
     chalk: "npm:^5.3.0"
@@ -3290,7 +3290,7 @@ __metadata:
   bin:
     ts-bridge: ./dist/index.js
     tsbridge: ./dist/index.js
-  checksum: 10/a23da563b99c56124538fbaf77a2d7a0ad01c898c86ab3be527e3dbe0b22f380daa9207bfeffd8591508ed878959ba168daf6197e06822ba8a3b62dfd7396dab
+  checksum: 10/1cbb8fbfc7f58b804553ab9bc06b689b409d4cdd0f1e960a0ea87971ec7885b5ee2a86cb192d955c7d3611afcadb960e7dfee66aeca60f798a70e7f97aa969c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This new version fixes a bug with CJS reexports.

See this [changelog](https://github.com/ts-bridge/ts-bridge/blob/main/packages/cli/CHANGELOG.md#061) for more details.