### PR TITLE
fix(keyring-api): fix missing `Transaction.status` for `'swap'`

### DIFF
--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -258,7 +258,11 @@ export const TransactionStruct = object({
    * Transaction type {@see TransactionType}. This will be used by MetaMask to enrich the transaction
    * details on the UI.
    */
-  type: enums([`${TransactionType.Send}`, `${TransactionType.Receive}`]),
+  type: enums([
+    `${TransactionType.Send}`,
+    `${TransactionType.Receive}`,
+    `${TransactionType.Swap}`,
+  ]),
 
   /**
    * Transaction sender addresses and amounts.


### PR DESCRIPTION
We forgot to add this into the struct itself.