### PR TITLE
refactor(keyring-internal-api)!: use `Keyring` from `keyring-utils`

### DIFF
--- a/packages/keyring-internal-api/CHANGELOG.md
+++ b/packages/keyring-internal-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `EthKeyring` now extends the `Keyring` type from `@metamask/keyring-utils` instead of `Keyring<Json>` from `@metamask/utils` ([#226](https://github.com/MetaMask/accounts/pull/226))
+
 ## [4.0.3]
 
 ### Changed

--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -47,8 +47,7 @@
   "dependencies": {
     "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-utils": "workspace:^",
-    "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.1.0"
+    "@metamask/superstruct": "^3.1.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",

--- a/packages/keyring-internal-api/src/eth/EthKeyring.ts
+++ b/packages/keyring-internal-api/src/eth/EthKeyring.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-redundant-type-constituents */
+
 import type {
   KeyringExecutionContext,
   EthBaseTransaction,

--- a/packages/keyring-internal-api/src/eth/EthKeyring.ts
+++ b/packages/keyring-internal-api/src/eth/EthKeyring.ts
@@ -5,9 +5,9 @@ import type {
   EthUserOperation,
   EthUserOperationPatch,
 } from '@metamask/keyring-api';
-import type { Json, Keyring } from '@metamask/utils';
+import type { Keyring } from '@metamask/keyring-utils';
 
-export type EthKeyring<State extends Json> = Keyring<State> & {
+export type EthKeyring = Keyring & {
   /**
    * Convert a base transaction to a base UserOperation.
    *

--- a/packages/keyring-internal-api/tsconfig.build.json
+++ b/packages/keyring-internal-api/tsconfig.build.json
@@ -8,6 +8,9 @@
   "references": [
     {
       "path": "../keyring-api/tsconfig.build.json"
+    },
+    {
+      "path": "../keyring-utils/tsconfig.build.json"
     }
   ],
   "include": ["./src/**/*.ts"],

--- a/packages/keyring-internal-api/tsconfig.json
+++ b/packages/keyring-internal-api/tsconfig.json
@@ -8,7 +8,7 @@
       "path": "../keyring-api/tsconfig.build.json"
     },
     {
-      "path": "../keyring-utils"
+      "path": "../keyring-utils/tsconfig.build.json"
     }
   ],
   "include": ["./src"],

--- a/packages/keyring-internal-api/tsconfig.json
+++ b/packages/keyring-internal-api/tsconfig.json
@@ -6,6 +6,9 @@
   "references": [
     {
       "path": "../keyring-api/tsconfig.build.json"
+    },
+    {
+      "path": "../keyring-utils"
     }
   ],
   "include": ["./src"],

--- a/packages/keyring-internal-api/tsconfig.json
+++ b/packages/keyring-internal-api/tsconfig.json
@@ -5,10 +5,10 @@
   },
   "references": [
     {
-      "path": "../keyring-api/tsconfig.build.json"
+      "path": "../keyring-api"
     },
     {
-      "path": "../keyring-utils/tsconfig.build.json"
+      "path": "../keyring-utils"
     }
   ],
   "include": ["./src"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,7 +1947,6 @@ __metadata:
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-utils": "workspace:^"
     "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/utils": "npm:^11.1.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

The `Keyring<Json>` from `@metamask/utils` has been deprecated in favor of `Keyring` from `@metamask/keyring-utils`. This PR changes the type extended by `EthKeyring` with the new one

