### PR TITLE
Revert "release: 18.0.0 (#135)"

### DIFF
--- a/packages/keyring-internal-api/CHANGELOG.md
+++ b/packages/keyring-internal-api/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
-### Changed
-
-- **BREAKING:** Bump `@metamask/keyring-api` from `^12.0.0` to `^13.0.0` ([#101](https://github.com/MetaMask/accounts/pull/101))
-  - This change was not properly reported as breaking on the `1.1.0`.
-  - `InternalAccount` extends `KeyringAccount` which has a new required field (`scopes`) and is part of the public API.
-
 ## [1.1.0]
 
 ### Changed
@@ -29,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This new version fixes a bug with CJS re-exports.
 - Initial release ([#24](https://github.com/MetaMask/accounts/pull/24))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-api@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-api@1.1.0...@metamask/keyring-internal-api@2.0.0
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-api@1.1.0...HEAD
 [1.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-api@1.0.0...@metamask/keyring-internal-api@1.1.0
 [1.0.0]: https://github.com/MetaMask/accounts/releases/tag/@metamask/keyring-internal-api@1.0.0

--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-internal-api",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "MetaMask Keyring Internal API",
   "keywords": [
     "metamask",

--- a/packages/keyring-internal-snap-client/CHANGELOG.md
+++ b/packages/keyring-internal-snap-client/CHANGELOG.md
@@ -7,17 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
-### Changed
-
-- **BREAKING:** Bump `@metamask/keyring-api` from `^12.0.0` to `^13.0.0` ([#101](https://github.com/MetaMask/accounts/pull/101))
-  - This change was not properly reported as breaking on the `1.1.0`.
-  - `KeyringAccount` has a new required field (`scopes`) and is part of the public API.
-- **BREAKING:** Bump `@metamask/keyring-snap-client` from `^1.0.0` to `^2.0.0` ([#135](https://github.com/MetaMask/accounts/pull/135))
-  - This change was not properly reported as breaking on the `1.1.0`.
-  - `KeyringAccount` has a new required field (`scopes`) and is part of the public API.
-
 ## [1.1.0]
 
 ### Changed
@@ -33,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This new version fixes a bug with CJS re-exports.
 - Initial release ([#24](https://github.com/MetaMask/accounts/pull/24))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@1.1.0...@metamask/keyring-internal-snap-client@2.0.0
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@1.1.0...HEAD
 [1.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@1.0.0...@metamask/keyring-internal-snap-client@1.1.0
 [1.0.0]: https://github.com/MetaMask/accounts/releases/tag/@metamask/keyring-internal-snap-client@1.0.0

--- a/packages/keyring-internal-snap-client/package.json
+++ b/packages/keyring-internal-snap-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-internal-snap-client",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "MetaMask Keyring Snap internal clients",
   "keywords": [
     "metamask",

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,20 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [8.0.0]
-
-### Changed
-
-- **BREAKING:** Bump `@metamask/keyring-api` from `^12.0.0` to `^13.0.0` ([#101](https://github.com/MetaMask/accounts/pull/101))
-  - This change was not properly reported as breaking on the `7.1.0`.
-  - `KeyringAccount` and `InternalAccount` have a new required field (`scopes`) and are part of the public API.
-- **BREAKING:** Bump `@metamask/keyring-internal-api` from `^1.0.0` to `^2.0.0` ([#135](https://github.com/MetaMask/accounts/pull/135))
-  - This change was not properly reported as breaking on the `7.1.0`.
-  - `InternalAccount` extends `KeyringAccount` which has a new required field (`scopes`) and is part of the public API.
-- **BREAKING:** Bump `@metamask/keyring-snap-internal-client` from `^1.0.0` to `^2.0.0` ([#135](https://github.com/MetaMask/accounts/pull/135))
-  - This change was not properly reported as breaking on the `7.1.0`.
-  - `KeyringAccount` has a new required field (`scopes`) and is part of the public API.
-
 ## [7.1.0]
 
 ### Changed
@@ -403,8 +389,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@8.0.0...HEAD
-[8.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@7.1.0...@metamask/eth-snap-keyring@8.0.0
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@7.1.0...HEAD
 [7.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@7.0.0...@metamask/eth-snap-keyring@7.1.0
 [7.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@6.0.0...@metamask/eth-snap-keyring@7.0.0
 [6.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@5.0.1...@metamask/eth-snap-keyring@6.0.0

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-snap-keyring",
-  "version": "8.0.0",
+  "version": "7.1.0",
   "description": "Snaps keyring bridge.",
   "repository": {
     "type": "git",

--- a/packages/keyring-snap-client/CHANGELOG.md
+++ b/packages/keyring-snap-client/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
-### Changed
-
-- **BREAKING:** Bump `@metamask/keyring-api` from `^12.0.0` to `^13.0.0` ([#101](https://github.com/MetaMask/accounts/pull/101))
-  - This change was not properly reported as breaking on the `1.1.0`.
-  - `KeyringAccount` has a new required field (`scopes`) and is part of the public API.
-
 ## [1.1.0]
 
 ### Changed
@@ -29,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This new version fixes a bug with CJS re-exports.
 - Initial release ([#24](https://github.com/MetaMask/accounts/pull/24))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@1.1.0...@metamask/keyring-snap-client@2.0.0
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@1.1.0...HEAD
 [1.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@1.0.0...@metamask/keyring-snap-client@1.1.0
 [1.0.0]: https://github.com/MetaMask/accounts/releases/tag/@metamask/keyring-snap-client@1.0.0

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-snap-client",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "MetaMask Keyring Snap clients",
   "keywords": [
     "metamask",

--- a/packages/keyring-snap-sdk/CHANGELOG.md
+++ b/packages/keyring-snap-sdk/CHANGELOG.md
@@ -7,14 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
-### Changed
-
-- **BREAKING:** Bump `@metamask/keyring-api` from `^12.0.0` to `^13.0.0` ([#101](https://github.com/MetaMask/accounts/pull/101))
-  - This change was not properly reported as breaking on the `1.1.0`.
-  - `KeyringAccount` has a new required field (`scopes`) and is part of the public API.
-
 ## [1.1.0]
 
 ### Changed
@@ -29,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This new version fixes a bug with CJS re-exports.
 - Initial release ([#24](https://github.com/MetaMask/accounts/pull/24))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@2.0.0...HEAD
-[2.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@1.1.0...@metamask/keyring-snap-sdk@2.0.0
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@1.1.0...HEAD
 [1.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@1.0.0...@metamask/keyring-snap-sdk@1.1.0
 [1.0.0]: https://github.com/MetaMask/accounts/releases/tag/@metamask/keyring-snap-sdk@1.0.0

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-snap-sdk",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "description": "MetaMask Keyring Snap SDK",
   "keywords": [
     "metamask",


### PR DESCRIPTION
This reverts commit 680cc4b148118e061a00199386308f1dd526e6a4.

- - -

This release could not get through because I forgot to update the [top-level package.json version](https://github.com/MetaMask/accounts/blob/680cc4b148118e061a00199386308f1dd526e6a4/package.json#L3).