### PR TITLE
feat: use event payload type for `emitSnapKeyringEvent`

### DIFF
--- a/packages/keyring-api/src/events.test-d.ts
+++ b/packages/keyring-api/src/events.test-d.ts
@@ -1,0 +1,410 @@
+import { expectAssignable, expectNotAssignable } from 'tsd';
+
+import { EthAccountType } from './api';
+import { EthScope } from './eth';
+import type { KeyringEventPayload, KeyringEvent } from './events';
+
+expectAssignable<KeyringEventPayload<KeyringEvent.AccountCreated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountCreated>>({
+  account: {
+    // Missing `id`
+    address: '0x0123',
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountCreated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    // Missing `address`
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountCreated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    // Missing `methods`
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountCreated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    // Missing `options`
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountCreated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    options: {},
+    // Missing `scopes`
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountCreated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    // Missing `type`
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountCreated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+    // Extra field
+    index: 1,
+  },
+});
+
+// ---------------------------------------------------------------------------
+
+expectAssignable<KeyringEventPayload<KeyringEvent.AccountDeleted>>({
+  id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountDeleted>>({
+  // Missing `id`
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountDeleted>>({
+  // Extra field
+  address: '0x123',
+});
+
+// ---------------------------------------------------------------------------
+
+expectAssignable<KeyringEventPayload<KeyringEvent.AccountUpdated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountUpdated>>({
+  account: {
+    // Missing `id`
+    address: '0x0123',
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountUpdated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    // Missing `address`
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountUpdated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    // Missing `methods`
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountUpdated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    // Missing `options`
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountUpdated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    options: {},
+    // Missing `scopes`
+    type: EthAccountType.Eoa,
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountUpdated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    // Missing `type`
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountUpdated>>({
+  account: {
+    id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+    address: '0x0123',
+    methods: [],
+    options: {},
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+    // Extra field
+    index: 1,
+  },
+});
+
+// ---------------------------------------------------------------------------
+
+expectAssignable<KeyringEventPayload<KeyringEvent.AccountBalancesUpdated>>({
+  balances: {
+    '11027d05-12f8-4ec0-b03f-151d86a8089e': {
+      'bip122:000000000019d6689c085ae165831e93/slip44:0': {
+        amount: '0.0001',
+        unit: 'BTC',
+      },
+    },
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountBalancesUpdated>>({
+  // Missing `balances`
+  '11027d05-12f8-4ec0-b03f-151d86a8089e': {
+    'bip122:000000000019d6689c085ae165831e93/slip44:0': {
+      amount: '0.0001',
+      unit: 'BTC',
+    },
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountBalancesUpdated>>({
+  balances: {
+    // Missing `accountId` key
+    'bip122:000000000019d6689c085ae165831e93/slip44:0': {
+      amount: '0.0001',
+      unit: 'BTC',
+    },
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountBalancesUpdated>>({
+  balances: {
+    '11027d05-12f8-4ec0-b03f-151d86a8089e': {
+      // Not CAIP-19 compliant
+      bitcoin: {
+        amount: '0.0001',
+        unit: 'BTC',
+      },
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+
+expectAssignable<KeyringEventPayload<KeyringEvent.AccountAssetListUpdated>>({
+  assets: {
+    '11027d05-12f8-4ec0-b03f-151d86a8089e': {
+      added: [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2',
+      ],
+      removed: [
+        'eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769',
+      ],
+    },
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountAssetListUpdated>>({
+  // Missing `assets`
+  '11027d05-12f8-4ec0-b03f-151d86a8089e': {
+    added: [
+      'bip122:000000000019d6689c085ae165831e93/slip44:0',
+      'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2',
+    ],
+    removed: [
+      'eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769',
+    ],
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountAssetListUpdated>>({
+  assets: {
+    // Missing `accountId` key
+    added: [
+      'bip122:000000000019d6689c085ae165831e93/slip44:0',
+      'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2',
+    ],
+    removed: [
+      'eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769',
+    ],
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountAssetListUpdated>>({
+  assets: {
+    '11027d05-12f8-4ec0-b03f-151d86a8089e': {
+      // Missing `added`
+      removed: [
+        'eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769',
+      ],
+    },
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountAssetListUpdated>>({
+  assets: {
+    '11027d05-12f8-4ec0-b03f-151d86a8089e': {
+      added: [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2',
+      ],
+      // Missing `removed`
+    },
+  },
+});
+
+expectNotAssignable<KeyringEventPayload<KeyringEvent.AccountAssetListUpdated>>({
+  assets: {
+    '11027d05-12f8-4ec0-b03f-151d86a8089e': {
+      added: [
+        'bip122:000000000019d6689c085ae165831e93/slip44:0',
+        'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2',
+      ],
+      removed: [
+        'eip155:1/erc721:0x06012c8cf97BEaD5deAe237070F9587f8E7A266d/771769',
+      ],
+      // Extra field
+      updated: ['eip155:1/slip44:60'],
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+
+expectAssignable<KeyringEventPayload<KeyringEvent.AccountTransactionsUpdated>>({
+  transactions: {
+    '11027d05-12f8-4ec0-b03f-151d86a8089e': [
+      {
+        id: 'f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6',
+        timestamp: null,
+        chain: 'eip155:1',
+        status: 'submitted',
+        type: 'send',
+        account: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+        from: [],
+        to: [],
+        fees: [],
+        events: [],
+      },
+    ],
+  },
+});
+
+expectNotAssignable<
+  KeyringEventPayload<KeyringEvent.AccountTransactionsUpdated>
+>({
+  // Missing `transactions`
+  '11027d05-12f8-4ec0-b03f-151d86a8089e': [
+    {
+      id: 'f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6',
+      timestamp: null,
+      chain: 'eip155:1',
+      status: 'submitted',
+      type: 'send',
+      account: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+      from: [],
+      to: [],
+      fees: [],
+      events: [],
+    },
+  ],
+});
+
+expectNotAssignable<
+  KeyringEventPayload<KeyringEvent.AccountTransactionsUpdated>
+>({
+  transactions: [
+    // Missing `accountId` key
+    {
+      id: 'f5d8ee39a430901c91a5917b9f2dc19d6d1a0e9cea205b009ca73dd04470b9a6',
+      timestamp: null,
+      chain: 'eip155:1',
+      status: 'submitted',
+      type: 'send',
+      account: '5cd17616-ea18-4d72-974f-6dbaa3c56d15',
+      from: [],
+      to: [],
+      fees: [],
+      events: [],
+    },
+  ],
+});
+
+expectNotAssignable<
+  KeyringEventPayload<KeyringEvent.AccountTransactionsUpdated>
+>({
+  transactions: {
+    '11027d05-12f8-4ec0-b03f-151d86a8089e': [
+      {
+        // Missing `id`
+        timestamp: null,
+        chain: 'eip155:1',
+        status: 'submitted',
+        type: 'send',
+        account: '11027d05-12f8-4ec0-b03f-151d86a8089e',
+        from: [],
+        to: [],
+        fees: [],
+        events: [],
+      },
+    ],
+  },
+});

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -1,3 +1,6 @@
+/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
+// FIXME: This rule seems to be triggering a false positive on the `KeyringEvents`.
+
 import {
   exactOptional,
   object,
@@ -257,6 +260,7 @@ export type AccountAssetListUpdatedEventPayload =
 /**
  * Keyring events.
  */
+// For some reason, eslint sometimes infer one of those members as `any`...
 type KeyringEvents =
   | AccountCreatedEvent
   | AccountUpdatedEvent

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -276,5 +276,7 @@ type KeyringEvents =
  */
 export type KeyringEventPayload<Event extends KeyringEvent> = Extract<
   KeyringEvents,
-  { method: Event }
+  // We need to use a literal string here, since that is what `KeyringEvents`
+  // is using (probably because of `superstruct`.
+  { method: `${Event}` }
 >['params'];

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -254,66 +254,23 @@ export type AccountAssetListUpdatedEvent = Infer<
 export type AccountAssetListUpdatedEventPayload =
   AccountAssetListUpdatedEvent['params'];
 
-// Events mapping:
-// -----------------------------------------------------------------------------------------------
-
-export type KeyringAccountCreatedEvent = {
-  event: KeyringEvent.AccountCreated;
-  payload: AccountCreatedEventPayload;
-};
-
-export type KeyringAccountUpdatedEvent = {
-  event: KeyringEvent.AccountUpdated;
-  payload: AccountUpdatedEventPayload;
-};
-
-export type KeyringAccountDeletedEvent = {
-  event: KeyringEvent.AccountDeleted;
-  payload: AccountDeletedEventPayload;
-};
-
-export type KeyringAccountAssetListUpdatedEvent = {
-  event: KeyringEvent.AccountAssetListUpdated;
-  payload: AccountAssetListUpdatedEventPayload;
-};
-
-export type KeyringAccountBalancesUpdatedEvent = {
-  event: KeyringEvent.AccountBalancesUpdated;
-  payload: AccountBalancesUpdatedEventPayload;
-};
-
-export type KeyringAccountTransactionsUpdatedEvent = {
-  event: KeyringEvent.AccountTransactionsUpdated;
-  payload: AccountTransactionsUpdatedEventPayload;
-};
-
-export type KeyringRequestApprovedEvent = {
-  event: KeyringEvent.RequestApproved;
-  payload: RequestApprovedEventPayload;
-};
-
-export type KeyringRequestRejectedEvent = {
-  event: KeyringEvent.RequestRejected;
-  payload: RequestRejectedEventPayload;
-};
-
 /**
  * Keyring events.
  */
 export type KeyringEvents =
-  | KeyringAccountCreatedEvent
-  | KeyringAccountUpdatedEvent
-  | KeyringAccountDeletedEvent
-  | KeyringAccountAssetListUpdatedEvent
-  | KeyringAccountBalancesUpdatedEvent
-  | KeyringAccountTransactionsUpdatedEvent
-  | KeyringRequestApprovedEvent
-  | KeyringRequestRejectedEvent;
+  | AccountCreatedEvent
+  | AccountUpdatedEvent
+  | AccountDeletedEvent
+  | AccountAssetListUpdatedEvent
+  | AccountBalancesUpdatedEvent
+  | AccountTransactionsUpdatedEvent
+  | RequestApprovedEvent
+  | RequestRejectedEvent;
 
 /**
  * Extract the payload for a given `KeyringEvent` event.
  */
-export type KeyringEventPayloadFrom<Event extends KeyringEvent> = Extract<
+export type KeyringEventPayload<Event extends KeyringEvent> = Extract<
   KeyringEvents,
-  { event: Event }
->['payload'];
+  { method: Event }
+>['params'];

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -257,7 +257,7 @@ export type AccountAssetListUpdatedEventPayload =
 /**
  * Keyring events.
  */
-export type KeyringEvents =
+type KeyringEvents =
   | AccountCreatedEvent
   | AccountUpdatedEvent
   | AccountDeletedEvent

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -78,6 +78,8 @@ export const AccountCreatedEventStruct = object({
     ...MetaMaskOptionsStruct.schema,
   }),
 });
+export type AccountCreatedEvent = Infer<typeof AccountCreatedEventStruct>;
+export type AccountCreatedEventPayload = AccountCreatedEvent['params'];
 
 export const AccountUpdatedEventStruct = object({
   method: literal(`${KeyringEvent.AccountUpdated}`),
@@ -88,6 +90,8 @@ export const AccountUpdatedEventStruct = object({
     account: KeyringAccountStruct,
   }),
 });
+export type AccountUpdatedEvent = Infer<typeof AccountUpdatedEventStruct>;
+export type AccountUpdatedEventPayload = AccountUpdatedEvent['params'];
 
 export const AccountDeletedEventStruct = object({
   method: literal(`${KeyringEvent.AccountDeleted}`),
@@ -98,6 +102,8 @@ export const AccountDeletedEventStruct = object({
     id: UuidStruct,
   }),
 });
+export type AccountDeletedEvent = Infer<typeof AccountDeletedEventStruct>;
+export type AccountDeletedEventPayload = AccountDeletedEvent['params'];
 
 export const RequestApprovedEventStruct = object({
   method: literal(`${KeyringEvent.RequestApproved}`),
@@ -113,6 +119,8 @@ export const RequestApprovedEventStruct = object({
     result: JsonStruct,
   }),
 });
+export type RequestApprovedEvent = Infer<typeof RequestApprovedEventStruct>;
+export type RequestApprovedEventPayload = RequestApprovedEvent['params'];
 
 export const RequestRejectedEventStruct = object({
   method: literal(`${KeyringEvent.RequestRejected}`),
@@ -123,10 +131,19 @@ export const RequestRejectedEventStruct = object({
     id: UuidStruct,
   }),
 });
+export type RequestRejectedEvent = Infer<typeof RequestRejectedEventStruct>;
+export type RequestRejectedEventPayload = RequestRejectedEvent['params'];
 
 // Assets related events:
 // -----------------------------------------------------------------------------------------------
 
+/**
+ * Event emitted when the balances of an account are updated.
+ *
+ * Only changes are reported.
+ *
+ * The Snap can choose to emit this event for multiple accounts at once.
+ */
 export const AccountBalancesUpdatedEventStruct = object({
   method: literal(`${KeyringEvent.AccountBalancesUpdated}`),
   params: object({
@@ -156,20 +173,20 @@ export const AccountBalancesUpdatedEventStruct = object({
     ),
   }),
 });
-
-/**
- * Event emitted when the balances of an account are updated.
- *
- * Only changes are reported.
- *
- * The Snap can choose to emit this event for multiple accounts at once.
- */
 export type AccountBalancesUpdatedEvent = Infer<
   typeof AccountBalancesUpdatedEventStruct
 >;
 export type AccountBalancesUpdatedEventPayload =
   AccountBalancesUpdatedEvent['params'];
 
+/**
+ * Event emitted when the transactions of an account are updated (added or
+ * changed).
+ *
+ * Only changes are reported.
+ *
+ * The Snap can choose to emit this event for multiple accounts at once.
+ */
 export const AccountTransactionsUpdatedEventStruct = object({
   method: literal(`${KeyringEvent.AccountTransactionsUpdated}`),
   params: object({
@@ -189,21 +206,19 @@ export const AccountTransactionsUpdatedEventStruct = object({
     ),
   }),
 });
-
-/**
- * Event emitted when the transactions of an account are updated (added or
- * changed).
- *
- * Only changes are reported.
- *
- * The Snap can choose to emit this event for multiple accounts at once.
- */
 export type AccountTransactionsUpdatedEvent = Infer<
   typeof AccountTransactionsUpdatedEventStruct
 >;
 export type AccountTransactionsUpdatedEventPayload =
   AccountTransactionsUpdatedEvent['params'];
 
+/**
+ * Event emitted when the assets of an account are updated.
+ *
+ * Only changes are reported.
+ *
+ * The Snap can choose to emit this event for multiple accounts at once.
+ */
 export const AccountAssetListUpdatedEventStruct = object({
   method: literal(`${KeyringEvent.AccountAssetListUpdated}`),
   params: object({
@@ -233,16 +248,72 @@ export const AccountAssetListUpdatedEventStruct = object({
     ),
   }),
 });
-
-/**
- * Event emitted when the assets of an account are updated.
- *
- * Only changes are reported.
- *
- * The Snap can choose to emit this event for multiple accounts at once.
- */
 export type AccountAssetListUpdatedEvent = Infer<
   typeof AccountAssetListUpdatedEventStruct
 >;
 export type AccountAssetListUpdatedEventPayload =
   AccountAssetListUpdatedEvent['params'];
+
+// Events mapping:
+// -----------------------------------------------------------------------------------------------
+
+export type KeyringAccountCreatedEvent = {
+  event: KeyringEvent.AccountCreated;
+  payload: AccountCreatedEventPayload;
+};
+
+export type KeyringAccountUpdatedEvent = {
+  event: KeyringEvent.AccountUpdated;
+  payload: AccountUpdatedEventPayload;
+};
+
+export type KeyringAccountDeletedEvent = {
+  event: KeyringEvent.AccountDeleted;
+  payload: AccountDeletedEventPayload;
+};
+
+export type KeyringAccountAssetListUpdatedEvent = {
+  event: KeyringEvent.AccountAssetListUpdated;
+  payload: AccountAssetListUpdatedEventPayload;
+};
+
+export type KeyringAccountBalancesUpdatedEvent = {
+  event: KeyringEvent.AccountBalancesUpdated;
+  payload: AccountBalancesUpdatedEventPayload;
+};
+
+export type KeyringAccountTransactionsUpdatedEvent = {
+  event: KeyringEvent.AccountTransactionsUpdated;
+  payload: AccountTransactionsUpdatedEventPayload;
+};
+
+export type KeyringRequestApprovedEvent = {
+  event: KeyringEvent.RequestApproved;
+  payload: RequestApprovedEventPayload;
+};
+
+export type KeyringRequestRejectedEvent = {
+  event: KeyringEvent.RequestRejected;
+  payload: RequestRejectedEventPayload;
+};
+
+/**
+ * Keyring events.
+ */
+export type KeyringEvents =
+  | KeyringAccountCreatedEvent
+  | KeyringAccountUpdatedEvent
+  | KeyringAccountDeletedEvent
+  | KeyringAccountAssetListUpdatedEvent
+  | KeyringAccountBalancesUpdatedEvent
+  | KeyringAccountTransactionsUpdatedEvent
+  | KeyringRequestApprovedEvent
+  | KeyringRequestRejectedEvent;
+
+/**
+ * Extract the payload for a given `KeyringEvent` event.
+ */
+export type KeyringEventPayloadFrom<Event extends KeyringEvent> = Extract<
+  KeyringEvents,
+  { event: Event }
+>['payload'];

--- a/packages/keyring-snap-sdk/src/snap-utils.ts
+++ b/packages/keyring-snap-sdk/src/snap-utils.ts
@@ -1,7 +1,4 @@
-import type {
-  KeyringEvent,
-  KeyringEventPayload,
-} from '@metamask/keyring-api';
+import type { KeyringEvent, KeyringEventPayload } from '@metamask/keyring-api';
 import type { SnapsProvider } from '@metamask/snaps-sdk';
 
 /**

--- a/packages/keyring-snap-sdk/src/snap-utils.ts
+++ b/packages/keyring-snap-sdk/src/snap-utils.ts
@@ -1,6 +1,6 @@
 import type {
   KeyringEvent,
-  KeyringEventPayloadFrom,
+  KeyringEventPayload,
 } from '@metamask/keyring-api';
 import type { SnapsProvider } from '@metamask/snaps-sdk';
 
@@ -14,7 +14,7 @@ import type { SnapsProvider } from '@metamask/snaps-sdk';
 export async function emitSnapKeyringEvent<Event extends KeyringEvent>(
   snap: SnapsProvider,
   event: Event,
-  data: KeyringEventPayloadFrom<Event>,
+  data: KeyringEventPayload<Event>,
 ): Promise<void> {
   await snap.request({
     method: 'snap_manageAccounts',

--- a/packages/keyring-snap-sdk/src/snap-utils.ts
+++ b/packages/keyring-snap-sdk/src/snap-utils.ts
@@ -1,6 +1,8 @@
-import type { KeyringEvent } from '@metamask/keyring-api';
+import type {
+  KeyringEvent,
+  KeyringEventPayloadFrom,
+} from '@metamask/keyring-api';
 import type { SnapsProvider } from '@metamask/snaps-sdk';
-import type { Json } from '@metamask/utils';
 
 /**
  * Emit a keyring event from a snap.
@@ -9,10 +11,10 @@ import type { Json } from '@metamask/utils';
  * @param event - The event name.
  * @param data - The event data.
  */
-export async function emitSnapKeyringEvent(
+export async function emitSnapKeyringEvent<Event extends KeyringEvent>(
   snap: SnapsProvider,
-  event: KeyringEvent,
-  data: Record<string, Json>,
+  event: Event,
+  data: KeyringEventPayloadFrom<Event>,
 ): Promise<void> {
   await snap.request({
     method: 'snap_manageAccounts',


### PR DESCRIPTION
Currently, the `emitSnapKeyringEvent` iss using a generic payload type (like a `Record<string, Json>`). We were already using `superstruct` under the hood to check that payload, but the error was then thrown at runtime.

This new implementation allows to extract the actual payload type associated with the event to get errors at compile-time.
