### PR TITLE
fix(keyring-snap-bridge): filter invalid accounts from `SnapKeyring:account*Updated` events

### DIFF
--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -579,7 +579,7 @@ describe('SnapKeyring', () => {
         });
         expect(mockPublishedEventCallback).toHaveBeenCalledWith(event);
         expect(consoleSpy).toHaveBeenCalledWith(
-          `SnapKeyring - ${KeyringEvent.AccountBalancesUpdated} - Found an unknown account ID "${unknownAccount.id}" for Snap ID "${snapId}". Skipping.`,
+          `SnapKeyring - SnapKeyring:accountBalancesUpdated - Found an unknown account ID "${unknownAccount.id}" for Snap ID "${snapId}". Skipping.`,
         );
       });
 
@@ -697,7 +697,7 @@ describe('SnapKeyring', () => {
         });
         expect(mockPublishedEventCallback).toHaveBeenCalledWith(event);
         expect(consoleSpy).toHaveBeenCalledWith(
-          `SnapKeyring - ${KeyringEvent.AccountTransactionsUpdated} - Found an unknown account ID "${unknownAccount.id}" for Snap ID "${snapId}". Skipping.`,
+          `SnapKeyring - SnapKeyring:accountTransactionsUpdated - Found an unknown account ID "${unknownAccount.id}" for Snap ID "${snapId}". Skipping.`,
         );
       });
 
@@ -757,7 +757,7 @@ describe('SnapKeyring', () => {
         });
         expect(mockPublishedEventCallback).toHaveBeenCalledWith(event);
         expect(consoleSpy).toHaveBeenCalledWith(
-          `SnapKeyring - ${KeyringEvent.AccountAssetListUpdated} - Found an unknown account ID "${unknownAccount.id}" for Snap ID "${snapId}". Skipping.`,
+          `SnapKeyring - SnapKeyring:accountAssetListUpdated - Found an unknown account ID "${unknownAccount.id}" for Snap ID "${snapId}". Skipping.`,
         );
       });
 


### PR DESCRIPTION
The Snap keyring re-publishes some Snap events and most of those events use a mapping between an "account ID" and the event info/data.

Currently, we are not checking that those "account IDs" belongs to the Snap that fires the events. There are 2 problems with this:
1. A Snap could be using an invalid account ID (or an ID that it does not own) and send some wrong data for that account
2. There could be some race-conditions where an event is being sent by the Snap for an account that no longer exists
  - This one is partially the Snap's fault, but we might want to have some guard around this logic to prevent firing those events to some other controllers (which will result in even more errors)