### PR TITLE
refactor: use `definePattern` from `@metamask/utils`

### DIFF
--- a/packages/keyring-api/src/eth/types.ts
+++ b/packages/keyring-api/src/eth/types.ts
@@ -1,7 +1,7 @@
-import { object, definePattern } from '@metamask/keyring-utils';
+import { object } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 import { nonempty, array, enums, literal } from '@metamask/superstruct';
-import { CaipChainIdStruct } from '@metamask/utils';
+import { definePattern, CaipChainIdStruct } from '@metamask/utils';
 
 import { EthScope } from '.';
 import { EthAccountType, KeyringAccountStruct } from '../api';

--- a/packages/keyring-api/src/sol/types.ts
+++ b/packages/keyring-api/src/sol/types.ts
@@ -1,7 +1,7 @@
-import { object, definePattern } from '@metamask/keyring-utils';
+import { object } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 import { array, enums, literal, nonempty } from '@metamask/superstruct';
-import { CaipChainIdStruct } from '@metamask/utils';
+import { definePattern, CaipChainIdStruct } from '@metamask/utils';
 
 import { KeyringAccountStruct, SolAccountType } from '../api';
 

--- a/packages/keyring-utils/src/superstruct.ts
+++ b/packages/keyring-utils/src/superstruct.ts
@@ -1,9 +1,4 @@
-import {
-  Struct,
-  assert,
-  define,
-  object as stObject,
-} from '@metamask/superstruct';
+import { Struct, assert, object as stObject } from '@metamask/superstruct';
 import type {
   Infer,
   Context,
@@ -110,39 +105,6 @@ export function exactOptional<Type, Schema>(
     refiner: (value, ctx) =>
       !hasOptional(ctx) || struct.refiner(value as Type, ctx),
   });
-}
-
-/**
- * Defines a new string-struct matching a regular expression.
- *
- * Example:
- *
- * ```ts
- * const EthAddressStruct = definePattern('EthAddress', /^0x[0-9a-f]{40}$/iu);
- * type EthAddress = Infer<typeof EthAddressStruct>; // string
- *
- * const CaipChainIdStruct = defineTypedPattern<`${string}:${string}`>(
- *   'CaipChainId',
- *   /^[-a-z0-9]{3,8}:[-_a-zA-Z0-9]{1,32}$/u;
- * );
- * type CaipChainId = Infer<typeof CaipChainIdStruct>; // `${string}:${string}`
- *
- * ```
- *
- * @param name - Type name.
- * @param pattern - Regular expression to match.
- * @template Pattern - The pattern type, defaults to `string`.
- * @returns A new string-struct that matches the given pattern.
- */
-export function definePattern<Pattern extends string = string>(
-  name: string,
-  pattern: RegExp,
-): Struct<Pattern, null> {
-  return define<Pattern>(
-    name,
-    (value: unknown): boolean =>
-      typeof value === 'string' && pattern.test(value),
-  );
 }
 
 /**

--- a/packages/keyring-utils/src/types.ts
+++ b/packages/keyring-utils/src/types.ts
@@ -1,6 +1,5 @@
 import { define, type Infer } from '@metamask/superstruct';
-
-import { definePattern } from './superstruct';
+import { definePattern } from '@metamask/utils';
 
 /**
  * UUIDv4 struct.


### PR DESCRIPTION
Now that `definePattern` has been moved to `@metamask/utils` we can our local one.