### PR TITLE
Revert "release: 15.0.0 (#123)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/accounts-monorepo",
-  "version": "15.0.0",
+  "version": "14.0.0",
   "private": true,
   "description": "Monorepo for MetaMask accounts related packages",
   "repository": {

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.0.0]
-
-### Changed
-
-- **BREAKING:** Enable Ledger clear signing ([#99](https://github.com/MetaMask/accounts/pull/99))
-  - The `LedgerSignTypedDataParams` type now requires a new `message` field which replaces the `domainSeparatorHex` and `hashStructMessage}Hex` fields.
-
 ## [7.0.0]
 
 ### Added
@@ -223,8 +216,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support new versions of ethereumjs/tx ([#68](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/68))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@8.0.0...HEAD
-[8.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@7.0.0...@metamask/eth-ledger-bridge-keyring@8.0.0
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@7.0.0...HEAD
 [7.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@6.0.0...@metamask/eth-ledger-bridge-keyring@7.0.0
 [6.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@5.0.1...@metamask/eth-ledger-bridge-keyring@6.0.0
 [5.0.1]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@5.0.0...@metamask/eth-ledger-bridge-keyring@5.0.1

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-ledger-bridge-keyring",
-  "version": "8.0.0",
+  "version": "7.0.0",
   "description": "A MetaMask compatible keyring, for ledger hardware wallets",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
This reverts commit 2c86434f6ef4e4b700540e6aa6d3a52ba17d5321.

---

This release could not get through because our new packages (resulting from the split of the `keyring-api`) are not yet published on `npm` and the release scripts uses them during the release process.

To remove them from the list of packages, we should use a version of `0.0.0`, see:
- https://github.com/MetaMask/action-publish-release/blob/main/scripts/get-release-packages.sh#L43