### PR TITLE
fix: missing references in some tsconfig.json

### DIFF
--- a/packages/keyring-api/tsconfig.json
+++ b/packages/keyring-api/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
+  "references": [{ "path": "../keyring-utils/tsconfig.build.json" }],
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }

--- a/packages/keyring-snap-bridge/tsconfig.json
+++ b/packages/keyring-snap-bridge/tsconfig.json
@@ -6,6 +6,11 @@
     "moduleResolution": "Node16",
     "target": "es2020"
   },
+  "references": [
+    { "path": "../keyring-api/tsconfig.build.json" },
+    { "path": "../keyring-internal-api/tsconfig.build.json" },
+    { "path": "../keyring-snap-internal-client/tsconfig.build.json" }
+  ],
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }

--- a/packages/keyring-snap-client/tsconfig.json
+++ b/packages/keyring-snap-client/tsconfig.json
@@ -3,6 +3,14 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
+  "references": [
+    {
+      "path": "../keyring-api/tsconfig.build.json"
+    },
+    {
+      "path": "../keyring-utils/tsconfig.build.json"
+    }
+  ],
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }

--- a/packages/keyring-snap-internal-client/tsconfig.json
+++ b/packages/keyring-snap-internal-client/tsconfig.json
@@ -3,6 +3,14 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
+  "references": [
+    {
+      "path": "../keyring-api/tsconfig.build.json"
+    },
+    {
+      "path": "../keyring-snap-client/tsconfig.build.json"
+    }
+  ],
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }

--- a/packages/keyring-snap-sdk/tsconfig.json
+++ b/packages/keyring-snap-sdk/tsconfig.json
@@ -3,6 +3,11 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
+  "references": [
+    {
+      "path": "../keyring-api/tsconfig.build.json"
+    }
+  ],
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }


### PR DESCRIPTION
Some `tsconfig.json` are not aligned with their `tsconfig.build.json`. This might cause some dev tools (that rely on `tsconfig.json` only) to not work as expected.