### PR TITLE
feat: add dedicated OneKey keyring class

### DIFF
--- a/packages/keyring-eth-trezor/jest.config.js
+++ b/packages/keyring-eth-trezor/jest.config.js
@@ -24,9 +24,9 @@ module.exports = merge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 48.27,
-      functions: 91.22,
-      lines: 89.94,
-      statements: 90.15,
+      functions: 91.37,
+      lines: 90.2,
+      statements: 90.4,
     },
   },
 });

--- a/packages/keyring-eth-trezor/src/index.ts
+++ b/packages/keyring-eth-trezor/src/index.ts
@@ -1,3 +1,4 @@
 export * from './trezor-keyring';
+export * from './onekey-keyring';
 export type * from './trezor-bridge';
 export * from './trezor-connect-bridge';

--- a/packages/keyring-eth-trezor/src/onekey-keyring.test.ts
+++ b/packages/keyring-eth-trezor/src/onekey-keyring.test.ts
@@ -1,0 +1,42 @@
+import HDKey from 'hdkey';
+import * as sinon from 'sinon';
+
+import { OneKeyKeyring } from './onekey-keyring';
+import { TrezorBridge } from './trezor-bridge';
+import { TrezorKeyring } from './trezor-keyring';
+
+const fakeXPubKey =
+  'xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt';
+const fakeHdKey = HDKey.fromExtendedKey(fakeXPubKey);
+
+describe('TrezorKeyring', function () {
+  let keyring: OneKeyKeyring;
+  let bridge: TrezorBridge;
+
+  beforeEach(async function () {
+    bridge = {} as TrezorBridge;
+    keyring = new OneKeyKeyring({ bridge });
+    keyring.hdk = fakeHdKey;
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('extends TrezorKeyring', () => {
+    expect(keyring).toBeInstanceOf(TrezorKeyring);
+  });
+
+  describe('Keyring.type', function () {
+    it('is a class property that returns the type string.', function () {
+      const { type } = TrezorKeyring;
+      expect(typeof type).toBe('string');
+    });
+
+    it('returns the correct value', function () {
+      const { type } = keyring;
+      const correct = OneKeyKeyring.type;
+      expect(type).toBe(correct);
+    });
+  });
+});

--- a/packages/keyring-eth-trezor/src/onekey-keyring.test.ts
+++ b/packages/keyring-eth-trezor/src/onekey-keyring.test.ts
@@ -9,7 +9,7 @@ const fakeXPubKey =
   'xpub6FnCn6nSzZAw5Tw7cgR9bi15UV96gLZhjDstkXXxvCLsUXBGXPdSnLFbdpq8p9HmGsApME5hQTZ3emM2rnY5agb9rXpVGyy3bdW6EEgAtqt';
 const fakeHdKey = HDKey.fromExtendedKey(fakeXPubKey);
 
-describe('TrezorKeyring', function () {
+describe('OneKeyKeyring', function () {
   let keyring: OneKeyKeyring;
   let bridge: TrezorBridge;
 

--- a/packages/keyring-eth-trezor/src/onekey-keyring.ts
+++ b/packages/keyring-eth-trezor/src/onekey-keyring.ts
@@ -1,0 +1,9 @@
+import { TrezorKeyring } from './trezor-keyring';
+
+const oneKeyKeyringType = 'OneKey Hardware';
+
+export class OneKeyKeyring extends TrezorKeyring {
+  static type: string = oneKeyKeyringType;
+
+  readonly type: string = oneKeyKeyringType;
+}


### PR DESCRIPTION
This PR adds support for a dedicated OneKey keyring (until now it was sharing the same keyring instance than Trezor) so it's considered as a standalone device and could get its own tag inside account list.

There are two others PRs:

- metamask-extension: https://github.com/MetaMask/metamask-extension/pull/29999
- core (accounts and keyring controllers): https://github.com/MetaMask/core/pull/5216


Fixes: https://github.com/MetaMask/accounts-planning/issues/793