### PR TITLE
refactor!: `TrezorKeyring` implements `Keyring` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ linkStyle default opacity:0.5
   keyring_snap_sdk(["@metamask/keyring-snap-sdk"]);
   keyring_utils(["@metamask/keyring-utils"]);
   keyring_api --> keyring_utils;
+  eth_trezor_keyring --> keyring_utils;
   keyring_internal_api --> keyring_api;
   keyring_internal_api --> keyring_utils;
   keyring_internal_snap_client --> keyring_api;

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `TrezorKeyring` now implements the `Keyring<Json>` type ([#194](https://github.com/MetaMask/accounts/pull/194))
+  - The class does not extend `EventEmitter` anymore.
+  - The `TrezorKeyring.accounts` class variable is now a `readonly Hex[]` array.
+  - The `addAccounts` method signature has been changed
+    - An `amount` number parameter is now required to specify the number of accounts to add.
+    - The method now returns a promise resolving to an array of `Hex` addresses.
+  - The `deserialize` method now requires a `TrezorControllerOptions` object as a parameter.
+  - The `unlock` method now returns `Promise<Hex>`
+  - The `getAccounts` method now returns `Promise<Hex[]>`
+  - The `signTransaction` method now accepts an `Hex` typed value as the `address` parameter
+  - The `signMessage` method now accepts an `Hex` typed value as the `withAccount` parameter
+  - The `signPersonalMessage` method now accepts an `Hex` typed value as the `withAccount` parameter
+  - The `signTypedData` method now accepts an `Hex` typed value as the `withAccount` parameter
+  - The `unlockAccountByAddress` method now accepts an `Hex` typed value as the `address` parameter
+
+### Removed
+
+- **BREAKING:** The `exportAccount` method has been removed
+
 ## [6.0.2]
 
 ### Changed

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** `TrezorKeyring` now implements the `Keyring<Json>` type ([#194](https://github.com/MetaMask/accounts/pull/194))
+- **BREAKING:** `TrezorKeyring` now implements the `Keyring` type ([#194](https://github.com/MetaMask/accounts/pull/194))
   - The class does not extend `EventEmitter` anymore.
   - The `TrezorKeyring.accounts` class variable is now a `readonly Hex[]` array.
   - The `addAccounts` method signature has been changed

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -12,21 +12,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** `TrezorKeyring` now implements the `Keyring` type ([#194](https://github.com/MetaMask/accounts/pull/194))
   - The class does not extend `EventEmitter` anymore.
   - The `TrezorKeyring.accounts` class variable is now a `readonly Hex[]` array.
-  - The `addAccounts` method signature has been changed
+  - The `addAccounts` method signature has been changed:
     - An `amount` number parameter is now required to specify the number of accounts to add.
     - The method now returns a promise resolving to an array of `Hex` addresses.
   - The `deserialize` method now requires a `TrezorControllerOptions` object as a parameter.
-  - The `unlock` method now returns `Promise<Hex>`
-  - The `getAccounts` method now returns `Promise<Hex[]>`
-  - The `signTransaction` method now accepts an `Hex` typed value as the `address` parameter
-  - The `signMessage` method now accepts an `Hex` typed value as the `withAccount` parameter
-  - The `signPersonalMessage` method now accepts an `Hex` typed value as the `withAccount` parameter
-  - The `signTypedData` method now accepts an `Hex` typed value as the `withAccount` parameter
-  - The `unlockAccountByAddress` method now accepts an `Hex` typed value as the `address` parameter
+  - The `unlock` method now returns `Promise<Hex>`.
+  - The `getAccounts` method now returns `Promise<Hex[]>`.
+  - The `signTransaction` method now accepts an `Hex` typed value as the `address` parameter.
+  - The `signMessage` method now accepts an `Hex` typed value as the `withAccount` parameter.
+  - The `signPersonalMessage` method now accepts an `Hex` typed value as the `withAccount` parameter.
+  - The `signTypedData` method now accepts an `Hex` typed value as the `withAccount` parameter.
+  - The `unlockAccountByAddress` method now accepts an `Hex` typed value as the `address` parameter.
 
 ### Removed
 
-- **BREAKING:** The `exportAccount` method has been removed
+- **BREAKING:** The `exportAccount` method has been removed ([#194](https://github.com/MetaMask/accounts/pull/194))
 
 ## [6.1.1]
 

--- a/packages/keyring-eth-trezor/jest.config.js
+++ b/packages/keyring-eth-trezor/jest.config.js
@@ -24,9 +24,9 @@ module.exports = merge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 48.24,
-      functions: 91.22,
-      lines: 89.89,
-      statements: 90.1,
+      functions: 91.07,
+      lines: 89.83,
+      statements: 90.05,
     },
   },
 });

--- a/packages/keyring-eth-trezor/jest.config.js
+++ b/packages/keyring-eth-trezor/jest.config.js
@@ -25,8 +25,8 @@ module.exports = merge(baseConfig, {
     global: {
       branches: 48.24,
       functions: 91.22,
-      lines: 89.89,
-      statements: 90.1,
+      lines: 90.1,
+      statements: 90.3,
     },
   },
 });

--- a/packages/keyring-eth-trezor/jest.config.js
+++ b/packages/keyring-eth-trezor/jest.config.js
@@ -23,10 +23,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 48.27,
+      branches: 48.24,
       functions: 91.22,
-      lines: 89.94,
-      statements: 90.15,
+      lines: 89.89,
+      statements: 90.1,
     },
   },
 });

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -60,7 +60,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-utils": "^2.1.1",
+    "@metamask/keyring-utils": "workspace:^",
     "@ts-bridge/cli": "^0.6.3",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/hdkey": "^2.0.1",

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -60,6 +60,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/keyring-utils": "^2.1.1",
     "@ts-bridge/cli": "^0.6.1",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/hdkey": "^2.0.1",

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -49,6 +49,7 @@
     "@ethereumjs/tx": "^4.2.0",
     "@ethereumjs/util": "^8.1.0",
     "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/utils": "^11.1.0",
     "@trezor/connect-plugin-ethereum": "^9.0.3",
     "@trezor/connect-web": "^9.1.11",
     "hdkey": "^2.1.0",
@@ -115,7 +116,9 @@
       "@trezor/connect-web>@trezor/connect>@trezor/blockchain-link>ws>bufferutil": false,
       "@trezor/connect-web>@trezor/connect>@trezor/blockchain-link>ws>utf-8-validate": false,
       "@trezor/connect-web>@trezor/connect>@trezor/protobuf>protobufjs": false,
-      "@trezor/connect-web>@trezor/connect>@trezor/transport>usb": false
+      "@trezor/connect-web>@trezor/connect>@trezor/transport>usb": false,
+      "jest-environment-jsdom>jsdom>ws>bufferutil": false,
+      "jest-environment-jsdom>jsdom>ws>utf-8-validate": false
     }
   }
 }

--- a/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
+++ b/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
@@ -658,22 +658,6 @@ describe('TrezorKeyring', function () {
     });
   });
 
-  describe('exportAccount', function () {
-    it('should throw an error because it is not supported', async function () {
-      let error: unknown = null;
-      try {
-        await keyring.exportAccount();
-      } catch (e) {
-        error = e;
-      }
-
-      expect(error instanceof Error).toBe(true);
-      expect((error as Error).toString()).toBe(
-        'Error: Not supported on this device',
-      );
-    });
-  });
-
   describe('forgetDevice', function () {
     it('should clear the content of the keyring', async function () {
       // Add an account

--- a/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
+++ b/packages/keyring-eth-trezor/src/trezor-keyring.test.ts
@@ -229,15 +229,15 @@ describe('TrezorKeyring', function () {
     describe('with no arguments', function () {
       it('returns a single account', async function () {
         keyring.setAccountToUnlock(0);
-        const accounts = await keyring.addAccounts();
+        const accounts = await keyring.addAccounts(1);
         expect(accounts).toHaveLength(1);
       });
 
       it('returns the custom accounts desired', async function () {
         keyring.setAccountToUnlock(0);
-        await keyring.addAccounts();
+        await keyring.addAccounts(1);
         keyring.setAccountToUnlock(2);
-        await keyring.addAccounts();
+        await keyring.addAccounts(1);
 
         const accounts = await keyring.getAccounts();
         expect(accounts[0]).toBe(fakeAccounts[0]);
@@ -276,7 +276,7 @@ describe('TrezorKeyring', function () {
     describe('if the account exists', function () {
       it('should remove that account', async function () {
         keyring.setAccountToUnlock(0);
-        const accounts = await keyring.addAccounts();
+        const accounts = await keyring.addAccounts(1);
         expect(accounts).toHaveLength(1);
         keyring.removeAccount(fakeAccounts[0]);
         const accountsAfterRemoval = await keyring.getAccounts();
@@ -285,9 +285,9 @@ describe('TrezorKeyring', function () {
 
       it('should remove only the account requested', async function () {
         keyring.setAccountToUnlock(0);
-        await keyring.addAccounts();
+        await keyring.addAccounts(1);
         keyring.setAccountToUnlock(1);
-        await keyring.addAccounts();
+        await keyring.addAccounts(1);
 
         let accounts = await keyring.getAccounts();
         expect(accounts).toHaveLength(2);
@@ -386,7 +386,7 @@ describe('TrezorKeyring', function () {
     let accounts: string[] = [];
     beforeEach(async function () {
       keyring.setAccountToUnlock(accountIndex);
-      await keyring.addAccounts();
+      await keyring.addAccounts(1);
       accounts = await keyring.getAccounts();
     });
 
@@ -592,7 +592,7 @@ describe('TrezorKeyring', function () {
       let error: unknown = null;
       try {
         await keyring.signTypedData(
-          String(null),
+          fakeAccounts[0],
           {
             types: { EIP712Domain: [], EmptyMessage: [] },
             primaryType: 'EmptyMessage',
@@ -678,7 +678,7 @@ describe('TrezorKeyring', function () {
     it('should clear the content of the keyring', async function () {
       // Add an account
       keyring.setAccountToUnlock(0);
-      await keyring.addAccounts();
+      await keyring.addAccounts(1);
 
       // Wipe the keyring
       keyring.forgetDevice();
@@ -693,7 +693,7 @@ describe('TrezorKeyring', function () {
   describe('setHdPath', function () {
     const initialProperties = {
       hdPath: `m/44'/60'/0'/0` as const,
-      accounts: ['Account 1'],
+      accounts: [fakeAccounts[0]],
       page: 2,
       perPage: 10,
     };

--- a/packages/keyring-eth-trezor/src/trezor-keyring.ts
+++ b/packages/keyring-eth-trezor/src/trezor-keyring.ts
@@ -6,14 +6,8 @@ import {
   SignTypedDataVersion,
   MessageTypes,
 } from '@metamask/eth-sig-util';
-import {
-  add0x,
-  getChecksumAddress,
-  Hex,
-  Json,
-  Keyring,
-  remove0x,
-} from '@metamask/utils';
+import type { Keyring } from '@metamask/keyring-utils';
+import { add0x, getChecksumAddress, Hex, remove0x } from '@metamask/utils';
 import { transformTypedData } from '@trezor/connect-plugin-ethereum';
 import type {
   EthereumTransactionEIP1559,
@@ -91,7 +85,7 @@ function isOldStyleEthereumjsTx(
   return typeof (tx as OldEthJsTransaction).getChainId === 'function';
 }
 
-export class TrezorKeyring implements Keyring<Json> {
+export class TrezorKeyring implements Keyring {
   static type: string = keyringType;
 
   readonly type: string = keyringType;

--- a/packages/keyring-eth-trezor/src/trezor-keyring.ts
+++ b/packages/keyring-eth-trezor/src/trezor-keyring.ts
@@ -510,10 +510,6 @@ export class TrezorKeyring implements Keyring<Json> {
     throw new Error(response.payload?.error || 'Unknown error');
   }
 
-  async exportAccount(): Promise<never> {
-    return Promise.reject(new Error('Not supported on this device'));
-  }
-
   forgetDevice(): void {
     this.accounts = [];
     this.hdk = new HDKey();

--- a/packages/keyring-eth-trezor/tsconfig.build.json
+++ b/packages/keyring-eth-trezor/tsconfig.build.json
@@ -10,6 +10,9 @@
     "lib": ["ES2020"],
     "target": "es2017"
   },
+  "references": [
+    { "path": "../keyring-utils/tsconfig.build.json" }
+  ],
   "include": ["./src/**/*.ts"],
   "exclude": ["./src/**/*.test.ts"]
 }

--- a/packages/keyring-eth-trezor/tsconfig.build.json
+++ b/packages/keyring-eth-trezor/tsconfig.build.json
@@ -10,9 +10,7 @@
     "lib": ["ES2020"],
     "target": "es2017"
   },
-  "references": [
-    { "path": "../keyring-utils/tsconfig.build.json" }
-  ],
+  "references": [{ "path": "../keyring-utils/tsconfig.build.json" }],
   "include": ["./src/**/*.ts"],
   "exclude": ["./src/**/*.test.ts"]
 }

--- a/packages/keyring-eth-trezor/tsconfig.json
+++ b/packages/keyring-eth-trezor/tsconfig.json
@@ -8,6 +8,9 @@
     "lib": ["ES2020"],
     "target": "es2017"
   },
+  "references": [
+    { "path": "../keyring-utils" }
+  ],
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }

--- a/packages/keyring-eth-trezor/tsconfig.json
+++ b/packages/keyring-eth-trezor/tsconfig.json
@@ -8,9 +8,7 @@
     "lib": ["ES2020"],
     "target": "es2017"
   },
-  "references": [
-    { "path": "../keyring-utils" }
-  ],
+  "references": [{ "path": "../keyring-utils" }],
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,7 +1833,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/keyring-utils": "npm:^2.1.1"
+    "@metamask/keyring-utils": "workspace:^"
     "@metamask/utils": "npm:^11.1.0"
     "@trezor/connect-plugin-ethereum": "npm:^9.0.3"
     "@trezor/connect-web": "npm:^9.1.11"
@@ -2057,18 +2057,6 @@ __metadata:
     "@metamask/providers": ^19.0.0
   languageName: unknown
   linkType: soft
-
-"@metamask/keyring-utils@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "@metamask/keyring-utils@npm:2.1.1"
-  dependencies:
-    "@ethereumjs/tx": "npm:^4.2.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.1.0"
-    bitcoin-address-validation: "npm:^2.2.3"
-  checksum: 10/eaa14376c1c6308316b5b1585b6885081307e8b93973b1e44b9743f30b412afdd570b46a69dbd795ab99a6f27d525f035d576fb4711dd4dc0df3a9fe9ab7591d
-  languageName: node
-  linkType: hard
 
 "@metamask/keyring-utils@workspace:^, @metamask/keyring-utils@workspace:packages/keyring-utils":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,6 +1833,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/utils": "npm:^11.1.0"
     "@trezor/connect-plugin-ethereum": "npm:^9.0.3"
     "@trezor/connect-web": "npm:^9.1.11"
     "@ts-bridge/cli": "npm:^0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1833,6 +1833,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/keyring-utils": "npm:^2.1.1"
     "@metamask/utils": "npm:^11.1.0"
     "@trezor/connect-plugin-ethereum": "npm:^9.0.3"
     "@trezor/connect-web": "npm:^9.1.11"
@@ -2056,6 +2057,18 @@ __metadata:
     "@metamask/providers": ^19.0.0
   languageName: unknown
   linkType: soft
+
+"@metamask/keyring-utils@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@metamask/keyring-utils@npm:2.1.1"
+  dependencies:
+    "@ethereumjs/tx": "npm:^4.2.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.1.0"
+    bitcoin-address-validation: "npm:^2.2.3"
+  checksum: 10/eaa14376c1c6308316b5b1585b6885081307e8b93973b1e44b9743f30b412afdd570b46a69dbd795ab99a6f27d525f035d576fb4711dd4dc0df3a9fe9ab7591d
+  languageName: node
+  linkType: hard
 
 "@metamask/keyring-utils@workspace:^, @metamask/keyring-utils@workspace:packages/keyring-utils":
   version: 0.0.0-use.local


### PR DESCRIPTION
The `TrezorKeyring` is being overhauled to implement the `Keyring` type from `@metamask/utils`. Most of the changes are due to the addresses type that is now `Hex` 

```
### Changed

- **BREAKING:** `TrezorKeyring` now implements the `Keyring` type ([#194](https://github.com/MetaMask/accounts/pull/194))
  - The class does not extend `EventEmitter` anymore.
  - The `TrezorKeyring.accounts` class variable is now a `readonly Hex[]` array.
  - The `addAccounts` method signature has been changed
    - An `amount` number parameter is now required to specify the number of accounts to add.
    - The method now returns a promise resolving to an array of `Hex` addresses.
  - The `deserialize` method now requires a `TrezorControllerOptions` object as a parameter.
  - The `unlock` method now returns `Promise<Hex>`
  - The `getAccounts` method now returns `Promise<Hex[]>`
  - The `signTransaction` method now accepts an `Hex` typed value as the `address` parameter
  - The `signMessage` method now accepts an `Hex` typed value as the `withAccount` parameter
  - The `signPersonalMessage` method now accepts an `Hex` typed value as the `withAccount` parameter
  - The `signTypedData` method now accepts an `Hex` typed value as the `withAccount` parameter
  - The `unlockAccountByAddress` method now accepts an `Hex` typed value as the `address` parameter

### Removed

- **BREAKING:** The `exportAccount` method has been removed
```

* Fixes: https://github.com/MetaMask/accounts/issues/142
