### PR TITLE
refactor!: use better CAIP types + add generic type in `definePattern`

### DIFF
--- a/packages/keyring-api/src/api/caip.ts
+++ b/packages/keyring-api/src/api/caip.ts
@@ -10,7 +10,7 @@ import {
 /**
  * A CAIP-19 asset type identifier, i.e., a human-readable type of asset identifier.
  */
-export const CaipAssetTypeStruct = definePattern(
+export const CaipAssetTypeStruct = definePattern<CaipAssetType>(
   'CaipAssetType',
   CAIP_ASSET_TYPE_REGEX,
 );
@@ -18,7 +18,7 @@ export const CaipAssetTypeStruct = definePattern(
 /**
  * A CAIP-19 asset ID identifier, i.e., a human-readable type of asset ID.
  */
-export const CaipAssetIdStruct = definePattern(
+export const CaipAssetIdStruct = definePattern<CaipAssetId>(
   'CaipAssetId',
   CAIP_ASSET_ID_REGEX,
 );

--- a/packages/keyring-api/src/api/caip.ts
+++ b/packages/keyring-api/src/api/caip.ts
@@ -1,11 +1,11 @@
 import { definePattern } from '@metamask/keyring-utils';
-import { is, type Infer } from '@metamask/superstruct';
-
-const CAIP_ASSET_TYPE_REGEX =
-  /^(?<chainId>(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-_a-zA-Z0-9]{1,32}))\/(?<assetNamespace>[-a-z0-9]{3,8}):(?<assetReference>[-.%a-zA-Z0-9]{1,128})$/u;
-
-const CAIP_ASSET_ID_REGEX =
-  /^(?<chainId>(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-_a-zA-Z0-9]{1,32}))\/(?<assetNamespace>[-a-z0-9]{3,8}):(?<assetReference>[-.%a-zA-Z0-9]{1,128})\/(?<tokenId>[-.%a-zA-Z0-9]{1,78})$/u;
+import type { CaipAssetId, CaipAssetType } from '@metamask/utils';
+import {
+  isCaipAssetType,
+  isCaipAssetId,
+  CAIP_ASSET_ID_REGEX,
+  CAIP_ASSET_TYPE_REGEX,
+} from '@metamask/utils';
 
 /**
  * A CAIP-19 asset type identifier, i.e., a human-readable type of asset identifier.
@@ -14,7 +14,6 @@ export const CaipAssetTypeStruct = definePattern(
   'CaipAssetType',
   CAIP_ASSET_TYPE_REGEX,
 );
-export type CaipAssetType = Infer<typeof CaipAssetTypeStruct>;
 
 /**
  * A CAIP-19 asset ID identifier, i.e., a human-readable type of asset ID.
@@ -23,36 +22,6 @@ export const CaipAssetIdStruct = definePattern(
   'CaipAssetId',
   CAIP_ASSET_ID_REGEX,
 );
-export type CaipAssetId = Infer<typeof CaipAssetIdStruct>;
 
-/**
- * Check if the given value is a {@link CaipAssetType}.
- *
- * @param value - The value to check.
- * @returns Whether the value is a {@link CaipAssetType}.
- * @example
- * ```ts
- * isCaipAssetType('eip155:1/slip44:60'); // true
- * isCaipAssetType('cosmos:cosmoshub-3/slip44:118'); // true
- * isCaipAssetType('hedera:mainnet/nft:0.0.55492/12'); // false
- * ```
- */
-export function isCaipAssetType(value: unknown): value is CaipAssetType {
-  return is(value, CaipAssetTypeStruct);
-}
-
-/**
- * Check if the given value is a {@link CaipAssetId}.
- *
- * @param value - The value to check.
- * @returns Whether the value is a {@link CaipAssetId}.
- * @example
- * ```ts
- * isCaipAssetType('eip155:1/slip44:60'); // false
- * isCaipAssetType('cosmos:cosmoshub-3/slip44:118'); // false
- * isCaipAssetType('hedera:mainnet/nft:0.0.55492/12'); // true
- * ```
- */
-export function isCaipAssetId(value: unknown): value is CaipAssetId {
-  return is(value, CaipAssetIdStruct);
-}
+export type { CaipAssetId, CaipAssetType };
+export { isCaipAssetId, isCaipAssetType };

--- a/packages/keyring-snap-client/src/KeyringClient.test.ts
+++ b/packages/keyring-snap-client/src/KeyringClient.test.ts
@@ -1,4 +1,5 @@
 import type {
+  CaipAssetType,
   KeyringAccount,
   KeyringRequest,
   KeyringResponse,
@@ -295,7 +296,9 @@ describe('KeyringClient', () => {
 
   describe('getAccountBalances', () => {
     it('returns a valid response', async () => {
-      const assets = ['bip122:000000000019d6689c085ae165831e93/slip44:0'];
+      const assets: CaipAssetType[] = [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+      ];
       const id = '1617ea08-d4b6-48bf-ba83-901ef1e45ed7';
       const expectedResponse = {
         [assets[0] as string]: {
@@ -318,7 +321,9 @@ describe('KeyringClient', () => {
     });
 
     it('throws an error because the amount has the wrong type', async () => {
-      const assets = ['bip122:000000000019d6689c085ae165831e93/slip44:0'];
+      const assets: CaipAssetType[] = [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+      ];
       const id = '1617ea08-d4b6-48bf-ba83-901ef1e45ed7';
       const expectedResponse = {
         [assets[0] as string]: {
@@ -334,7 +339,9 @@ describe('KeyringClient', () => {
     });
 
     it("throws an error because the amount isn't a StringNumber", async () => {
-      const assets = ['bip122:000000000019d6689c085ae165831e93/slip44:0'];
+      const assets: CaipAssetType[] = [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+      ];
       const id = '1617ea08-d4b6-48bf-ba83-901ef1e45ed7';
       const expectedResponse = {
         [assets[0] as string]: {

--- a/packages/keyring-utils/src/superstruct.ts
+++ b/packages/keyring-utils/src/superstruct.ts
@@ -119,17 +119,26 @@ export function exactOptional<Type, Schema>(
  *
  * ```ts
  * const EthAddressStruct = definePattern('EthAddress', /^0x[0-9a-f]{40}$/iu);
+ * type EthAddress = Infer<typeof EthAddressStruct>; // string
+ *
+ * const CaipChainIdStruct = defineTypedPattern<`${string}:${string}`>(
+ *   'CaipChainId',
+ *   /^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}$/u;
+ * );
+ * type CaipChainId = Infer<typeof CaipChainIdStruct>; // `${string}:${string}`
+ *
  * ```
  *
  * @param name - Type name.
  * @param pattern - Regular expression to match.
+ * @template Pattern - The pattern type, defaults to `string`.
  * @returns A new string-struct that matches the given pattern.
  */
-export function definePattern(
+export function definePattern<Pattern extends string = string>(
   name: string,
   pattern: RegExp,
-): Struct<string, null> {
-  return define<string>(
+): Struct<Pattern, null> {
+  return define<Pattern>(
     name,
     (value: unknown): boolean =>
       typeof value === 'string' && pattern.test(value),


### PR DESCRIPTION
Now those types have been moved to `@metamask/utils`, so just re-export them to keep them in the API.

Also, we are still re-defining the structs, since our `definePattern` allow for better error messages.

This is **BREAKING** for the `keyring-api` since the CAIP types used in the public API will now be more restrictive (`${string}:${string}/${string}:${string}` for `CaipAssetType` rather than a simple `string`)