### PR TITLE
refactor: move deps to devDeps for types + use peerDep for keyring-api

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -9,6 +9,8 @@ ignores:
   - 'tsd'
   # Ignore dependencies imported implicitly by TypeScript
   - '@types/*'
+  # Ignore peer dependencies that appears unused, but are required
+  - 'webextension-polyfill'
   # Ignore tools (packages which we use as executables and not libraries)
   - 'rimraf'
   - '@lavamoat/allow-scripts'

--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -9,8 +9,6 @@ ignores:
   - 'tsd'
   # Ignore dependencies imported implicitly by TypeScript
   - '@types/*'
-  # Ignore peer dependencies that appears unused, but are required
-  - 'webextension-polyfill'
   # Ignore tools (packages which we use as executables and not libraries)
   - 'rimraf'
   - '@lavamoat/allow-scripts'

--- a/.syncpackrc
+++ b/.syncpackrc
@@ -23,7 +23,7 @@
     },
     {
       "label": "use workspace version of the keyring-api",
-      "dependencyTypes": ["!local"],
+      "dependencyTypes": ["!peer", "!local"],
       "dependencies": ["@metamask/keyring-api"],
       "pinVersion": "workspace:^"
     },
@@ -57,5 +57,12 @@
       "dependencies": ["@metamask/keyring-utils"],
       "pinVersion": "workspace:^"
     },
+    {
+      "label": "use same range than @metamask/providers for webextension-polyfill",
+      "packages": ["**"],
+      "dependencyTypes": ["peer"],
+      "dependencies": ["webextension-polyfill"],
+      "range": "^0.10.0 || ^0.11.0 || ^0.12.0"
+    }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -46,17 +46,17 @@ linkStyle default opacity:0.5
   keyring_snap_sdk(["@metamask/keyring-snap-sdk"]);
   keyring_utils(["@metamask/keyring-utils"]);
   keyring_api --> keyring_utils;
-  keyring_internal_api --> keyring_api;
   keyring_internal_api --> keyring_utils;
-  keyring_internal_snap_client --> keyring_api;
+  keyring_internal_api --> keyring_api;
   keyring_internal_snap_client --> keyring_snap_client;
   keyring_internal_snap_client --> keyring_utils;
-  eth_snap_keyring --> keyring_api;
+  keyring_internal_snap_client --> keyring_api;
   eth_snap_keyring --> keyring_internal_api;
   eth_snap_keyring --> keyring_internal_snap_client;
   eth_snap_keyring --> keyring_utils;
-  keyring_snap_client --> keyring_api;
+  eth_snap_keyring --> keyring_api;
   keyring_snap_client --> keyring_utils;
+  keyring_snap_client --> keyring_api;
   keyring_snap_sdk --> keyring_utils;
   keyring_snap_sdk --> keyring_api;
 ```

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -59,7 +59,6 @@
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
-    "@types/webextension-polyfill": "^0.12.1",
     "deepmerge": "^4.2.2",
     "depcheck": "^1.4.7",
     "jest": "^29.5.0",

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -61,7 +61,8 @@
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "deepmerge": "^4.2.2",
-    "jest": "^29.5.0"
+    "jest": "^29.5.0",
+    "typescript": "~5.6.3"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -52,8 +52,7 @@
     "@metamask/eth-sig-util": "^8.1.2",
     "@trezor/connect-plugin-ethereum": "^9.0.3",
     "@trezor/connect-web": "^9.1.11",
-    "hdkey": "^2.1.0",
-    "tslib": "^2.6.2"
+    "hdkey": "^2.1.0"
   },
   "devDependencies": {
     "@ethereumjs/common": "^3.2.0",
@@ -76,8 +75,12 @@
     "sinon": "^19.0.2",
     "ts-jest": "^29.0.5",
     "ts-node": "^10.9.2",
+    "tslib": "^2.6.2",
     "typedoc": "^0.25.13",
     "typescript": "~5.6.3"
+  },
+  "peerDependencies": {
+    "tslib": "^2.6.2"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -45,7 +45,6 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-utils": "workspace:^",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.0.1"
@@ -54,6 +53,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/keyring-api": "workspace:^",
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
@@ -67,6 +67,9 @@
     "tsd": "^0.31.0",
     "typedoc": "^0.25.13",
     "typescript": "~5.6.3"
+  },
+  "peerDependencies": {
+    "@metamask/keyring-api": "workspace:^"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -69,7 +69,7 @@
     "typescript": "~5.6.3"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": "^13.0.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-internal-snap-client/package.json
+++ b/packages/keyring-internal-snap-client/package.json
@@ -46,7 +46,10 @@
   },
   "dependencies": {
     "@metamask/keyring-snap-client": "workspace:^",
-    "@metamask/keyring-utils": "workspace:^"
+    "@metamask/keyring-utils": "workspace:^",
+    "@metamask/snaps-controllers": "^9.10.0",
+    "@metamask/snaps-sdk": "^6.7.0",
+    "@metamask/snaps-utils": "^8.3.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",
@@ -54,9 +57,6 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^18.3.1",
-    "@metamask/snaps-controllers": "^9.10.0",
-    "@metamask/snaps-sdk": "^6.7.0",
-    "@metamask/snaps-utils": "^8.3.0",
     "@metamask/utils": "^11.0.1",
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
@@ -72,6 +72,10 @@
     "typedoc": "^0.25.13",
     "typescript": "~5.6.3",
     "webextension-polyfill": "^0.12.0"
+  },
+  "peerDependencies": {
+    "@metamask/providers": "^18.3.1",
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-internal-snap-client/package.json
+++ b/packages/keyring-internal-snap-client/package.json
@@ -45,19 +45,18 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-snap-client": "workspace:^",
-    "@metamask/keyring-utils": "workspace:^",
-    "@metamask/snaps-controllers": "^9.10.0",
-    "@metamask/snaps-sdk": "^6.7.0",
-    "@metamask/snaps-utils": "^8.3.0",
-    "webextension-polyfill": "^0.12.0"
+    "@metamask/keyring-utils": "workspace:^"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^18.3.1",
+    "@metamask/snaps-controllers": "^9.10.0",
+    "@metamask/snaps-sdk": "^6.7.0",
+    "@metamask/snaps-utils": "^8.3.0",
     "@metamask/utils": "^11.0.1",
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
@@ -71,10 +70,8 @@
     "ts-node": "^10.9.2",
     "tsd": "^0.31.0",
     "typedoc": "^0.25.13",
-    "typescript": "~5.6.3"
-  },
-  "peerDependencies": {
-    "@metamask/providers": "^18.3.1"
+    "typescript": "~5.6.3",
+    "webextension-polyfill": "^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -42,6 +42,9 @@
     "@metamask/keyring-internal-api": "workspace:^",
     "@metamask/keyring-internal-snap-client": "workspace:^",
     "@metamask/keyring-utils": "workspace:^",
+    "@metamask/snaps-controllers": "^9.10.0",
+    "@metamask/snaps-sdk": "^6.7.0",
+    "@metamask/snaps-utils": "^8.3.0",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.0.1",
     "uuid": "^9.0.1"
@@ -49,9 +52,6 @@
   "devDependencies": {
     "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^18.3.1",
-    "@metamask/snaps-controllers": "^9.10.0",
-    "@metamask/snaps-sdk": "^6.7.0",
-    "@metamask/snaps-utils": "^8.3.0",
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
@@ -68,7 +68,9 @@
     "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": "workspace:^",
+    "@metamask/providers": "^18.3.1",
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -68,7 +68,7 @@
     "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "workspace:^",
+    "@metamask/keyring-api": "^13.0.0",
     "@metamask/providers": "^18.3.1",
     "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   },

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -39,27 +39,23 @@
   "dependencies": {
     "@ethereumjs/tx": "^4.2.0",
     "@metamask/eth-sig-util": "^8.1.2",
-    "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-internal-api": "workspace:^",
     "@metamask/keyring-internal-snap-client": "workspace:^",
     "@metamask/keyring-utils": "workspace:^",
+    "@metamask/superstruct": "^3.1.0",
+    "@metamask/utils": "^11.0.1",
+    "uuid": "^9.0.1"
+  },
+  "devDependencies": {
+    "@metamask/keyring-api": "workspace:^",
+    "@metamask/providers": "^18.3.1",
     "@metamask/snaps-controllers": "^9.10.0",
     "@metamask/snaps-sdk": "^6.7.0",
     "@metamask/snaps-utils": "^8.3.0",
-    "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.0.1",
-    "@types/uuid": "^9.0.8",
-    "uuid": "^9.0.1",
-    "webextension-polyfill": "^0.12.0"
-  },
-  "devDependencies": {
-    "@lavamoat/allow-scripts": "^3.2.1",
-    "@lavamoat/preinstall-always-fail": "^2.1.0",
-    "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/providers": "^18.3.1",
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
+    "@types/uuid": "^9.0.8",
     "deepmerge": "^4.2.2",
     "depcheck": "^1.4.7",
     "jest": "^29.5.0",
@@ -68,11 +64,11 @@
     "ts-node": "^10.9.2",
     "tsd": "^0.31.0",
     "typedoc": "^0.25.13",
-    "typescript": "~5.6.3"
+    "typescript": "~5.6.3",
+    "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "workspace:^",
-    "@metamask/providers": "^18.3.1"
+    "@metamask/keyring-api": "workspace:^"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -50,6 +50,7 @@
     "uuid": "^9.0.1"
   },
   "devDependencies": {
+    "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^18.3.1",
     "@ts-bridge/cli": "^0.6.1",

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -29,7 +29,7 @@ import { KeyringSnapControllerClient } from '@metamask/keyring-internal-snap-cli
 import { strictMask } from '@metamask/keyring-utils';
 import type { SnapController } from '@metamask/snaps-controllers';
 import type { SnapId } from '@metamask/snaps-sdk';
-import { type Snap } from '@metamask/snaps-utils';
+import type { Snap } from '@metamask/snaps-utils';
 import { assert, mask, object, string } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
 import {

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -71,7 +71,8 @@
     "typescript": "~5.6.3"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "^13.0.0"
+    "@metamask/keyring-api": "^13.0.0",
+    "@metamask/providers": "^18.3.1"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -45,22 +45,20 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-utils": "workspace:^",
     "@metamask/superstruct": "^3.1.0",
-    "@types/uuid": "^9.0.8",
-    "uuid": "^9.0.1",
-    "webextension-polyfill": "^0.12.0"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/providers": "^18.3.1",
+    "@metamask/keyring-api": "workspace:^",
     "@metamask/utils": "^11.0.1",
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
+    "@types/uuid": "^9.0.8",
     "deepmerge": "^4.2.2",
     "depcheck": "^1.4.7",
     "jest": "^29.5.0",
@@ -73,7 +71,7 @@
     "typescript": "~5.6.3"
   },
   "peerDependencies": {
-    "@metamask/providers": "^18.3.1"
+    "@metamask/keyring-api": "workspace:^"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -71,7 +71,7 @@
     "typescript": "~5.6.3"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": "^13.0.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@metamask/keyring-utils": "workspace:^",
+    "@metamask/snaps-sdk": "^6.7.0",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.0.1"
   },
@@ -55,7 +56,6 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^18.3.1",
-    "@metamask/snaps-sdk": "^6.7.0",
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
@@ -72,7 +72,9 @@
     "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": "workspace:^",
+    "@metamask/providers": "^18.3.1",
+    "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -72,7 +72,7 @@
     "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "workspace:^",
+    "@metamask/keyring-api": "^13.0.0",
     "@metamask/providers": "^18.3.1",
     "webextension-polyfill": "^0.10.0 || ^0.11.0 || ^0.12.0"
   },

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -46,10 +46,8 @@
   },
   "dependencies": {
     "@metamask/keyring-utils": "workspace:^",
-    "@metamask/snaps-sdk": "^6.7.0",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.0.1",
-    "webextension-polyfill": "^0.12.0"
+    "@metamask/utils": "^11.0.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",
@@ -57,6 +55,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^18.3.1",
+    "@metamask/snaps-sdk": "^6.7.0",
     "@ts-bridge/cli": "^0.6.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
@@ -69,10 +68,11 @@
     "ts-node": "^10.9.2",
     "tsd": "^0.31.0",
     "typedoc": "^0.25.13",
-    "typescript": "~5.6.3"
+    "typescript": "~5.6.3",
+    "webextension-polyfill": "^0.12.0"
   },
   "peerDependencies": {
-    "@metamask/providers": "^18.3.1"
+    "@metamask/keyring-api": "workspace:^"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1883,6 +1883,7 @@ __metadata:
     deepmerge: "npm:^4.2.2"
     ethereum-cryptography: "npm:^2.1.2"
     jest: "npm:^29.5.0"
+    typescript: "npm:~5.6.3"
   languageName: unknown
   linkType: soft
 
@@ -1994,9 +1995,6 @@ __metadata:
   resolution: "@metamask/eth-snap-keyring@workspace:packages/keyring-snap-bridge"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
-    "@lavamoat/allow-scripts": "npm:^3.2.1"
-    "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
-    "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.1.2"
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-internal-api": "workspace:^"
@@ -2025,7 +2023,6 @@ __metadata:
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/keyring-api": "workspace:^"
-    "@metamask/providers": ^18.3.1
   languageName: unknown
   linkType: soft
 
@@ -2062,6 +2059,8 @@ __metadata:
     tslib: "npm:^2.6.2"
     typedoc: "npm:^0.25.13"
     typescript: "npm:~5.6.3"
+  peerDependencies:
+    tslib: ^2.6.2
   languageName: unknown
   linkType: soft
 
@@ -2150,7 +2149,6 @@ __metadata:
     "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
-    "@types/webextension-polyfill": "npm:^0.12.1"
     bech32: "npm:^2.0.0"
     deepmerge: "npm:^4.2.2"
     depcheck: "npm:^1.4.7"
@@ -2188,6 +2186,8 @@ __metadata:
     tsd: "npm:^0.31.0"
     typedoc: "npm:^0.25.13"
     typescript: "npm:~5.6.3"
+  peerDependencies:
+    "@metamask/keyring-api": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -2220,8 +2220,6 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typescript: "npm:~5.6.3"
     webextension-polyfill: "npm:^0.12.0"
-  peerDependencies:
-    "@metamask/providers": ^18.3.1
   languageName: unknown
   linkType: soft
 
@@ -2234,7 +2232,6 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-utils": "workspace:^"
-    "@metamask/providers": "npm:^18.3.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.0.1"
     "@ts-bridge/cli": "npm:^0.6.1"
@@ -2252,9 +2249,8 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typescript: "npm:~5.6.3"
     uuid: "npm:^9.0.1"
-    webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/providers": ^18.3.1
+    "@metamask/keyring-api": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -2286,7 +2282,7 @@ __metadata:
     typescript: "npm:~5.6.3"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/providers": ^18.3.1
+    "@metamask/keyring-api": "workspace:^"
   languageName: unknown
   linkType: soft
 
@@ -3675,13 +3671,6 @@ __metadata:
   version: 0.0.69
   resolution: "@types/web@npm:0.0.69"
   checksum: 10/676c83e1d367d5f56619ed34c6ba50cccd5c394b5474dddaccb9e7dc7e121f26748d377c248da8a7eee106f87688239dd0027d087e3e09e9918f03b7c6082e92
-  languageName: node
-  linkType: hard
-
-"@types/webextension-polyfill@npm:^0.12.1":
-  version: 0.12.1
-  resolution: "@types/webextension-polyfill@npm:0.12.1"
-  checksum: 10/80c1f81af272d378098474a41e0941bf9375261423ea289cd8250efc9a628cec4fa6083cb9cd5c62ff0f828ac235a044c0b95543c0606e894dfd485cea55b0aa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1995,6 +1995,7 @@ __metadata:
   resolution: "@metamask/eth-snap-keyring@workspace:packages/keyring-snap-bridge"
   dependencies:
     "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.1.2"
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-internal-api": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2023,6 +2023,8 @@ __metadata:
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/keyring-api": "workspace:^"
+    "@metamask/providers": ^18.3.1
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -2220,6 +2222,9 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typescript: "npm:~5.6.3"
     webextension-polyfill: "npm:^0.12.0"
+  peerDependencies:
+    "@metamask/providers": ^18.3.1
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
   linkType: soft
 
@@ -2283,6 +2288,8 @@ __metadata:
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
     "@metamask/keyring-api": "workspace:^"
+    "@metamask/providers": ^18.3.1
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,7 +2022,7 @@ __metadata:
     uuid: "npm:^9.0.1"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": ^13.0.0
     "@metamask/providers": ^18.3.1
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown
@@ -2287,7 +2287,7 @@ __metadata:
     typescript: "npm:~5.6.3"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": ^13.0.0
     "@metamask/providers": ^18.3.1
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,7 +2189,7 @@ __metadata:
     typedoc: "npm:^0.25.13"
     typescript: "npm:~5.6.3"
   peerDependencies:
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": ^13.0.0
   languageName: unknown
   linkType: soft
 
@@ -2255,7 +2255,8 @@ __metadata:
     typescript: "npm:~5.6.3"
     uuid: "npm:^9.0.1"
   peerDependencies:
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": ^13.0.0
+    "@metamask/providers": ^18.3.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Updating some deps to avoid pulling non-needed dependencies in the main dependency tree.

Also, use `@metamask/keyring-api` as a `peerDependencies` for every packages to force using the same API everywhere.