### PR TITLE
fix: `init` uses a timeout and other methods reattempt `init`

### DIFF
--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -23,10 +23,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 91.15,
-      functions: 96.19,
-      lines: 95.18,
-      statements: 95.22,
+      branches: 91.09,
+      functions: 96.11,
+      lines: 95.09,
+      statements: 95.14,
     },
   },
 });

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
@@ -160,21 +160,6 @@ describe('LedgerIframeBridge', function () {
       expect(promise1).toStrictEqual(promise2);
       expect(appendChildSpy).toHaveBeenCalledTimes(1);
     });
-
-    it('removes the uninitialized iframe from the page in case of error', async function () {
-      bridge = new LedgerIframeBridge();
-      const appendChildSpy = jest
-        .spyOn(document.head, 'appendChild')
-        .mockImplementation((child) => {
-          (child as HTMLIFrameElement).onerror?.(new Event('error'));
-          return {} as Node;
-        });
-
-      await bridge.init();
-
-      expect(bridge.iframe).toBeUndefined();
-      expect(appendChildSpy).toHaveBeenCalledTimes(1);
-    });
   });
 
   describe('destroy', function () {

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
@@ -341,32 +341,23 @@ export class LedgerIframeBridge
   }
 
   async #setupIframe(bridgeUrl: string): Promise<void> {
-    const timeout = new Promise((_, reject) => {
-      setTimeout(() => {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
         reject(new Error('Bridge initialization timed out'));
       }, IFRAME_INIT_TIMEOUT);
-    });
 
-    const initIframe = new Promise<void>((resolve, reject) => {
       this.iframe = document.createElement('iframe');
       this.iframe.src = bridgeUrl;
       this.iframe.allow = `hid 'src'`;
+
       this.iframe.onload = async (): Promise<void> => {
+        clearTimeout(timeout);
         this.iframeLoaded = true;
         resolve();
       };
-      this.iframe.onerror = (): void => {
-        if (this.iframe) {
-          document.head.removeChild(this.iframe);
-          this.iframe = undefined;
-        }
-        this.iframeLoaded = false;
-        reject(new Error('Failed to load iframe'));
-      };
+
       document.head.appendChild(this.iframe);
     });
-
-    await Promise.race([initIframe, timeout]);
   }
 
   #getOrigin(bridgeUrl: string): string {

--- a/packages/keyring-eth-ledger-bridge/test/document.shim.ts
+++ b/packages/keyring-eth-ledger-bridge/test/document.shim.ts
@@ -13,7 +13,6 @@ const shim = {
     appendChild: (child: { onload?: () => void }): void => {
       child.onload?.();
     },
-    removeChild: (): boolean => false,
   },
   createElement: (): Element => ({
     src: false,


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
The `LedgerBridgeIframe` class gets initialized through the `init` method. However, if the iframe that is set up during this method call fails for some reason, the promise returned by `init` will never resolve/reject. 

Downstream, this prevents the KeyringController mutex from being ever released, causing deadlocks at unlock time.

The solution applied in this PR is to make the iframe set up during the `init` call optional, and then later reattempting it whenever another method needs the iframe and finds it uninitialized  
