### PR TITLE
chore: Rename ControllerMessenger to Messenger

### DIFF
--- a/packages/keyring-internal-snap-client/src/KeyringInternalSnapClient.ts
+++ b/packages/keyring-internal-snap-client/src/KeyringInternalSnapClient.ts
@@ -1,4 +1,4 @@
-import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import type { RestrictedMessenger } from '@metamask/base-controller';
 import { KeyringClient, type Sender } from '@metamask/keyring-snap-client';
 import type { JsonRpcRequest } from '@metamask/keyring-utils';
 import type { HandleSnapRequest } from '@metamask/snaps-controllers';
@@ -13,7 +13,7 @@ type AllowedActions = HandleSnapRequest;
  * A restricted-`Messenger` used by `KeyringInternalSnapClient` to dispatch
  * internal Snap requests.
  */
-export type KeyringInternalSnapClientMessenger = RestrictedControllerMessenger<
+export type KeyringInternalSnapClientMessenger = RestrictedMessenger<
   'KeyringInternalSnapClient',
   AllowedActions,
   never,

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -1,5 +1,5 @@
 import { TransactionFactory } from '@ethereumjs/tx';
-import { ControllerMessenger } from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import { SignTypedDataVersion } from '@metamask/eth-sig-util';
 import type {
   KeyringAccount,
@@ -183,23 +183,18 @@ describe('SnapKeyring', () => {
     chainId: '1',
   };
 
-  // Fake the ControllerMessenger and registers all mock actions here:
-  const controllerMessenger: ControllerMessenger<
-    SnapKeyringAllowedActions,
-    SnapKeyringEvents
-  > = new ControllerMessenger();
-  controllerMessenger.registerActionHandler(
-    'SnapController:get',
-    mockMessenger.get,
-  );
-  controllerMessenger.registerActionHandler(
+  // Fake the Messenger and registers all mock actions here:
+  const messenger: Messenger<SnapKeyringAllowedActions, SnapKeyringEvents> =
+    new Messenger();
+  messenger.registerActionHandler('SnapController:get', mockMessenger.get);
+  messenger.registerActionHandler(
     'SnapController:handleRequest',
     mockMessenger.handleRequest,
   );
 
-  // Now extracts a rectricted messenger for the Snap keyring only.
+  // Now extracts a restricted messenger for the Snap keyring only.
   const mockSnapKeyringMessenger: SnapKeyringMessenger =
-    controllerMessenger.getRestricted({
+    messenger.getRestricted({
       name: 'SnapKeyring',
       allowedEvents: [],
       allowedActions: ['SnapController:get', 'SnapController:handleRequest'],

--- a/packages/keyring-snap-bridge/src/SnapKeyringMessenger.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringMessenger.ts
@@ -1,4 +1,4 @@
-import type { RestrictedControllerMessenger } from '@metamask/base-controller';
+import type { RestrictedMessenger } from '@metamask/base-controller';
 import type {
   AccountAssetListUpdatedEventPayload,
   AccountBalancesUpdatedEventPayload,
@@ -33,7 +33,7 @@ export type SnapKeyringEvents =
 
 export type SnapKeyringAllowedActions = HandleSnapRequest | GetSnap;
 
-export type SnapKeyringMessenger = RestrictedControllerMessenger<
+export type SnapKeyringMessenger = RestrictedMessenger<
   'SnapKeyring',
   SnapKeyringAllowedActions,
   SnapKeyringEvents,


### PR DESCRIPTION
## Explanation

Rename `RestrictedControllerMessenger` to `RestrictedMessenger` and `ControllerMessenger` to `Messenger`.

## References

Relates to #4538

## Changelog

No functional changes.

## Checklist

- [x] I've updated the test suite for new or updated code as appropriate
- [x] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [x] I've highlighted breaking changes using the "BREAKING" category above as appropriate
- [x] I've prepared draft pull requests for clients and consumer packages to resolve any breaking changes
