### PR TITLE
fix(29917): Trezor accounts not able to add multiple HD path accounts into the account list

### DIFF
--- a/packages/keyring-eth-trezor/jest.config.js
+++ b/packages/keyring-eth-trezor/jest.config.js
@@ -24,9 +24,9 @@ module.exports = merge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 48.27,
-      functions: 91.22,
-      lines: 89.94,
-      statements: 90.15,
+      functions: 92.98,
+      lines: 90.21,
+      statements: 90.42,
     },
   },
 });

--- a/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
+++ b/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
@@ -133,6 +133,15 @@ describe('TrezorKeyring', function () {
     });
   });
 
+  describe('getModel', function () {
+    it('gets bridge model', async function () {
+      keyring.bridge.model = 'foo';
+      const model = keyring.getModel();
+
+      expect(model).toBe('foo');
+    });
+  });
+
   describe('init', function () {
     it('initialises the bridge', async function () {
       const initStub = sinon.stub().resolves();

--- a/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
+++ b/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
@@ -729,10 +729,9 @@ describe('TrezorKeyring', function () {
       expect(keyring.paths).toStrictEqual(mockPaths);
     });
 
-    it('should update the hdPath and reset account and page properties if passed a new hdPath', async function () {
+    it('should update the hdPath if passed a new hdPath', async function () {
       const SLIP0044TestnetPath = `m/44'/1'/0'/0`;
       keyring.setHdPath(SLIP0044TestnetPath);
-
       expect(keyring.hdPath).toBe(SLIP0044TestnetPath);
       expect(keyring.hdk.publicKey).toBeNull();
     });

--- a/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
+++ b/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
@@ -722,16 +722,10 @@ describe('TrezorKeyring', function () {
 
     it('should update the hdPath and reset account and page properties if passed a new hdPath', async function () {
       const SLIP0044TestnetPath = `m/44'/1'/0'/0`;
-
       keyring.setHdPath(SLIP0044TestnetPath);
 
       expect(keyring.hdPath).toBe(SLIP0044TestnetPath);
-      expect(keyring.accounts).toStrictEqual([]);
-      expect(keyring.page).toBe(0);
-      expect(keyring.perPage).toBe(5);
       expect(keyring.hdk.publicKey).toBeNull();
-      expect(keyring.unlockedAccount).toBe(0);
-      expect(keyring.paths).toStrictEqual({});
     });
 
     it('should throw an error if passed an unsupported hdPath', async function () {

--- a/packages/keyring-eth-trezor/src/trezor-keyring.ts
+++ b/packages/keyring-eth-trezor/src/trezor-keyring.ts
@@ -539,11 +539,6 @@ export class TrezorKeyring extends EventEmitter {
     // Reset HDKey if the path changes
     if (this.hdPath !== hdPath) {
       this.hdk = new HDKey();
-      this.accounts = [];
-      this.page = 0;
-      this.perPage = 5;
-      this.unlockedAccount = 0;
-      this.paths = {};
     }
     this.hdPath = hdPath;
   }


### PR DESCRIPTION
Currently it's not possible to add accounts from different HDPaths with Trezor related devices. For some reason, on a path change we do the exact same operations than when we "forget" a device. This is not something that we do for ledger devices so it appears useless (and then creates bugs).

Fixes https://github.com/MetaMask/metamask-extension/issues/29917