### PR TITLE
refactor(keyring-snap-bridge)!: remove `saveState` from callbacks + use events for `account{Created,Updated,Deleted}`

### DIFF
--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -71,6 +71,8 @@ export const AccountCreatedEventStruct = object({
     displayAccountNameSuggestion: exactOptional(boolean()),
   }),
 });
+export type AccountCreatedEvent = Infer<typeof AccountCreatedEventStruct>;
+export type AccountCreatedEventPayload = AccountCreatedEvent['params'];
 
 export const AccountUpdatedEventStruct = object({
   method: literal(`${KeyringEvent.AccountUpdated}`),
@@ -81,6 +83,8 @@ export const AccountUpdatedEventStruct = object({
     account: KeyringAccountStruct,
   }),
 });
+export type AccountUpdatedEvent = Infer<typeof AccountUpdatedEventStruct>;
+export type AccountUpdatedEventPayload = AccountUpdatedEvent['params'];
 
 export const AccountDeletedEventStruct = object({
   method: literal(`${KeyringEvent.AccountDeleted}`),
@@ -91,6 +95,8 @@ export const AccountDeletedEventStruct = object({
     id: UuidStruct,
   }),
 });
+export type AccountDeletedEvent = Infer<typeof AccountDeletedEventStruct>;
+export type AccountDeletedEventPayload = AccountDeletedEvent['params'];
 
 export const RequestApprovedEventStruct = object({
   method: literal(`${KeyringEvent.RequestApproved}`),

--- a/packages/keyring-snap-bridge/src/SnapKeyringMessenger.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringMessenger.ts
@@ -1,5 +1,8 @@
 import type { RestrictedMessenger } from '@metamask/base-controller';
 import type {
+  AccountCreatedEventPayload,
+  AccountUpdatedEventPayload,
+  AccountDeletedEventPayload,
   AccountAssetListUpdatedEventPayload,
   AccountBalancesUpdatedEventPayload,
   AccountTransactionsUpdatedEventPayload,
@@ -9,6 +12,21 @@ import type { HandleSnapRequest, GetSnap } from '@metamask/snaps-controllers';
 export type SnapKeyringGetAccountsAction = {
   type: `SnapKeyring:getAccounts`;
   handler: () => string[];
+};
+
+export type SnapKeyringAccountCreatedEvent = {
+  type: `SnapKeyring:accountCreated`;
+  payload: [AccountCreatedEventPayload];
+};
+
+export type SnapKeyringAccountUpdatedEvent = {
+  type: `SnapKeyring:accountUpdated`;
+  payload: [AccountUpdatedEventPayload];
+};
+
+export type SnapKeyringAccountDeletedEvent = {
+  type: `SnapKeyring:accountDeleted`;
+  payload: [AccountDeletedEventPayload];
 };
 
 export type SnapKeyringAccountBalancesUpdatedEvent = {
@@ -27,6 +45,9 @@ export type SnapKeyringAccountTransactionsUpdatedEvent = {
 };
 
 export type SnapKeyringEvents =
+  | SnapKeyringAccountCreatedEvent
+  | SnapKeyringAccountUpdatedEvent
+  | SnapKeyringAccountDeletedEvent
   | SnapKeyringAccountAssetListUpdatedEvent
   | SnapKeyringAccountBalancesUpdatedEvent
   | SnapKeyringAccountTransactionsUpdatedEvent;


### PR DESCRIPTION
TODO