### PR TITLE
feat(keyring-snap-bridge): add Snap keyring migrations

### DIFF
--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -26,7 +26,7 @@ import { toCaipChainId } from '@metamask/utils';
 import type { KeyringState } from '.';
 import { SnapKeyring } from '.';
 import type { KeyringAccountV1 } from './account';
-import { migrateAccountV1 } from './migrations';
+import { migrateAccountV1, getScopesForAccountV1 } from './migrations';
 
 const regexForUUIDInRequiredSyncErrorMessage =
   /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to snap 'local:snap.mock' is pending and noPending is true/u;
@@ -897,7 +897,6 @@ describe('SnapKeyring', () => {
       btcP2wpkhAccount,
       btcP2wpkhTestnetAccount,
       solDataAccount,
-      unknownAccount,
     ])('migrates accounts v1: %s', async (expectedAccount: KeyringAccount) => {
       // A v1 account has no scopes, so remove it.
       const state = {
@@ -920,13 +919,18 @@ describe('SnapKeyring', () => {
       btcP2wpkhAccount,
       btcP2wpkhTestnetAccount,
       solDataAccount,
-      unknownAccount,
     ])(
       'migrates v2 accounts to v1 accounts is noop: %s',
-      async (expectedAccount: KeyringAccount) => {
+      (expectedAccount: KeyringAccount) => {
         expect(migrateAccountV1(expectedAccount)).toBe(expectedAccount);
       },
     );
+
+    it('unknown v1 accounts scopes defaults to EOA scopes', () => {
+      expect(getScopesForAccountV1(unknownAccount)).toStrictEqual([
+        EthScopes.Namespace,
+      ]);
+    });
   });
 
   describe('async request redirect', () => {

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -409,7 +409,9 @@ export class SnapKeyring extends EventEmitter {
     for (const [snapId, entry] of Object.entries(state.accounts)) {
       // V1 accounts are missing the scopes.
       if (isAccountV1(entry.account)) {
-        log(`Found a KeyringAccountV1, migrating to V2: ${entry.account.id}`);
+        console.info(
+          `SnapKeyring - Found a KeyringAccountV1, migrating to V2: ${entry.account.id}`,
+        );
         accounts[snapId] = {
           ...entry,
           account: migrateAccountV1(entry.account),

--- a/packages/keyring-snap-bridge/src/account.ts
+++ b/packages/keyring-snap-bridge/src/account.ts
@@ -4,9 +4,9 @@ import type { Infer } from '@metamask/superstruct';
 
 /**
  * A `KeyringAccount` with some optional fields which can be used to keep
- * the retro-compatility with older version of keyring events.
+ * the retro-compatility with older version of keyring accounts/events.
  */
-export const KeyringAccountFromEventStruct = object({
+export const KeyringAccountV1Struct = object({
   // Derive from a `KeyringAccount`.
   ...KeyringAccountStruct.schema,
 
@@ -14,6 +14,4 @@ export const KeyringAccountFromEventStruct = object({
   scopes: exactOptional(KeyringAccountStruct.schema.scopes),
 });
 
-export type KeyringAccountFromEvent = Infer<
-  typeof KeyringAccountFromEventStruct
->;
+export type KeyringAccountV1 = Infer<typeof KeyringAccountV1Struct>;

--- a/packages/keyring-snap-bridge/src/account.ts
+++ b/packages/keyring-snap-bridge/src/account.ts
@@ -1,17 +1,10 @@
 import { KeyringAccountStruct } from '@metamask/keyring-api';
-import { object, exactOptional } from '@metamask/keyring-utils';
-import type { Infer } from '@metamask/superstruct';
+import { omit, type Infer } from '@metamask/superstruct';
 
 /**
  * A `KeyringAccount` with some optional fields which can be used to keep
  * the retro-compatility with older version of keyring accounts/events.
  */
-export const KeyringAccountV1Struct = object({
-  // Derive from a `KeyringAccount`.
-  ...KeyringAccountStruct.schema,
-
-  // This has been introduced since: @metamask/keyring-api@>11
-  scopes: exactOptional(KeyringAccountStruct.schema.scopes),
-});
+export const KeyringAccountV1Struct = omit(KeyringAccountStruct, ['scopes']);
 
 export type KeyringAccountV1 = Infer<typeof KeyringAccountV1Struct>;

--- a/packages/keyring-snap-bridge/src/events.ts
+++ b/packages/keyring-snap-bridge/src/events.ts
@@ -7,14 +7,14 @@ import {
 } from '@metamask/keyring-api';
 import { object } from '@metamask/keyring-utils';
 
-import { KeyringAccountFromEventStruct } from './account';
+import { KeyringAccountV1Struct } from './account';
 
 export const AccountCreatedEventStruct = object({
   ...OriginalAccountCreatedEventStruct.schema,
 
   params: object({
     ...OriginalAccountCreatedEventStruct.schema.params.schema,
-    account: KeyringAccountFromEventStruct,
+    account: KeyringAccountV1Struct,
   }),
 });
 
@@ -23,7 +23,7 @@ export const AccountUpdatedEventStruct = object({
 
   params: object({
     ...OriginalAccountUpdatedEventStruct.schema.params.schema,
-    account: KeyringAccountFromEventStruct,
+    account: KeyringAccountV1Struct,
   }),
 });
 

--- a/packages/keyring-snap-bridge/src/events.ts
+++ b/packages/keyring-snap-bridge/src/events.ts
@@ -4,8 +4,10 @@ import {
   AccountDeletedEventStruct,
   RequestApprovedEventStruct,
   RequestRejectedEventStruct,
+  KeyringAccountStruct,
 } from '@metamask/keyring-api';
 import { object } from '@metamask/keyring-utils';
+import { union } from '@metamask/superstruct';
 
 import { KeyringAccountV1Struct } from './account';
 
@@ -14,7 +16,7 @@ export const AccountCreatedEventStruct = object({
 
   params: object({
     ...OriginalAccountCreatedEventStruct.schema.params.schema,
-    account: KeyringAccountV1Struct,
+    account: union([KeyringAccountV1Struct, KeyringAccountStruct]),
   }),
 });
 
@@ -23,7 +25,7 @@ export const AccountUpdatedEventStruct = object({
 
   params: object({
     ...OriginalAccountUpdatedEventStruct.schema.params.schema,
-    account: KeyringAccountV1Struct,
+    account: union([KeyringAccountV1Struct, KeyringAccountStruct]),
   }),
 });
 

--- a/packages/keyring-snap-bridge/src/migrations/index.ts
+++ b/packages/keyring-snap-bridge/src/migrations/index.ts
@@ -1,0 +1,1 @@
+export * from './v1';

--- a/packages/keyring-snap-bridge/src/migrations/v1.ts
+++ b/packages/keyring-snap-bridge/src/migrations/v1.ts
@@ -1,0 +1,125 @@
+import {
+  BtcAccountType,
+  BtcScopes,
+  EthAccountType,
+  EthScopes,
+  SolAccountType,
+  SolScopes,
+  type KeyringAccount,
+} from '@metamask/keyring-api';
+import { isBtcMainnetAddress } from '@metamask/keyring-utils';
+
+import type { KeyringAccountV1 } from '../account';
+
+/**
+ * Checks if an account is an `KeyringAccount` v1.
+ *
+ * @param account - The account to check.
+ * @returns True if the account is v1, false otherwise.
+ */
+export function isAccountV1(
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+  account: KeyringAccountV1 | KeyringAccount,
+): boolean {
+  const { scopes } = account;
+
+  // If we don't have a `scopes` field, then we are not compatible with a normal `KeyringAccount`.
+  return scopes === undefined;
+}
+
+/**
+ * Transform an account v1. This account might have optional fields that are now required by
+ * the Keyring API. This function will automatically provides the missing fields with some
+ * default values.
+ *
+ * @param accountV1 - The account (coming from keyring events) to transform.
+ * @throws An error if the v1 account cannot be transformed.
+ * @returns A valid KeyringAccount.
+ */
+export function transformAccountV1(
+  accountV1: KeyringAccountV1,
+): KeyringAccount {
+  const { type } = accountV1;
+
+  if (!isAccountV1(accountV1)) {
+    // Nothing to do in this case.
+    return accountV1 as KeyringAccount;
+  }
+
+  if (type === EthAccountType.Eoa) {
+    // EVM EOA account are compatible with any EVM networks, and we use CAIP-2
+    // namespaces when the scope relates to ALL chains (from that namespace).
+    return {
+      ...accountV1,
+      scopes: [EthScopes.Namespace],
+    };
+  }
+
+  // For all non-EVM Snaps and ERC4337 Snaps, the scopes is required.
+  throw new Error(
+    `Account scopes is required for non-EVM and ERC4337 accounts`,
+  );
+}
+
+/**
+ * Migrate an account v1. This account might have optional fields that are now required by
+ * the Keyring API. This function will automatically provides the missing fields with some
+ * meaningful default values.
+ *
+ * @param accountV1 - The account to migrate.
+ * @returns A valid KeyringAccount.
+ */
+export function migrateAccountV1(accountV1: KeyringAccountV1): KeyringAccount {
+  const { type } = accountV1;
+
+  if (!isAccountV1(accountV1)) {
+    // Nothing to do in this case.
+    return accountV1 as KeyringAccount;
+  }
+
+  switch (type) {
+    case EthAccountType.Eoa: {
+      // EVM EOA account are compatible with any EVM networks, and we use CAIP-2
+      // namespaces when the scope relates to ALL chains (from that namespace).
+      return {
+        ...accountV1,
+        scopes: [EthScopes.Namespace],
+      };
+    }
+    case EthAccountType.Erc4337: {
+      // EVM Erc4337 account
+      // NOTE: A Smart Contract account might not be compatible with every chain, but we still use
+      // "generic" scope for now. Also, there's no official Snap as of today that uses this account type. So
+      // this case should never happen.
+      return {
+        ...accountV1,
+        scopes: [EthScopes.Namespace],
+      };
+    }
+    case BtcAccountType.P2wpkh: {
+      // Bitcoin uses different accounts for testnet and mainnet
+      return {
+        ...accountV1,
+        scopes: [
+          isBtcMainnetAddress(accountV1.address)
+            ? BtcScopes.Mainnet
+            : BtcScopes.Testnet,
+        ],
+      };
+    }
+    case SolAccountType.DataAccount: {
+      // Solana account supports multiple chains.
+      return {
+        ...accountV1,
+        scopes: [SolScopes.Mainnet, SolScopes.Testnet, SolScopes.Devnet],
+      };
+    }
+    default:
+      // For now, if none of the account's type matches and that we have no scopes, then
+      // we will consider this account as an EOA accounts.
+      return {
+        ...accountV1,
+        scopes: [EthScopes.Namespace],
+      };
+  }
+}

--- a/packages/keyring-utils/package.json
+++ b/packages/keyring-utils/package.json
@@ -46,7 +46,8 @@
   },
   "dependencies": {
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.0.1"
+    "@metamask/utils": "^11.0.1",
+    "bitcoin-address-validation": "^2.2.3"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",

--- a/packages/keyring-utils/src/btc/address.test.ts
+++ b/packages/keyring-utils/src/btc/address.test.ts
@@ -1,0 +1,54 @@
+import { isBtcMainnetAddress, isBtcTestnetAddress } from './address';
+
+const BTC_MAINNET_ADDRESSES = [
+  // P2WPKH
+  'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
+  // P2PKH
+  '1P5ZEDWTKTFGxQjZphgWPQUpe554WKDfHQ',
+];
+
+const BTC_TESTNET_ADDRESSES = [
+  // P2WPKH
+  'tb1q6rmsq3vlfdhjdhtkxlqtuhhlr6pmj09y6w43g8',
+];
+
+const ETH_ADDRESSES = ['0x6431726EEE67570BF6f0Cf892aE0a3988F03903F'];
+
+const SOL_ADDRESSES = [
+  '7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV',
+  'DpNXPNWvWoHaZ9P3WtfGCb2ZdLihW8VW1w1Ph4KDH9iG',
+];
+
+describe('address', () => {
+  describe('isBtcMainnetAddress', () => {
+    it.each(BTC_MAINNET_ADDRESSES)(
+      'returns true if address is compatible with BTC mainnet: %s',
+      (address: string) => {
+        expect(isBtcMainnetAddress(address)).toBe(true);
+      },
+    );
+
+    it.each([...BTC_TESTNET_ADDRESSES, ...ETH_ADDRESSES, ...SOL_ADDRESSES])(
+      'returns false if address is not compatible with BTC mainnet: %s',
+      (address: string) => {
+        expect(isBtcMainnetAddress(address)).toBe(false);
+      },
+    );
+  });
+
+  describe('isBtcTestnetAddress', () => {
+    it.each(BTC_TESTNET_ADDRESSES)(
+      'returns true if address is compatible with BTC testnet: %s',
+      (address: string) => {
+        expect(isBtcTestnetAddress(address)).toBe(true);
+      },
+    );
+
+    it.each([...BTC_MAINNET_ADDRESSES, ...ETH_ADDRESSES, ...SOL_ADDRESSES])(
+      'returns false if address is compatible with BTC testnet: %s',
+      (address: string) => {
+        expect(isBtcTestnetAddress(address)).toBe(false);
+      },
+    );
+  });
+});

--- a/packages/keyring-utils/src/btc/address.ts
+++ b/packages/keyring-utils/src/btc/address.ts
@@ -1,0 +1,21 @@
+import { validate, Network } from 'bitcoin-address-validation';
+
+/**
+ * Returns whether an address is on the Bitcoin mainnet.
+ *
+ * @param address - The address to check.
+ * @returns `true` if the address is on the Bitcoin mainnet, `false` otherwise.
+ */
+export function isBtcMainnetAddress(address: string): boolean {
+  return validate(address, Network.mainnet);
+}
+
+/**
+ * Returns whether an address is on the Bitcoin testnet.
+ *
+ * @param address - The address to check.
+ * @returns `true` if the address is on the Bitcoin testnet, `false` otherwise.
+ */
+export function isBtcTestnetAddress(address: string): boolean {
+  return validate(address, Network.testnet);
+}

--- a/packages/keyring-utils/src/btc/index.ts
+++ b/packages/keyring-utils/src/btc/index.ts
@@ -1,0 +1,1 @@
+export * from './address';

--- a/packages/keyring-utils/src/index.ts
+++ b/packages/keyring-utils/src/index.ts
@@ -1,3 +1,4 @@
+export * from './btc';
 export * from './types';
 export * from './typing';
 export * from './superstruct';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,6 +2302,7 @@ __metadata:
     "@ts-bridge/cli": "npm:^0.6.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
+    bitcoin-address-validation: "npm:^2.2.3"
     deepmerge: "npm:^4.2.2"
     depcheck: "npm:^1.4.7"
     jest: "npm:^29.5.0"
@@ -4501,6 +4502,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"base58-js@npm:^1.0.0":
+  version: 1.0.5
+  resolution: "base58-js@npm:1.0.5"
+  checksum: 10/46c1b39d3a70bca0a47d56069c74a25d547680afd0f28609c90f280f5d614f5de36db5df993fa334db24008a68ab784a72fcdaa13eb40078e03c8999915a1100
+  languageName: node
+  linkType: hard
+
 "base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
@@ -4592,6 +4600,17 @@ __metadata:
   dependencies:
     safe-buffer: "npm:^5.0.1"
   checksum: 10/6257e90ff2149aa08740ff4009730c1bceb1a3456571d3006a36b39f30044f2973e05f043ea6977046d6ab66e4a8d6f5c9785094f8317f4ff546a325baece1ab
+  languageName: node
+  linkType: hard
+
+"bitcoin-address-validation@npm:^2.2.3":
+  version: 2.2.3
+  resolution: "bitcoin-address-validation@npm:2.2.3"
+  dependencies:
+    base58-js: "npm:^1.0.0"
+    bech32: "npm:^2.0.0"
+    sha256-uint8array: "npm:^0.10.3"
+  checksum: 10/01603b5edf610ecf0843ae546534313f1cffabc8e7435a3678bc9788f18a54e51302218a539794aafd49beb5be70b5d1d507eb7442cb33970fcd665592a71305
   languageName: node
   linkType: hard
 
@@ -10471,6 +10490,13 @@ __metadata:
   bin:
     sha.js: ./bin.js
   checksum: 10/d833bfa3e0a67579a6ce6e1bc95571f05246e0a441dd8c76e3057972f2a3e098465687a4369b07e83a0375a88703577f71b5b2e966809e67ebc340dbedb478c7
+  languageName: node
+  linkType: hard
+
+"sha256-uint8array@npm:^0.10.3":
+  version: 0.10.7
+  resolution: "sha256-uint8array@npm:0.10.7"
+  checksum: 10/e427f9d2f9c521dea552f033d3f0c3bd641ab214d214dd41bde3c805edde393519cf982b3eee7d683b32e5f28fa23b2278d25935940e13fbe831b216a37832be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With the new additions of the `scopes` field on the `KeyringAccount`, the Snap keyring state might be incompatible when we first deserialize it (and until it's being updated).

We initially wanted to run those migrations on the client side (extension) to update the `AccountsController` internal state, but the Snap keyring state will still be outdated. Also, the `AccountsController` is re-creating its internal state based on the accounts coming from each keyrings (including Snap accounts), so the Snap keyring state HAS TO BE updated, since it's the "source of truth" here.