### PR TITLE
test(keyring-eth-hd): use bigger timeout for flaky test

### DIFF
--- a/packages/keyring-eth-hd/test/index.test.ts
+++ b/packages/keyring-eth-hd/test/index.test.ts
@@ -50,33 +50,40 @@ const getAddressAtIndex = (keyring: HdKeyring, index: number): Hex => {
 
 describe('hd-keyring', () => {
   describe('compare old bip39 implementation with new', () => {
-    it('should derive the same accounts from the same mnemonics', async () => {
-      const mnemonics: Buffer[] = [];
-      for (let i = 0; i < 99; i++) {
-        mnemonics.push(oldMMForkBIP39.generateMnemonic());
-      }
+    // NOTE: This test sometimes exceed the default 2s timeout on the CI, making this test
+    // a bit flaky. We just increase its timeout value to avoid the flakiness.
+    const timeout = 3000;
+    it(
+      'should derive the same accounts from the same mnemonics',
+      async () => {
+        const mnemonics: Buffer[] = [];
+        for (let i = 0; i < 99; i++) {
+          mnemonics.push(oldMMForkBIP39.generateMnemonic());
+        }
 
-      await Promise.all(
-        mnemonics.map(async (mnemonic) => {
-          const newHDKeyring = new HdKeyring();
-          await newHDKeyring.deserialize({
-            mnemonic,
-            numberOfAccounts: 3,
-          });
-          const oldHDKeyring = new OldHdKeyring({
-            mnemonic,
-            numberOfAccounts: 3,
-          });
-          const newAccounts = newHDKeyring.getAccounts();
-          const oldAccounts = await oldHDKeyring.getAccounts();
-          expect(newAccounts[0]).toStrictEqual(oldAccounts[0]);
+        await Promise.all(
+          mnemonics.map(async (mnemonic) => {
+            const newHDKeyring = new HdKeyring();
+            await newHDKeyring.deserialize({
+              mnemonic,
+              numberOfAccounts: 3,
+            });
+            const oldHDKeyring = new OldHdKeyring({
+              mnemonic,
+              numberOfAccounts: 3,
+            });
+            const newAccounts = newHDKeyring.getAccounts();
+            const oldAccounts = await oldHDKeyring.getAccounts();
+            expect(newAccounts[0]).toStrictEqual(oldAccounts[0]);
 
-          expect(newAccounts[1]).toStrictEqual(oldAccounts[1]);
+            expect(newAccounts[1]).toStrictEqual(oldAccounts[1]);
 
-          expect(newAccounts[2]).toStrictEqual(oldAccounts[2]);
-        }),
-      );
-    });
+            expect(newAccounts[2]).toStrictEqual(oldAccounts[2]);
+          }),
+        );
+      },
+      timeout,
+    );
   });
 
   describe('re-initialization protection', () => {


### PR DESCRIPTION
One of the test for the HD keyring is a long-running one, and it sometimes make the CI fails:
- https://github.com/MetaMask/accounts/commit/4f0115dc27245f0183517a2cf092acaa5ad5c79b
- https://github.com/MetaMask/accounts/actions/runs/13419393891/job/37488188415

To avoid flakiness, we just increase the timeout.

We could also update the test itself, but I think this makes sense to go with the timeout option for now.