### PR TITLE
feat: add `listAccountAssets` method

### DIFF
--- a/packages/keyring-api/src/api/caip.ts
+++ b/packages/keyring-api/src/api/caip.ts
@@ -12,7 +12,7 @@ const CAIP_ASSET_TYPE_OR_ID_REGEX =
   /^(?<chainId>(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-_a-zA-Z0-9]{1,32}))\/(?<assetNamespace>[-a-z0-9]{3,8}):(?<assetReference>[-.%a-zA-Z0-9]{1,128})(\/(?<tokenId>[-.%a-zA-Z0-9]{1,78}))?$/u;
 
 /**
- * A CAIP-19 asset type or asset ID identifier, i.e., a human-readable type of asset identifier.
+ * A CAIP-19 asset type identifier, i.e., a human-readable type of asset identifier.
  */
 export const CaipAssetTypeStruct = definePattern<CaipAssetType>(
   'CaipAssetType',

--- a/packages/keyring-api/src/api/caip.ts
+++ b/packages/keyring-api/src/api/caip.ts
@@ -1,19 +1,25 @@
 import { definePattern } from '@metamask/keyring-utils';
+import { type Infer } from '@metamask/superstruct';
 import type { CaipAssetId, CaipAssetType } from '@metamask/utils';
 import {
+  CAIP_ASSET_TYPE_REGEX,
+  CAIP_ASSET_ID_REGEX,
   isCaipAssetType,
   isCaipAssetId,
-  CAIP_ASSET_ID_REGEX,
-  CAIP_ASSET_TYPE_REGEX,
 } from '@metamask/utils';
 
+const CAIP_ASSET_TYPE_OR_ID_REGEX =
+  /^(?<chainId>(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-_a-zA-Z0-9]{1,32}))\/(?<assetNamespace>[-a-z0-9]{3,8}):(?<assetReference>[-.%a-zA-Z0-9]{1,128})(\/(?<tokenId>[-.%a-zA-Z0-9]{1,78}))?$/u;
+
 /**
- * A CAIP-19 asset type identifier, i.e., a human-readable type of asset identifier.
+ * A CAIP-19 asset type or asset ID identifier, i.e., a human-readable type of asset identifier.
  */
 export const CaipAssetTypeStruct = definePattern<CaipAssetType>(
   'CaipAssetType',
   CAIP_ASSET_TYPE_REGEX,
 );
+export type { CaipAssetType };
+export { isCaipAssetType };
 
 /**
  * A CAIP-19 asset ID identifier, i.e., a human-readable type of asset ID.
@@ -22,6 +28,13 @@ export const CaipAssetIdStruct = definePattern<CaipAssetId>(
   'CaipAssetId',
   CAIP_ASSET_ID_REGEX,
 );
+export type { CaipAssetId };
+export { isCaipAssetId };
 
-export type { CaipAssetId, CaipAssetType };
-export { isCaipAssetId, isCaipAssetType };
+/**
+ * A CAIP-19 asset type or asset ID identifier, i.e., a human-readable type of asset identifier.
+ */
+export const CaipAssetTypeOrIdStruct = definePattern<
+  CaipAssetType | CaipAssetId
+>('CaipAssetTypeOrId', CAIP_ASSET_TYPE_OR_ID_REGEX);
+export type CaipAssetTypeOrId = Infer<typeof CaipAssetTypeOrIdStruct>;

--- a/packages/keyring-api/src/api/keyring.ts
+++ b/packages/keyring-api/src/api/keyring.ts
@@ -5,7 +5,7 @@ import type { Json } from '@metamask/utils';
 
 import type { KeyringAccount } from './account';
 import type { Balance } from './balance';
-import type { CaipAssetType } from './caip';
+import type { CaipAssetType, CaipAssetTypeOrId } from './caip';
 import type { KeyringAccountData } from './export';
 import type { Paginated, Pagination } from './pagination';
 import type { KeyringRequest } from './request';
@@ -50,6 +50,17 @@ export type Keyring = {
    * object without any private information.
    */
   createAccount(options?: Record<string, Json>): Promise<KeyringAccount>;
+
+  /**
+   * Lists the assets of an account (fungibles and non-fungibles) represented
+   * by their respective CAIP-19:
+   * - Asset types for fungibles assets.
+   * - Asset IDs for non-fungible ones.
+   *
+   * @param id - The ID of the account to list the assets for.
+   * @returns A promise that resolves to list of assets for that account.
+   */
+  listAccountAssets?(id: string): Promise<CaipAssetTypeOrId[]>;
 
   /**
    * Lists the transactions of an account, paginated and ordered by the most

--- a/packages/keyring-api/src/rpc.ts
+++ b/packages/keyring-api/src/rpc.ts
@@ -19,6 +19,7 @@ import {
   KeyringResponseStruct,
   TransactionsPageStruct,
   PaginationStruct,
+  CaipAssetTypeOrIdStruct,
 } from './api';
 
 /**
@@ -28,6 +29,7 @@ export enum KeyringRpcMethod {
   ListAccounts = 'keyring_listAccounts',
   GetAccount = 'keyring_getAccount',
   CreateAccount = 'keyring_createAccount',
+  ListAccountAssets = 'keyring_listAccountAssets',
   ListAccountTransactions = 'keyring_listAccountTransactions',
   GetAccountBalances = 'keyring_getAccountBalances',
   FilterAccountChains = 'keyring_filterAccountChains',
@@ -126,6 +128,27 @@ export const ListAccountTransactionsResponseStruct = TransactionsPageStruct;
 
 export type ListAccountTransactionsResponse = Infer<
   typeof ListAccountTransactionsResponseStruct
+>;
+
+// ----------------------------------------------------------------------------
+// List account assets
+
+export const ListAccountAssetsRequestStruct = object({
+  ...CommonHeader,
+  method: literal('keyring_listAccountAssets'),
+  params: object({
+    id: UuidStruct,
+  }),
+});
+
+export type ListAccountAssetsRequest = Infer<
+  typeof ListAccountAssetsRequestStruct
+>;
+
+export const ListAccountAssetsResponseStruct = array(CaipAssetTypeOrIdStruct);
+
+export type ListAccountAssetsResponse = Infer<
+  typeof ListAccountAssetsResponseStruct
 >;
 
 // ----------------------------------------------------------------------------

--- a/packages/keyring-snap-client/src/KeyringClient.test.ts
+++ b/packages/keyring-snap-client/src/KeyringClient.test.ts
@@ -1,5 +1,6 @@
 import type {
   CaipAssetType,
+  CaipAssetTypeOrId,
   KeyringAccount,
   KeyringRequest,
   KeyringResponse,
@@ -290,6 +291,59 @@ describe('KeyringClient', () => {
         }),
       ).rejects.toThrow(
         'At path: data.0.fees.0.type -- Expected one of `"base","priority"`, but received: "invalid-type"',
+      );
+    });
+  });
+
+  describe('listAccountAssets', () => {
+    it('returns an empty list of assets', async () => {
+      const id = '4eda78cd-aed8-42c1-a2a0-4c9b36e8282f';
+      const expectedResponse: CaipAssetTypeOrId[] = [];
+
+      mockSender.send.mockResolvedValue(expectedResponse);
+      const assets = await keyring.listAccountAssets(id);
+
+      expect(mockSender.send).toHaveBeenCalledWith({
+        jsonrpc: '2.0',
+        id: expect.any(String),
+        method: 'keyring_listAccountAssets',
+        params: { id },
+      });
+
+      expect(assets).toStrictEqual(expectedResponse);
+    });
+
+    it('returns a non-empty assets list', async () => {
+      const id = '4eda78cd-aed8-42c1-a2a0-4c9b36e8282f';
+      const expectedResponse: CaipAssetTypeOrId[] = [
+        // DAI Token
+        'eip155:1/erc20:0x6b175474e89094c44da98b954eedeac495271d0f',
+        // CryptoKitties Collection
+        'eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d',
+        // CryptoKitties Collectible #771769
+        'eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769',
+      ];
+
+      mockSender.send.mockResolvedValue(expectedResponse);
+      const assets = await keyring.listAccountAssets(id);
+
+      expect(mockSender.send).toHaveBeenCalledWith({
+        jsonrpc: '2.0',
+        id: expect.any(String),
+        method: 'keyring_listAccountAssets',
+        params: { id },
+      });
+
+      expect(assets).toStrictEqual(expectedResponse);
+    });
+
+    it('throws an error if one asset is not CAIP-19 compliant', async () => {
+      const id = '4eda78cd-aed8-42c1-a2a0-4c9b36e8282f';
+      const expectedResponse = ['not:compliant'];
+
+      mockSender.send.mockResolvedValue(expectedResponse);
+      await expect(keyring.listAccountAssets(id)).rejects.toThrow(
+        'At path: 0 -- Expected a value of type `CaipAssetTypeOrId`, but received: `"not:compliant"`',
       );
     });
   });

--- a/packages/keyring-snap-client/src/KeyringClient.ts
+++ b/packages/keyring-snap-client/src/KeyringClient.ts
@@ -8,6 +8,7 @@ import type {
   Balance,
   TransactionsPage,
   Pagination,
+  CaipAssetTypeOrId,
 } from '@metamask/keyring-api';
 import {
   ApproveRequestResponseStruct,
@@ -20,6 +21,7 @@ import {
   GetRequestResponseStruct,
   ListAccountsResponseStruct,
   ListAccountTransactionsResponseStruct,
+  ListAccountAssetsResponseStruct,
   ListRequestsResponseStruct,
   RejectRequestResponseStruct,
   SubmitRequestResponseStruct,
@@ -116,6 +118,16 @@ export class KeyringClient implements Keyring {
         params: { id, pagination },
       }),
       ListAccountTransactionsResponseStruct,
+    );
+  }
+
+  async listAccountAssets(id: string): Promise<CaipAssetTypeOrId[]> {
+    return strictMask(
+      await this.#send({
+        method: KeyringRpcMethod.ListAccountAssets,
+        params: { id },
+      }),
+      ListAccountAssetsResponseStruct,
     );
   }
 

--- a/packages/keyring-snap-sdk/src/rpc-handler.test.ts
+++ b/packages/keyring-snap-sdk/src/rpc-handler.test.ts
@@ -10,6 +10,7 @@ describe('handleKeyringRequest', () => {
     getAccount: jest.fn(),
     createAccount: jest.fn(),
     listAccountTransactions: jest.fn(),
+    listAccountAssets: jest.fn(),
     getAccountBalances: jest.fn(),
     filterAccountChains: jest.fn(),
     updateAccount: jest.fn(),
@@ -151,6 +152,43 @@ describe('handleKeyringRequest', () => {
 
     await expect(handleKeyringRequest(partialKeyring, request)).rejects.toThrow(
       'Method not supported: keyring_listAccountTransactions',
+    );
+  });
+
+  it('calls keyring_listAccountAssets', async () => {
+    const accountId = '5767f284-5273-44c1-9556-31959b2afd10';
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: '9f014e5b-262b-4fb9-99b7-642d5afa21ee',
+      method: KeyringRpcMethod.ListAccountAssets,
+      params: {
+        id: accountId,
+      },
+    };
+
+    const dummyResponse = 'ListAccountAssets result';
+    keyring.listAccountAssets.mockResolvedValue(dummyResponse);
+    const result = await handleKeyringRequest(keyring, request);
+
+    expect(keyring.listAccountAssets).toHaveBeenCalledWith(accountId);
+    expect(result).toBe(dummyResponse);
+  });
+
+  it('throws an error if `keyring_listAccountAssets` is not implemented', async () => {
+    const request: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: '57854955-7c1f-4603-92a8-69de8e6c678a',
+      method: KeyringRpcMethod.ListAccountAssets,
+      params: {
+        id: '46e59db9-8e05-46a9-a73e-f514c55e7894',
+      },
+    };
+
+    const partialKeyring: Keyring = { ...keyring };
+    delete partialKeyring.listAccountAssets;
+
+    await expect(handleKeyringRequest(partialKeyring, request)).rejects.toThrow(
+      'Method not supported: keyring_listAccountAssets',
     );
   });
 

--- a/packages/keyring-snap-sdk/src/rpc-handler.ts
+++ b/packages/keyring-snap-sdk/src/rpc-handler.ts
@@ -15,6 +15,7 @@ import {
   ListAccountsRequestStruct,
   ListRequestsRequestStruct,
   GetAccountBalancesRequestStruct,
+  ListAccountAssetsRequestStruct,
 } from '@metamask/keyring-api';
 import type { JsonRpcRequest } from '@metamask/keyring-utils';
 import { JsonRpcRequestStruct } from '@metamask/keyring-utils';
@@ -71,6 +72,14 @@ async function dispatchRequest(
         request.params.id,
         request.params.pagination,
       );
+    }
+
+    case `${KeyringRpcMethod.ListAccountAssets}`: {
+      if (keyring.listAccountAssets === undefined) {
+        throw new MethodNotSupportedError(request.method);
+      }
+      assert(request, ListAccountAssetsRequestStruct);
+      return keyring.listAccountAssets(request.params.id);
     }
 
     case `${KeyringRpcMethod.GetAccountBalances}`: {


### PR DESCRIPTION
This new method allows a Snap account to list all the owned assets for a given accounts.

It can be used in combinations with `getAccountBalances`.

The client would first fetch the assets for an account and then get the associated balances:
```ts
// Keyring client to interact with the account Snap.
const client = new KeyringClient(...);

// The account we want to retrieve assets from.
const id = '418b6f26-40e7-4b50-a768-018c9aba496d';

// Assets.
const tokens: CaipAssetType[] = [];
const nfts: CaipAssetId[] = [];

// Fetch assets:
for (const asset in await client.listAccountAssets()) {
  if (isCaipAssetId(asset)) {
    nfts.push(asset);
  } else if (isCaipAssetType(asset)) {
    tokens.push(asset);
  } else {
    console.warn(`Malformed asset, skipping: ${asset}`);
  }
}

// Fetch token balances:
const balances = await client.getAccountBalances(tokens);
...
```