### PR TITLE
fix(keyring-eth-ledger-bridge): fix webpack build about non-exported `EIP712Message` type

### DIFF
--- a/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
@@ -1,6 +1,6 @@
 import type LedgerHwAppEth from '@ledgerhq/hw-app-eth';
 import type Transport from '@ledgerhq/hw-transport';
-import { EIP712Message } from '@ledgerhq/types-live';
+import type { EIP712Message } from '@ledgerhq/types-live';
 
 export type GetPublicKeyParams = { hdPath: string };
 export type GetPublicKeyResponse = Awaited<


### PR DESCRIPTION
Webpack build failed in MM extension complaining `EIP712Message` not found.

This PR will fix the issue.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->
