### PR TITLE
feat(keyring-snap-bridge): add `displayAccountNameSuggestion` flag

### DIFF
--- a/packages/keyring-api/src/events.test.ts
+++ b/packages/keyring-api/src/events.test.ts
@@ -62,7 +62,7 @@ describe('events', () => {
             type: EthAccountType.Eoa,
           },
           displayConfirmation: true,
-          displayAccountNameDialog: true,
+          displayAccountNameSuggestion: true,
         },
       };
 

--- a/packages/keyring-api/src/events.test.ts
+++ b/packages/keyring-api/src/events.test.ts
@@ -62,6 +62,7 @@ describe('events', () => {
             type: EthAccountType.Eoa,
           },
           displayConfirmation: true,
+          displayAccountNameDialog: true,
         },
       };
 

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -66,7 +66,7 @@ export const AccountCreatedEventStruct = object({
      * **Note:** This is not guaranteed to be honored by the MetaMask client.
      */
 
-    displayAccountNameDialog: exactOptional(boolean()),
+    displayAccountNameSuggestion: exactOptional(boolean()),
   }),
 });
 

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -68,7 +68,6 @@ export const AccountCreatedEventStruct = object({
      *
      * **Note:** This is not guaranteed to be honored by the MetaMask client.
      */
-
     displayAccountNameSuggestion: exactOptional(boolean()),
   }),
 });

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -59,6 +59,14 @@ export const AccountCreatedEventStruct = object({
      * **Note:** This is not guaranteed to be honored by the MetaMask client.
      */
     displayConfirmation: exactOptional(boolean()),
+
+    /**
+     * Instructs MetaMask to display the name confirmation dialog in the UI.
+     * Otherwise, the account will be added with the suggested name.
+     * **Note:** This is not guaranteed to be honored by the MetaMask client.
+     */
+
+    displayAccountNameDialog: exactOptional(boolean()),
   }),
 });
 

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -26,7 +26,7 @@ import {
 } from '@metamask/keyring-api';
 import type { JsonRpcRequest } from '@metamask/keyring-utils';
 import type { HandleSnapRequest } from '@metamask/snaps-controllers';
-import type { SnapId } from '@metamask/snaps-sdk';
+import { type SnapId } from '@metamask/snaps-sdk';
 import { KnownCaipNamespace, toCaipChainId } from '@metamask/utils';
 
 import type { KeyringState } from '.';
@@ -122,6 +122,14 @@ describe('SnapKeyring', () => {
   const ethEoaAccount3 = {
     id: 'c6697bcf-5710-4751-a1cb-340e4b50617a',
     address: '0xf7bDe8609231033c69E502C08f85153f8A1548F2'.toLowerCase(),
+    options: {},
+    methods: ETH_EOA_METHODS,
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+  };
+  const ethEoaAccount4 = {
+    id: '7e14f1fa-818c-4590-bab5-b19f947559a5',
+    address: '0xd7eb71598059D0856cd24DcbeF48a0DB5ffDa4D4'.toLowerCase(),
     options: {},
     methods: ETH_EOA_METHODS,
     scopes: [EthScope.Eoa],
@@ -293,6 +301,7 @@ describe('SnapKeyring', () => {
           expect.any(Function),
           undefined,
           undefined,
+          undefined,
         );
       });
 
@@ -318,6 +327,7 @@ describe('SnapKeyring', () => {
           nonEvmAccount.address,
           snapId,
           expect.any(Function),
+          undefined,
           undefined,
           undefined,
         );
@@ -375,17 +385,27 @@ describe('SnapKeyring', () => {
             { ...ethEoaAccount1 },
             'New Account',
             undefined,
+            undefined,
           ],
           [
             'handles account creation with displayConfirmation',
             { ...ethEoaAccount2 },
             undefined,
             false,
+            undefined,
           ],
           [
             'handles account creation with both accountNameSuggestion and displayConfirmation',
             { ...ethEoaAccount3 },
             'New Account',
+            false,
+            undefined,
+          ],
+          [
+            'handles account creation with both accountNameSuggestion and displayAccountNameDialog',
+            { ...ethEoaAccount4 },
+            'New Account',
+            false,
             false,
           ],
         ])(
@@ -395,6 +415,7 @@ describe('SnapKeyring', () => {
             account,
             accountNameSuggestion,
             displayConfirmation,
+            displayAccountNameDialog,
           ) => {
             // Reset mock
             mockCallbacks.addAccount.mockClear();
@@ -406,6 +427,9 @@ describe('SnapKeyring', () => {
               ...(displayConfirmation !== undefined && { displayConfirmation }),
               ...(accountNameSuggestion !== undefined && {
                 accountNameSuggestion,
+              }),
+              ...(displayAccountNameDialog !== undefined && {
+                displayAccountNameDialog,
               }),
             };
 
@@ -420,6 +444,7 @@ describe('SnapKeyring', () => {
               expect.any(Function),
               accountNameSuggestion,
               displayConfirmation,
+              displayAccountNameDialog,
             );
           },
         );
@@ -649,6 +674,7 @@ describe('SnapKeyring', () => {
           account.address.toLowerCase(),
           snapId,
           expect.any(Function),
+          undefined,
           undefined,
           undefined,
         );

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -402,7 +402,7 @@ describe('SnapKeyring', () => {
             undefined,
           ],
           [
-            'handles account creation with both accountNameSuggestion and displayAccountNameDialog',
+            'handles account creation with both accountNameSuggestion and displayAccountNameSuggestion',
             { ...ethEoaAccount4 },
             'New Account',
             false,
@@ -415,7 +415,7 @@ describe('SnapKeyring', () => {
             account,
             accountNameSuggestion,
             displayConfirmation,
-            displayAccountNameDialog,
+            displayAccountNameSuggestion,
           ) => {
             // Reset mock
             mockCallbacks.addAccount.mockClear();
@@ -428,8 +428,8 @@ describe('SnapKeyring', () => {
               ...(accountNameSuggestion !== undefined && {
                 accountNameSuggestion,
               }),
-              ...(displayAccountNameDialog !== undefined && {
-                displayAccountNameDialog,
+              ...(displayAccountNameSuggestion !== undefined && {
+                displayAccountNameSuggestion,
               }),
             };
 
@@ -444,7 +444,7 @@ describe('SnapKeyring', () => {
               expect.any(Function),
               accountNameSuggestion,
               displayConfirmation,
-              displayAccountNameDialog,
+              displayAccountNameSuggestion,
             );
           },
         );

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -103,7 +103,7 @@ export type SnapKeyringCallbacks = {
     handleUserInput: (accepted: boolean) => Promise<void>,
     accountNameSuggestion?: string,
     displayConfirmation?: boolean,
-    displayAccountNameDialog?: boolean,
+    displayAccountNameSuggestion?: boolean,
   ): Promise<void>;
 
   removeAccount(
@@ -206,7 +206,7 @@ export class SnapKeyring extends EventEmitter {
       account: newAccountFromEvent,
       accountNameSuggestion,
       displayConfirmation,
-      displayAccountNameDialog,
+      displayAccountNameSuggestion,
     } = message.params;
 
     // READ THIS CAREFULLY:
@@ -263,7 +263,7 @@ export class SnapKeyring extends EventEmitter {
       },
       accountNameSuggestion,
       displayConfirmation,
-      displayAccountNameDialog,
+      displayAccountNameSuggestion,
     );
 
     return null;

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -103,6 +103,7 @@ export type SnapKeyringCallbacks = {
     handleUserInput: (accepted: boolean) => Promise<void>,
     accountNameSuggestion?: string,
     displayConfirmation?: boolean,
+    displayAccountNameDialog?: boolean,
   ): Promise<void>;
 
   removeAccount(
@@ -205,6 +206,7 @@ export class SnapKeyring extends EventEmitter {
       account: newAccountFromEvent,
       accountNameSuggestion,
       displayConfirmation,
+      displayAccountNameDialog,
     } = message.params;
 
     // READ THIS CAREFULLY:
@@ -261,6 +263,7 @@ export class SnapKeyring extends EventEmitter {
       },
       accountNameSuggestion,
       displayConfirmation,
+      displayAccountNameDialog,
     );
 
     return null;


### PR DESCRIPTION
## Background

Some preinstalled snaps (such as the institutional snap, and some non EVMs) may need to create accounts non-interactively. Additionally, the profile sync feature might require accounts to be restored without user input.

Users normally are asked to name their snap accounts, but this isn't appropriate where a canonical name exists.

This adds `displayAccountNameDialog` similar to `displayConfirmation`

It's intended that similar logic would be used in the client that is used for displayConfirmation ([extension code](https://github.com/MetaMask/metamask-extension/blob/2ca6b570a3580fa8b7dd18af492e8c1db702d814/app/scripts/lib/snap-keyring/snap-keyring.ts#L208)), i.e. it would default to true, and negation would only be allowed in the case of preinstalled snaps.

## Examples
- Institutional snap gets names from custodians, so users need not be asked to enter names
- The designs for Multi-SRP have the user pick a name for an account as they are choosing the SRP, so before the snap invocation


* Fixes: Jira ticket [https://consensyssoftware.atlassian.net/browse/MMMULTISRP-56](MMMULTISRP-56)
