### PR TITLE
feat: re-export `Caip*` types/structs

### DIFF
--- a/packages/keyring-api/jest.config.js
+++ b/packages/keyring-api/jest.config.js
@@ -14,7 +14,11 @@ module.exports = merge(baseConfig, {
   // The display name when running multiple projects
   displayName,
 
-  coveragePathIgnorePatterns: ['./src/tests'],
+  coveragePathIgnorePatterns: [
+    './src/tests',
+    // We re-exports some CAIP types from `@metamask/utils`, no need to cover them.
+    './src/api/caip',
+  ],
 
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {

--- a/packages/keyring-api/jest.config.js
+++ b/packages/keyring-api/jest.config.js
@@ -14,11 +14,7 @@ module.exports = merge(baseConfig, {
   // The display name when running multiple projects
   displayName,
 
-  coveragePathIgnorePatterns: [
-    './src/tests',
-    // We re-exports some CAIP types from `@metamask/utils`, no need to cover them.
-    './src/api/caip',
-  ],
+  coveragePathIgnorePatterns: ['./src/tests'],
 
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {

--- a/packages/keyring-api/src/api/account.ts
+++ b/packages/keyring-api/src/api/account.ts
@@ -1,7 +1,9 @@
 import { AccountIdStruct, object } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 import { nonempty, array, enums, record, string } from '@metamask/superstruct';
-import { CaipChainIdStruct, JsonStruct } from '@metamask/utils';
+import { JsonStruct } from '@metamask/utils';
+
+import { CaipChainIdStruct } from './caip';
 
 /**
  * Supported Ethereum account types.

--- a/packages/keyring-api/src/api/caip.ts
+++ b/packages/keyring-api/src/api/caip.ts
@@ -1,3 +1,5 @@
+// istanbul ignore file
+
 import {
   CaipAssetIdStruct,
   CaipAssetTypeStruct,

--- a/packages/keyring-api/src/api/caip.ts
+++ b/packages/keyring-api/src/api/caip.ts
@@ -1,0 +1,20 @@
+import {
+  CaipAssetIdStruct,
+  CaipAssetTypeStruct,
+  CaipAssetTypeOrIdStruct,
+  CaipChainIdStruct,
+} from '@metamask/utils';
+import type {
+  CaipAssetId,
+  CaipAssetType,
+  CaipAssetTypeOrId,
+  CaipChainId,
+} from '@metamask/utils';
+
+export {
+  CaipAssetIdStruct,
+  CaipAssetTypeStruct,
+  CaipAssetTypeOrIdStruct,
+  CaipChainIdStruct,
+};
+export type { CaipAssetId, CaipAssetType, CaipAssetTypeOrId, CaipChainId };

--- a/packages/keyring-api/src/api/index.ts
+++ b/packages/keyring-api/src/api/index.ts
@@ -2,6 +2,7 @@ export * from './account';
 export * from './address';
 export * from './asset';
 export * from './balance';
+export * from './caip';
 export * from './export';
 export * from './request';
 export * from './response';

--- a/packages/keyring-api/src/api/keyring.ts
+++ b/packages/keyring-api/src/api/keyring.ts
@@ -2,16 +2,12 @@
 // This rule seems to be triggering a false positive on the `KeyringAccount`.
 
 import type { JsonRpcRequest } from '@metamask/keyring-utils';
-import type {
-  Json,
-  CaipChainId,
-  CaipAssetType,
-  CaipAssetTypeOrId,
-} from '@metamask/utils';
+import type { Json } from '@metamask/utils';
 
 import type { KeyringAccount } from './account';
 import type { ResolvedAccountAddress } from './address';
 import type { Balance } from './balance';
+import type { CaipChainId, CaipAssetType, CaipAssetTypeOrId } from './caip';
 import type { KeyringAccountData } from './export';
 import type { Paginated, Pagination } from './pagination';
 import type { KeyringRequest } from './request';

--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -2,9 +2,9 @@ import type { InferEquals } from '@metamask/keyring-utils';
 import { object, UuidStruct } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 import { array, enums, nullable, number, string } from '@metamask/superstruct';
-import { CaipChainIdStruct } from '@metamask/utils';
 
 import { AssetStruct } from './asset';
+import { CaipChainIdStruct } from './caip';
 import type { Paginated } from './pagination';
 
 /**

--- a/packages/keyring-api/src/btc/constants.ts
+++ b/packages/keyring-api/src/btc/constants.ts
@@ -1,4 +1,4 @@
-/* istanbul ignore file */
+// istanbul ignore file
 
 /**
  * Scopes for Bitcoin account type. See {@link KeyringAccount.scopes}.

--- a/packages/keyring-api/src/btc/types.ts
+++ b/packages/keyring-api/src/btc/types.ts
@@ -8,10 +8,13 @@ import {
   literal,
   size,
 } from '@metamask/superstruct';
-import { CaipChainIdStruct } from '@metamask/utils';
 import { bech32 } from 'bech32';
 
-import { BtcAccountType, KeyringAccountStruct } from '../api';
+import {
+  BtcAccountType,
+  KeyringAccountStruct,
+  CaipChainIdStruct,
+} from '../api';
 
 export const BtcP2wpkhAddressStruct = refine(
   string(),

--- a/packages/keyring-api/src/eth/constants.ts
+++ b/packages/keyring-api/src/eth/constants.ts
@@ -1,4 +1,4 @@
-/* istanbul ignore file */
+// istanbul ignore file
 
 /**
  * Scopes for EVM account type. See {@link KeyringAccount.scopes}.

--- a/packages/keyring-api/src/eth/types.ts
+++ b/packages/keyring-api/src/eth/types.ts
@@ -1,10 +1,14 @@
 import { object } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 import { nonempty, array, enums, literal } from '@metamask/superstruct';
-import { definePattern, CaipChainIdStruct } from '@metamask/utils';
+import { definePattern } from '@metamask/utils';
 
 import { EthScope } from '.';
-import { EthAccountType, KeyringAccountStruct } from '../api';
+import {
+  CaipChainIdStruct,
+  EthAccountType,
+  KeyringAccountStruct,
+} from '../api';
 
 export const EthBytesStruct = definePattern('EthBytes', /^0x[0-9a-f]*$/iu);
 

--- a/packages/keyring-api/src/rpc.ts
+++ b/packages/keyring-api/src/rpc.ts
@@ -13,14 +13,12 @@ import {
   string,
   union,
 } from '@metamask/superstruct';
+import { JsonStruct } from '@metamask/utils';
+
 import {
-  JsonStruct,
   CaipAssetTypeStruct,
   CaipAssetTypeOrIdStruct,
   CaipChainIdStruct,
-} from '@metamask/utils';
-
-import {
   BalanceStruct,
   KeyringAccountDataStruct,
   KeyringAccountStruct,

--- a/packages/keyring-api/src/sol/constants.ts
+++ b/packages/keyring-api/src/sol/constants.ts
@@ -1,4 +1,4 @@
-/* istanbul ignore file */
+// istanbul ignore file
 
 /**
  * Scopes for Solana account type. See {@link KeyringAccount.scopes}.

--- a/packages/keyring-api/src/sol/types.ts
+++ b/packages/keyring-api/src/sol/types.ts
@@ -1,9 +1,13 @@
 import { object } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 import { array, enums, literal, nonempty } from '@metamask/superstruct';
-import { definePattern, CaipChainIdStruct } from '@metamask/utils';
+import { definePattern } from '@metamask/utils';
 
-import { KeyringAccountStruct, SolAccountType } from '../api';
+import {
+  CaipChainIdStruct,
+  KeyringAccountStruct,
+  SolAccountType,
+} from '../api';
 
 /**
  * Solana addresses are represented in the format of a 256-bit ed25519 public key and

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -27,6 +27,7 @@ import type {
   EthUserOperation,
   EthUserOperationPatch,
   ResolvedAccountAddress,
+  CaipChainId,
 } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client';
@@ -35,7 +36,7 @@ import { strictMask } from '@metamask/keyring-utils';
 import type { SnapId } from '@metamask/snaps-sdk';
 import { type Snap } from '@metamask/snaps-utils';
 import { assert, mask, object, string } from '@metamask/superstruct';
-import type { Json, CaipChainId } from '@metamask/utils';
+import type { Json } from '@metamask/utils';
 import {
   bigIntToHex,
   KnownCaipNamespace,

--- a/packages/keyring-snap-bridge/src/logger.ts
+++ b/packages/keyring-snap-bridge/src/logger.ts
@@ -1,4 +1,4 @@
-/* istanbul ignore file */
+// istanbul ignore file
 
 import { createProjectLogger, createModuleLogger } from '@metamask/utils';
 

--- a/packages/keyring-snap-bridge/src/migrations/v1.ts
+++ b/packages/keyring-snap-bridge/src/migrations/v1.ts
@@ -1,15 +1,14 @@
 import {
   BtcAccountType,
-  BtcScope,
   EthAccountType,
-  EthScope,
   SolAccountType,
+  BtcScope,
+  EthScope,
   SolScope,
-  type KeyringAccount,
 } from '@metamask/keyring-api';
+import type { CaipChainId, KeyringAccount } from '@metamask/keyring-api';
 import { isBtcMainnetAddress } from '@metamask/keyring-utils';
 import { is } from '@metamask/superstruct';
-import type { CaipChainId } from '@metamask/utils';
 
 import {
   assertKeyringAccount,

--- a/packages/keyring-snap-client/src/KeyringClient.test.ts
+++ b/packages/keyring-snap-client/src/KeyringClient.test.ts
@@ -1,15 +1,13 @@
+import { BtcMethod, KeyringRpcMethod } from '@metamask/keyring-api';
 import type {
   KeyringAccount,
   KeyringRequest,
   KeyringResponse,
-} from '@metamask/keyring-api';
-import { BtcMethod, KeyringRpcMethod } from '@metamask/keyring-api';
-import type { JsonRpcRequest } from '@metamask/keyring-utils';
-import type {
   CaipChainId,
   CaipAssetType,
   CaipAssetTypeOrId,
-} from '@metamask/utils';
+} from '@metamask/keyring-api';
+import type { JsonRpcRequest } from '@metamask/keyring-utils';
 
 import { KeyringClient } from '.'; // Import from `index.ts` to test the public API
 

--- a/packages/keyring-snap-client/src/KeyringClient.ts
+++ b/packages/keyring-snap-client/src/KeyringClient.ts
@@ -1,14 +1,3 @@
-import type {
-  Keyring,
-  KeyringAccount,
-  KeyringRequest,
-  KeyringAccountData,
-  KeyringResponse,
-  Balance,
-  TransactionsPage,
-  Pagination,
-  ResolvedAccountAddress,
-} from '@metamask/keyring-api';
 import {
   ApproveRequestResponseStruct,
   CreateAccountResponseStruct,
@@ -28,15 +17,24 @@ import {
   KeyringRpcMethod,
   ResolveAccountAddressResponseStruct,
 } from '@metamask/keyring-api';
-import type { JsonRpcRequest } from '@metamask/keyring-utils';
-import { strictMask } from '@metamask/keyring-utils';
-import { assert } from '@metamask/superstruct';
 import type {
+  Keyring,
+  KeyringAccount,
+  KeyringRequest,
+  KeyringAccountData,
+  KeyringResponse,
+  Balance,
+  TransactionsPage,
+  Pagination,
+  ResolvedAccountAddress,
   CaipChainId,
   CaipAssetType,
   CaipAssetTypeOrId,
-  Json,
-} from '@metamask/utils';
+} from '@metamask/keyring-api';
+import type { JsonRpcRequest } from '@metamask/keyring-utils';
+import { strictMask } from '@metamask/keyring-utils';
+import { assert } from '@metamask/superstruct';
+import type { Json } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 
 export type Sender = {


### PR DESCRIPTION
Re-exporting `Caip*` types and structs for convenience and to avoid making the consumers depending on `@metamask/utils`.

The rational being that the `@metamask/keyring-*` packages could be used in a standalone way without relying on other internal libraries that are not closely related to Snaps.