### PR TITLE
feat(keyring-api): add `swap` transaction type

### DIFF
--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -134,6 +134,12 @@ export enum TransactionType {
    * another account.
    */
   Receive = 'receive',
+
+  /**
+   * The transaction is a swap. It decreases the balance of one asset and
+   * increases the balance of another asset in a single transaction.
+   */
+  Swap = 'swap',
 }
 
 /**

--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -138,6 +138,8 @@ export enum TransactionType {
   /**
    * The transaction is a swap. It decreases the balance of one asset and
    * increases the balance of another asset in a single transaction.
+   *
+   * A swap transaction must be originated by the account.
    */
   Swap = 'swap',
 }


### PR DESCRIPTION
This PR adds the `swap` transaction type. It is up to the Snap to determine whether a transaction is a swap. The main goal of marking a transaction as a swap is to enable the client to display such transactions in a more meaningful way.