### PR TITLE
feat(keyring-snap-sdk): add UNIX timestamp helpers

### DIFF
--- a/packages/keyring-snap-sdk/src/index.ts
+++ b/packages/keyring-snap-sdk/src/index.ts
@@ -1,2 +1,3 @@
 export * from './rpc-handler';
 export * from './snap-utils';
+export * from './time';

--- a/packages/keyring-snap-sdk/src/time.test.ts
+++ b/packages/keyring-snap-sdk/src/time.test.ts
@@ -1,0 +1,31 @@
+import { getCurrentUnixTimestamp, toUnixTimestamp } from './time';
+
+describe('time', () => {
+  describe('toUnixTimestamp', () => {
+    it.each([
+      ['1970-01-01', 0],
+      ['1970-01-02', 24 * 60 * 60],
+    ])('converts a Date object to a UNIX timestamp', (format, timestamp) => {
+      const date = new Date(format);
+
+      expect(toUnixTimestamp(date)).toBe(timestamp);
+    });
+  });
+
+  describe('getCurrentTimestamp', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('converts the current time to its equivalent UNIX timestamp', () => {
+      const seconds = 17;
+
+      jest.setSystemTime(seconds * 1000); // ms
+      expect(getCurrentUnixTimestamp()).toBe(seconds);
+    });
+  });
+});

--- a/packages/keyring-snap-sdk/src/time.ts
+++ b/packages/keyring-snap-sdk/src/time.ts
@@ -1,0 +1,18 @@
+/**
+ * Convert a date to its UNIX timestamp equivalent.
+ *
+ * @param date - The date object to convert.
+ * @returns A UNIX timestamp.
+ */
+export function toUnixTimestamp(date: Date): number {
+  return Math.floor(date.getTime() / 1000);
+}
+
+/**
+ * Get the current UNIX timestamp.
+ *
+ * @returns The current UNIX timestamp.
+ */
+export function getCurrentUnixTimestamp(): number {
+  return toUnixTimestamp(new Date());
+}


### PR DESCRIPTION
Some of our methods/handlers requires a UNIX timestamp, so adding those helpers to avoid having doing manual conversions in the Snaps themselves.
