### PR TITLE
feat(keyring-snap-bridge)!: add `onceSaved` deferred promise for `addAccount` callback

### DIFF
--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -86,6 +86,7 @@ describe('SnapKeyring', () => {
         _address,
         _snapId,
         handleUserInput,
+        _onceSaved,
         _accountNameSuggestion,
         _displayConfirmation,
       ) => {
@@ -240,6 +241,7 @@ describe('SnapKeyring', () => {
         _address,
         _snapId,
         handleUserInput,
+        _onceSaved,
         _accountNameSuggestion,
         _displayConfirmation,
       ) => {
@@ -291,6 +293,7 @@ describe('SnapKeyring', () => {
           account.address.toLowerCase(),
           snapId,
           expect.any(Function),
+          expect.any(Promise),
           undefined,
           undefined,
         );
@@ -318,6 +321,7 @@ describe('SnapKeyring', () => {
           nonEvmAccount.address,
           snapId,
           expect.any(Function),
+          expect.any(Promise),
           undefined,
           undefined,
         );
@@ -418,6 +422,7 @@ describe('SnapKeyring', () => {
               account.address.toLowerCase(),
               snapId,
               expect.any(Function),
+              expect.any(Promise),
               accountNameSuggestion,
               displayConfirmation,
             );
@@ -649,6 +654,7 @@ describe('SnapKeyring', () => {
           account.address.toLowerCase(),
           snapId,
           expect.any(Function),
+          expect.any(Promise),
           undefined,
           undefined,
         );

--- a/packages/keyring-utils/src/types.ts
+++ b/packages/keyring-utils/src/types.ts
@@ -12,6 +12,7 @@ export const UuidStruct = definePattern(
  * Account ID (UUIDv4).
  */
 export const AccountIdStruct = UuidStruct; // Alias for better naming purposes.
+export type AccountId = Infer<typeof AccountIdStruct>; // Alias for better naming purposes.
 
 /**
  * Validates if a given value is a valid URL.


### PR DESCRIPTION
Adding a new deferred promise and passing it down to `addAccount` which allows this callback to actually "await" for `saveState` to finish (since this part of the flow is asynchronous and not "awaited" anymore).