### PR TITLE
fix: export `keyring` from `keyring-utils`

### DIFF
--- a/packages/keyring-utils/CHANGELOG.md
+++ b/packages/keyring-utils/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Export `Keyring` and `KeyringClass` types from package root ([#208](https://github.com/MetaMask/accounts/pull/208))
+
 ## [2.1.0]
 
 ### Added

--- a/packages/keyring-utils/src/index.ts
+++ b/packages/keyring-utils/src/index.ts
@@ -3,3 +3,4 @@ export * from './types';
 export * from './typing';
 export * from './superstruct';
 export * from './JsonRpcRequest';
+export type * from './keyring';


### PR DESCRIPTION
With https://github.com/MetaMask/accounts/pull/201 the `Keyring` type has been added to `@metamask/keyring-utils`, specifically under `src/keyring.ts`. Though this new file is currently not exported from `index.ts`. This PR fixes that 