### PR TITLE
build: bump `ts-bridge` to `0.6.3` (fix some un-exported types)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@metamask/eslint-config-nodejs": "^13.0.0",
     "@metamask/eslint-config-typescript": "^13.0.0",
     "@npmcli/package-json": "^5.0.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "@typescript-eslint/eslint-plugin": "^8.5.0",

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -56,7 +56,7 @@
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-utils": "workspace:^",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "@types/webextension-polyfill": "^0.12.1",

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -56,7 +56,7 @@
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/bip39": "^4.0.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "deepmerge": "^4.2.2",
     "jest": "^29.5.0",

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -63,7 +63,7 @@
     "@ledgerhq/types-live": "^6.52.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/utils": "^11.1.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/hdkey": "^2.0.1",
     "@types/jest": "^29.5.12",

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -55,7 +55,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -59,7 +59,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/hdkey": "^2.0.1",
     "@types/jest": "^29.5.12",

--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -54,7 +54,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-internal-snap-client/package.json
+++ b/packages/keyring-internal-snap-client/package.json
@@ -58,7 +58,7 @@
     "@metamask/snaps-sdk": "^6.16.0",
     "@metamask/snaps-utils": "^8.9.1",
     "@metamask/utils": "^11.1.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -56,7 +56,7 @@
     "@metamask/snaps-controllers": "^9.18.0",
     "@metamask/snaps-sdk": "^6.16.0",
     "@metamask/snaps-utils": "^8.9.1",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -58,7 +58,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/providers": "^19.0.0",
     "@metamask/utils": "^11.1.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -57,7 +57,7 @@
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^19.0.0",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/packages/keyring-utils/package.json
+++ b/packages/keyring-utils/package.json
@@ -54,7 +54,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@ts-bridge/cli": "^0.6.1",
+    "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",
     "deepmerge": "^4.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1461,7 +1461,7 @@ __metadata:
     "@metamask/eslint-config-nodejs": "npm:^13.0.0"
     "@metamask/eslint-config-typescript": "npm:^13.0.0"
     "@npmcli/package-json": "npm:^5.0.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@typescript-eslint/eslint-plugin": "npm:^8.5.0"
@@ -1671,7 +1671,7 @@ __metadata:
     "@metamask/key-tree": "npm:^10.0.2"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     deepmerge: "npm:^4.2.2"
     ethereum-cryptography: "npm:^2.1.2"
@@ -1698,7 +1698,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/ethereumjs-tx": "npm:^1.0.1"
     "@types/hdkey": "npm:^2.0.1"
     "@types/jest": "npm:^29.5.12"
@@ -1766,7 +1766,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/ethereumjs-tx": "npm:^1.0.1"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
@@ -1803,7 +1803,7 @@ __metadata:
     "@metamask/snaps-utils": "npm:^8.9.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/uuid": "npm:^9.0.8"
@@ -1835,7 +1835,7 @@ __metadata:
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@trezor/connect-plugin-ethereum": "npm:^9.0.3"
     "@trezor/connect-web": "npm:^9.1.11"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/ethereumjs-tx": "npm:^1.0.1"
     "@types/hdkey": "npm:^2.0.1"
     "@types/jest": "npm:^29.5.12"
@@ -1916,7 +1916,7 @@ __metadata:
     "@metamask/keyring-utils": "workspace:^"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/webextension-polyfill": "npm:^0.12.1"
@@ -1944,7 +1944,7 @@ __metadata:
     "@metamask/keyring-utils": "workspace:^"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     deepmerge: "npm:^4.2.2"
@@ -1975,7 +1975,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^6.16.0"
     "@metamask/snaps-utils": "npm:^8.9.1"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     deepmerge: "npm:^4.2.2"
@@ -2003,7 +2003,7 @@ __metadata:
     "@metamask/providers": "npm:^19.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/uuid": "npm:^9.0.8"
@@ -2037,7 +2037,7 @@ __metadata:
     "@metamask/snaps-sdk": "npm:^6.16.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     deepmerge: "npm:^4.2.2"
@@ -2066,7 +2066,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.1.0"
-    "@ts-bridge/cli": "npm:^0.6.1"
+    "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     bitcoin-address-validation: "npm:^2.2.3"
@@ -3041,9 +3041,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ts-bridge/cli@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "@ts-bridge/cli@npm:0.6.1"
+"@ts-bridge/cli@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "@ts-bridge/cli@npm:0.6.3"
   dependencies:
     "@ts-bridge/resolver": "npm:^0.2.0"
     chalk: "npm:^5.3.0"
@@ -3054,7 +3054,7 @@ __metadata:
   bin:
     ts-bridge: ./dist/index.js
     tsbridge: ./dist/index.js
-  checksum: 10/1cbb8fbfc7f58b804553ab9bc06b689b409d4cdd0f1e960a0ea87971ec7885b5ee2a86cb192d955c7d3611afcadb960e7dfee66aeca60f798a70e7f97aa969c3
+  checksum: 10/01cba56ff0f097ca0ef15b79cff80a6be07b7f237e7153f63f7a9acf911583d0a410385fa1711d7b14e3a5e95fed63310b6a743700e7ecc0dd3a2d97a0df75b3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR fixes the type issue in `@metamask/eth-simple-keyring` where the TypedTransaction is not being exported. 

Error:
```
TypeError: Cannot destructure property 'TypedTransaction' of '_ethereumjs_tx__WEBPACK_IMPORTED_MODULE_0___default(...)' as it is undefined.
    at ./node_modules/@metamask/eth-simple-keyring/dist/simple-keyring.mjs (http://localhost:6006/vendors-node_modules_metamask_keyring-controller_dist_KeyringController_mjs.iframe.bundle.js:7880:9)`
```