### PR TITLE
feat(keyring-eth-hd): store mnemonic seed in `HdKeyring` class

### DIFF
--- a/packages/keyring-eth-hd/src/hd-keyring.test.ts
+++ b/packages/keyring-eth-hd/src/hd-keyring.test.ts
@@ -19,9 +19,12 @@ import {
   type MessageTypes,
   type EIP7702Authorization,
 } from '@metamask/eth-sig-util';
+import { mnemonicPhraseToBytes } from '@metamask/key-tree';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { assert, bytesToHex, hexToBytes, type Hex } from '@metamask/utils';
 import { webcrypto } from 'crypto';
+// eslint-disable-next-line n/no-sync
+import { mnemonicToSeedSync } from 'ethereum-cryptography/bip39';
 import { keccak256 } from 'ethereum-cryptography/keccak';
 // eslint-disable-next-line @typescript-eslint/naming-convention
 import OldHdKeyring from 'old-hd-keyring';
@@ -36,6 +39,10 @@ const sampleMnemonic =
   'finish oppose decorate face calm tragic certain desk hour urge dinosaur mango';
 const firstAcct = '0x1c96099350f13d558464ec79b9be4445aa0ef579';
 const secondAcct = '0x1b00aed43a693f3a957f9feb5cc08afa031e37a0';
+
+const sampleMnemonicBytes = mnemonicPhraseToBytes(sampleMnemonic);
+// eslint-disable-next-line n/no-sync
+const sampleMnemonicSeed = mnemonicToSeedSync(sampleMnemonic);
 
 const notKeyringAddress = '0xbD20F6F5F1616947a39E11926E78ec94817B3931';
 
@@ -175,6 +182,8 @@ describe('hd-keyring', () => {
       const accounts = keyring.getAccounts();
       expect(accounts[0]).toStrictEqual(firstAcct);
       expect(accounts[1]).toStrictEqual(secondAcct);
+      expect(keyring.mnemonic).toStrictEqual(sampleMnemonicBytes);
+      expect(keyring.seed).toStrictEqual(sampleMnemonicSeed);
     });
 
     it('deserializes with a typeof buffer mnemonic', async () => {
@@ -188,6 +197,8 @@ describe('hd-keyring', () => {
       const accounts = keyring.getAccounts();
       expect(accounts[0]).toStrictEqual(firstAcct);
       expect(accounts[1]).toStrictEqual(secondAcct);
+      expect(keyring.mnemonic).toStrictEqual(sampleMnemonicBytes);
+      expect(keyring.seed).toStrictEqual(sampleMnemonicSeed);
     });
 
     it('deserializes with a typeof Uint8Array mnemonic', async () => {
@@ -207,6 +218,8 @@ describe('hd-keyring', () => {
       const accounts = keyring.getAccounts();
       expect(accounts[0]).toStrictEqual(firstAcct);
       expect(accounts[1]).toStrictEqual(secondAcct);
+      expect(keyring.mnemonic).toStrictEqual(sampleMnemonicBytes);
+      expect(keyring.seed).toStrictEqual(sampleMnemonicSeed);
     });
 
     it('deserializes using custom cryptography', async () => {
@@ -251,6 +264,8 @@ describe('hd-keyring', () => {
       const accounts = keyring.getAccounts();
       expect(accounts[0]).toStrictEqual(firstAcct);
       expect(accounts[1]).toStrictEqual(secondAcct);
+      expect(keyring.mnemonic).toStrictEqual(sampleMnemonicBytes);
+      expect(keyring.seed).toStrictEqual(sampleMnemonicSeed);
       expect(cryptographicFunctions.pbkdf2Sha512).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/keyring-eth-hd/src/hd-keyring.ts
+++ b/packages/keyring-eth-hd/src/hd-keyring.ts
@@ -90,6 +90,8 @@ export class HdKeyring {
 
   mnemonic?: Uint8Array | null;
 
+  seed?: Uint8Array | null;
+
   root?: HDKey | null;
 
   hdWallet?: HDKey;
@@ -588,12 +590,12 @@ export class HdKeyring {
 
     this.mnemonic = this.#mnemonicToUint8Array(mnemonic);
 
-    const seed = await mnemonicToSeed(
+    this.seed = await mnemonicToSeed(
       this.mnemonic,
       '', // No passphrase
       this.#cryptographicFunctions,
     );
-    this.hdWallet = HDKey.fromMasterSeed(seed);
+    this.hdWallet = HDKey.fromMasterSeed(this.seed);
     this.root = this.hdWallet.derive(this.hdPath);
   }
 

--- a/packages/keyring-eth-hd/src/hd-keyring.ts
+++ b/packages/keyring-eth-hd/src/hd-keyring.ts
@@ -156,6 +156,7 @@ export class HdKeyring {
     }
     this.#wallets = [];
     this.mnemonic = null;
+    this.seed = null;
     this.root = null;
     this.hdPath = opts.hdPath ?? hdPathString;
 


### PR DESCRIPTION
Store the computed mnemonic seed in the `HdKeyring` class which allows it to be re-used by other parts of MetaMask doing key derivation on compatible curves.

This will unlock some performance improvements in the Snaps platform that currently uses the mnemonic and recomputes the seed for key derivation.