### PR TITLE
fix: fix version for new packages `0.0.1` -> `0.0.0`

### DIFF
--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-internal-api",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "MetaMask Keyring Internal API",
   "keywords": [
     "metamask",

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-snap-client",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "MetaMask Keyring Snap clients",
   "keywords": [
     "metamask",

--- a/packages/keyring-snap-internal-client/package.json
+++ b/packages/keyring-snap-internal-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-snap-internal-client",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "MetaMask Keyring Snap internal clients",
   "keywords": [
     "metamask",

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-snap-sdk",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "MetaMask Keyring Snap SDK",
   "keywords": [
     "metamask",

--- a/packages/keyring-utils/package.json
+++ b/packages/keyring-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-utils",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "MetaMask Keyring utils",
   "keywords": [
     "metamask",


### PR DESCRIPTION
Those packages are not released/published yet. To avoid considering those packages during the release process, we have to use the `0.0.0` version, see:
- #123 