### PR TITLE
fix(keyring-utils): fix missing export for `isScope{Equal,EqualToAny}`

### DIFF
--- a/packages/keyring-utils/src/index.ts
+++ b/packages/keyring-utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './btc';
 export * from './types';
 export * from './typing';
+export * from './scopes';
 export * from './superstruct';
 export * from './JsonRpcRequest';
 export type * from './keyring';

--- a/packages/keyring-utils/src/scopes.test.ts
+++ b/packages/keyring-utils/src/scopes.test.ts
@@ -1,4 +1,4 @@
-import { isScopeEqual, isScopeEqualToAny } from './scopes';
+import { isScopeEqual, isScopeEqualToAny } from '.';
 
 const ETH_EOA = 'eip155:0';
 const ETH_MAINNET = 'eip155:1';


### PR DESCRIPTION
Missing exports.