### PR TITLE
refactor!: `SimpleKeyring` uses `@metamask/keyring-utils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ linkStyle default opacity:0.5
   keyring_snap_sdk(["@metamask/keyring-snap-sdk"]);
   keyring_utils(["@metamask/keyring-utils"]);
   keyring_api --> keyring_utils;
+  eth_simple_keyring --> keyring_utils;
   keyring_internal_api --> keyring_api;
   keyring_internal_api --> keyring_utils;
   keyring_internal_snap_client --> keyring_api;

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** The `SimpleKeyring` class now implements `Keyring` from `@metamask/keyring-utils` ([#217](https://github.com/MetaMask/accounts/pull/217))
+  - The `deserialize` method now requires a `string[]` argument
+
 ## [8.1.1]
 
 ### Changed

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** The `SimpleKeyring` class now implements `Keyring` from `@metamask/keyring-utils` ([#217](https://github.com/MetaMask/accounts/pull/217))
-  - The `deserialize` method now requires a `string[]` argument
+  - The `deserialize` method now requires a `string[]` argument.
 
 ## [8.1.1]
 

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -55,6 +55,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/keyring-utils": "workspace:^",
     "@ts-bridge/cli": "^0.6.3",
     "@types/ethereumjs-tx": "^1.0.1",
     "@types/jest": "^29.5.12",

--- a/packages/keyring-eth-simple/src/simple-keyring.test.ts
+++ b/packages/keyring-eth-simple/src/simple-keyring.test.ts
@@ -78,12 +78,12 @@ describe('simple-keyring', function () {
     });
   });
 
-  describe('#deserialize an empty value', function () {
+  describe('#deserialize an empty array', function () {
     it('resets wallets', async function () {
       await keyring.deserialize([testAccount.key]);
       const serialized = await keyring.serialize();
       expect(serialized).toHaveLength(1);
-      await keyring.deserialize(undefined);
+      await keyring.deserialize([]);
       const serialized2 = await keyring.serialize();
       expect(serialized2).toHaveLength(0);
     });

--- a/packages/keyring-eth-simple/src/simple-keyring.ts
+++ b/packages/keyring-eth-simple/src/simple-keyring.ts
@@ -20,7 +20,8 @@ import {
   signTypedData,
   SignTypedDataVersion,
 } from '@metamask/eth-sig-util';
-import { add0x, Eip1024EncryptedData, Hex, Keyring } from '@metamask/utils';
+import { Keyring } from '@metamask/keyring-utils';
+import { add0x, Eip1024EncryptedData, Hex } from '@metamask/utils';
 import { keccak256 } from 'ethereum-cryptography/keccak';
 import randombytes from 'randombytes';
 
@@ -37,7 +38,7 @@ type Wallet = {
 const TYPE = 'Simple Key Pair';
 
 // FIXME: This should not be exported as default.
-export default class SimpleKeyring implements Keyring<string[]> {
+export default class SimpleKeyring implements Keyring {
   #wallets: { privateKey: Buffer; publicKey: Buffer }[];
 
   readonly type: string = TYPE;
@@ -58,7 +59,7 @@ export default class SimpleKeyring implements Keyring<string[]> {
     return this.#wallets.map((a) => a.privateKey.toString('hex'));
   }
 
-  async deserialize(privateKeys: string[] = []): Promise<void> {
+  async deserialize(privateKeys: string[]): Promise<void> {
     this.#wallets = privateKeys.map((hexPrivateKey) => {
       const strippedHexPrivateKey = stripHexPrefix(hexPrivateKey);
       const privateKey = Buffer.from(strippedHexPrivateKey, 'hex');

--- a/packages/keyring-eth-simple/tsconfig.build.json
+++ b/packages/keyring-eth-simple/tsconfig.build.json
@@ -6,6 +6,11 @@
     "rootDir": "src",
     "target": "es2020"
   },
+  "references": [
+    {
+      "path": "../keyring-utils/tsconfig.build.json"
+    }
+  ],
   "include": ["./src/**/*.ts"],
   "exclude": ["./src/**/*.test.ts", "./src/sample.ts"]
 }

--- a/packages/keyring-eth-simple/tsconfig.json
+++ b/packages/keyring-eth-simple/tsconfig.json
@@ -5,7 +5,7 @@
   },
   "references": [
     { "path": "../keyring-utils" }
-  ]
+  ],
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }

--- a/packages/keyring-eth-simple/tsconfig.json
+++ b/packages/keyring-eth-simple/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
-  "references": [
-    { "path": "../keyring-utils" }
-  ],
+  "references": [{ "path": "../keyring-utils" }],
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }

--- a/packages/keyring-eth-simple/tsconfig.json
+++ b/packages/keyring-eth-simple/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "baseUrl": "./"
   },
+  "references": [
+    { "path": "../keyring-utils" }
+  ]
   "include": ["./src"],
   "exclude": ["./dist/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1765,6 +1765,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/keyring-utils": "workspace:^"
     "@metamask/utils": "npm:^11.1.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/ethereumjs-tx": "npm:^1.0.1"


### PR DESCRIPTION
- **BREAKING:** The `SimpleKeyring` class now implements `Keyring` from `@metamask/keyring-utils` ([#217](https://github.com/MetaMask/accounts/pull/217))
  - The `deserialize` method now requires a `string[]` argument
