### PR TITLE
feat!: add `SnapKeyring.createAccount` + internal options

### DIFF
--- a/packages/keyring-api/src/api/index.ts
+++ b/packages/keyring-api/src/api/index.ts
@@ -8,4 +8,5 @@ export * from './request';
 export * from './response';
 export * from './transaction';
 export * from './pagination';
+export * from './options';
 export type * from './keyring';

--- a/packages/keyring-api/src/api/keyring.ts
+++ b/packages/keyring-api/src/api/keyring.ts
@@ -9,6 +9,7 @@ import type { ResolvedAccountAddress } from './address';
 import type { Balance } from './balance';
 import type { CaipChainId, CaipAssetType, CaipAssetTypeOrId } from './caip';
 import type { KeyringAccountData } from './export';
+import type { InternalOptions } from './options';
 import type { Paginated, Pagination } from './pagination';
 import type { KeyringRequest } from './request';
 import type { KeyringResponse } from './response';
@@ -47,11 +48,14 @@ export type Keyring = {
    *
    * Creates a new account with optional, keyring-defined, account options.
    *
-   * @param options - Keyring-defined options for the account (optional).
+   * @param options - Keyring-defined options for the account (optional). The
+   * 'metamask' internal options needs to be re-emitted during `notify:*` events.
    * @returns A promise that resolves to the newly created KeyringAccount
    * object without any private information.
    */
-  createAccount(options?: Record<string, Json>): Promise<KeyringAccount>;
+  createAccount(
+    options?: Record<string, Json> & InternalOptions,
+  ): Promise<KeyringAccount>;
 
   /**
    * Lists the assets of an account (fungibles and non-fungibles) represented

--- a/packages/keyring-api/src/api/keyring.ts
+++ b/packages/keyring-api/src/api/keyring.ts
@@ -9,7 +9,7 @@ import type { ResolvedAccountAddress } from './address';
 import type { Balance } from './balance';
 import type { CaipChainId, CaipAssetType, CaipAssetTypeOrId } from './caip';
 import type { KeyringAccountData } from './export';
-import type { InternalOptions } from './options';
+import type { MetaMaskOptions } from './options';
 import type { Paginated, Pagination } from './pagination';
 import type { KeyringRequest } from './request';
 import type { KeyringResponse } from './response';
@@ -54,7 +54,7 @@ export type Keyring = {
    * object without any private information.
    */
   createAccount(
-    options?: Record<string, Json> & InternalOptions,
+    options?: Record<string, Json> & MetaMaskOptions,
   ): Promise<KeyringAccount>;
 
   /**

--- a/packages/keyring-api/src/api/options.ts
+++ b/packages/keyring-api/src/api/options.ts
@@ -1,0 +1,19 @@
+import { exactOptional, object, UuidStruct } from '@metamask/keyring-utils';
+import type { Infer } from '@metamask/superstruct';
+
+export const InternalOptionsStruct = object({
+  /**
+   * MetaMask internal options. The 'metamask' field will only be set when
+   * the keyring API is being used by a MetaMask client.
+   */
+  metamask: exactOptional(
+    object({
+      /**
+       * Correlation ID that can be passed by MetaMask.
+       */
+      correlationId: UuidStruct,
+    }),
+  ),
+});
+
+export type InternalOptions = Infer<typeof InternalOptionsStruct>;

--- a/packages/keyring-api/src/api/options.ts
+++ b/packages/keyring-api/src/api/options.ts
@@ -1,7 +1,7 @@
 import { exactOptional, object, UuidStruct } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 
-export const InternalOptionsStruct = object({
+export const MetaMaskOptionsStruct = object({
   /**
    * MetaMask internal options. The 'metamask' field will only be set when
    * the keyring API is being used by a MetaMask client.
@@ -16,4 +16,4 @@ export const InternalOptionsStruct = object({
   ),
 });
 
-export type InternalOptions = Infer<typeof InternalOptionsStruct>;
+export type MetaMaskOptions = Infer<typeof MetaMaskOptionsStruct>;

--- a/packages/keyring-api/src/events.test.ts
+++ b/packages/keyring-api/src/events.test.ts
@@ -48,26 +48,6 @@ describe('events', () => {
 
       expect(is(event, AccountCreatedEventStruct)).toBe(false);
     });
-
-    it('should be a valid accountCreated event with displayConfirmation', () => {
-      const event = {
-        method: KeyringEvent.AccountCreated,
-        params: {
-          account: {
-            id: '11027d05-12f8-4ec0-b03f-151d86a8089e',
-            address: '0x0123',
-            methods: [],
-            options: {},
-            scopes: [EthScope.Eoa],
-            type: EthAccountType.Eoa,
-          },
-          displayConfirmation: true,
-          displayAccountNameSuggestion: true,
-        },
-      };
-
-      expect(is(event, AccountCreatedEventStruct)).toBe(true);
-    });
   });
 
   describe('AccountUpdatedEventStruct', () => {

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -16,7 +16,7 @@ import {
   FungibleAssetAmountStruct,
   KeyringAccountStruct,
   TransactionStruct,
-  InternalOptionsStruct,
+  MetaMaskOptionsStruct,
 } from './api';
 
 /**
@@ -78,7 +78,7 @@ export const AccountCreatedEventStruct = object({
     /**
      * Metamask internal options.
      */
-    ...InternalOptionsStruct.schema,
+    ...MetaMaskOptionsStruct.schema,
   }),
 });
 

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -5,7 +5,7 @@ import {
   AccountIdStruct,
 } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
-import { array, boolean, literal, record, string } from '@metamask/superstruct';
+import { array, literal, record, string } from '@metamask/superstruct';
 import {
   CaipAssetTypeStruct,
   CaipAssetTypeOrIdStruct,
@@ -16,6 +16,7 @@ import {
   FungibleAssetAmountStruct,
   KeyringAccountStruct,
   TransactionStruct,
+  InternalOptionsStruct,
 } from './api';
 
 /**
@@ -55,20 +56,9 @@ export const AccountCreatedEventStruct = object({
     accountNameSuggestion: exactOptional(string()),
 
     /**
-     * Instructs MetaMask to display the add account confirmation dialog in the UI.
-     * **Note:** This is not guaranteed to be honored by the MetaMask client.
+     * Metamask internal options.
      */
-    displayConfirmation: exactOptional(boolean()),
-
-    /**
-     * Instructs MetaMask to display the name confirmation dialog in the UI.
-     * Otherwise, the account will be added with the suggested name, if it's not
-     * already in use; if it is, a suffix will be appended to the name to make it
-     * unique.
-     *
-     * **Note:** This is not guaranteed to be honored by the MetaMask client.
-     */
-    displayAccountNameSuggestion: exactOptional(boolean()),
+    ...InternalOptionsStruct.schema,
   }),
 });
 

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -5,7 +5,7 @@ import {
   AccountIdStruct,
 } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
-import { array, literal, record, string } from '@metamask/superstruct';
+import { array, boolean, literal, record, string } from '@metamask/superstruct';
 import {
   CaipAssetTypeStruct,
   CaipAssetTypeOrIdStruct,
@@ -54,6 +54,26 @@ export const AccountCreatedEventStruct = object({
      * client decides to use a different name.
      */
     accountNameSuggestion: exactOptional(string()),
+
+    /**
+     * Instructs MetaMask to display the add account confirmation dialog in the UI.
+     * **Note:** This is not guaranteed to be honored by the MetaMask client.
+     *
+     * @deprecated No longer used, see {@link InternalOptions} instead.
+     */
+    displayConfirmation: exactOptional(boolean()),
+
+    /**
+     * Instructs MetaMask to display the name confirmation dialog in the UI.
+     * Otherwise, the account will be added with the suggested name, if it's not
+     * already in use; if it is, a suffix will be appended to the name to make it
+     * unique.
+     *
+     * **Note:** This is not guaranteed to be honored by the MetaMask client.
+     *
+     * @deprecated No longer used, see {@link InternalOptions} instead.
+     */
+    displayAccountNameSuggestion: exactOptional(boolean()),
 
     /**
      * Metamask internal options.

--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -5,7 +5,7 @@ import {
   AccountIdStruct,
 } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
-import { array, boolean, literal, record, string } from '@metamask/superstruct';
+import { array, literal, record, string } from '@metamask/superstruct';
 import {
   CaipAssetTypeStruct,
   CaipAssetTypeOrIdStruct,
@@ -54,26 +54,6 @@ export const AccountCreatedEventStruct = object({
      * client decides to use a different name.
      */
     accountNameSuggestion: exactOptional(string()),
-
-    /**
-     * Instructs MetaMask to display the add account confirmation dialog in the UI.
-     * **Note:** This is not guaranteed to be honored by the MetaMask client.
-     *
-     * @deprecated No longer used, see {@link InternalOptions} instead.
-     */
-    displayConfirmation: exactOptional(boolean()),
-
-    /**
-     * Instructs MetaMask to display the name confirmation dialog in the UI.
-     * Otherwise, the account will be added with the suggested name, if it's not
-     * already in use; if it is, a suffix will be appended to the name to make it
-     * unique.
-     *
-     * **Note:** This is not guaranteed to be honored by the MetaMask client.
-     *
-     * @deprecated No longer used, see {@link InternalOptions} instead.
-     */
-    displayAccountNameSuggestion: exactOptional(boolean()),
 
     /**
      * Metamask internal options.

--- a/packages/keyring-snap-bridge/src/SnapIdMap.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapIdMap.test.ts
@@ -97,6 +97,30 @@ describe('SnapIdMap', () => {
     });
   });
 
+  describe('pop', () => {
+    it('returns undefined when the key is not in the map', () => {
+      const map = new SnapIdMap<{ snapId: SnapId; value: number }>();
+      const value = map.pop(SNAP_1_ID, 'foo');
+      expect(value).toBeUndefined();
+    });
+
+    it('returns undefined when the snapId does not match', () => {
+      const map = new SnapIdMap<{ snapId: SnapId; value: number }>();
+      map.set('foo', { snapId: SNAP_1_ID, value: 1 });
+      const value = map.pop(SNAP_2_ID, 'foo');
+      expect(value).toBeUndefined();
+    });
+
+    it('returns the value when the snapId matches', () => {
+      const map = new SnapIdMap<{ snapId: SnapId; value: number }>();
+      map.set('foo', { snapId: SNAP_1_ID, value: 1 });
+      expect(map.has(SNAP_1_ID, 'foo')).toBe(true);
+      const value = map.pop(SNAP_1_ID, 'foo');
+      expect(value).toStrictEqual({ snapId: SNAP_1_ID, value: 1 });
+      expect(map.has(SNAP_1_ID, 'foo')).toBe(false);
+    });
+  });
+
   describe('hasSnapId', () => {
     it('returns false when the snapId is not in the map', () => {
       const map = new SnapIdMap<{ snapId: SnapId; value: number }>();

--- a/packages/keyring-snap-bridge/src/SnapIdMap.ts
+++ b/packages/keyring-snap-bridge/src/SnapIdMap.ts
@@ -154,10 +154,7 @@ export class SnapIdMap<Value extends { snapId: SnapId }> {
    */
   pop(snapId: SnapId, key: string): Value | undefined {
     const value = this.get(snapId, key);
-
-    if (value !== undefined) {
-      this.delete(snapId, key);
-    }
+    this.delete(snapId, key);
     return value;
   }
 

--- a/packages/keyring-snap-bridge/src/SnapIdMap.ts
+++ b/packages/keyring-snap-bridge/src/SnapIdMap.ts
@@ -133,6 +133,35 @@ export class SnapIdMap<Value extends { snapId: SnapId }> {
   }
 
   /**
+   * Gets and delete a value from the map.
+   *
+   * If the given key is not present in the map or the Snap ID of the value is
+   * different from the given Snap ID, returns `undefined`.
+   *
+   * Example:
+   *
+   * ```ts
+   * const map = new SnapIdMap();
+   * map.set('foo', { snapId: '1', name: 'foo' });
+   * map.pop('1', 'foo'); // Returns { snapId: '1', name: 'foo' }
+   * map.pop('1', 'foo'); // Returns `undefined` (already returned and deleted)
+   * map.pop('1', 'bar'); // Returns `undefined`
+   * ```
+   *
+   * @param snapId - Snap ID present in the value to get.
+   * @param key - Key of the element to get.
+   * @returns The value associated with the given key and Snap ID.
+   */
+  pop(snapId: SnapId, key: string): Value | undefined {
+    const value = this.get(snapId, key);
+
+    if (value !== undefined) {
+      this.delete(snapId, key);
+    }
+    return value;
+  }
+
+  /**
    * Checks if a key is present in the map.
    *
    * If the given key is not present in the map or the Snap ID of the value is

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -10,7 +10,7 @@ import type {
   AccountBalancesUpdatedEventPayload,
   AccountTransactionsUpdatedEventPayload,
   AccountAssetListUpdatedEventPayload,
-  InternalOptions,
+  MetaMaskOptions,
 } from '@metamask/keyring-api';
 import {
   EthScope,
@@ -2150,7 +2150,7 @@ describe('SnapKeyring', () => {
           // When using `createAccount` through the Snap keyring, some internal options context
           // will be injected into the params (with the `metamask` key), so we expect to have
           // them to be defined.
-          const params = request.params.options as InternalOptions;
+          const params = request.params.options as MetaMaskOptions;
           expect(params.metamask).toBeDefined();
           expect(params.metamask?.correlationId).toBeDefined();
 
@@ -2165,7 +2165,7 @@ describe('SnapKeyring', () => {
               // to be able to map the internal options.
               // NOTE: It's safe to use type cast, since we have already checked that
               // params.metamask is defined!
-              metamask: params.metamask as InternalOptions,
+              metamask: params.metamask as MetaMaskOptions,
             },
           });
 
@@ -2190,7 +2190,7 @@ describe('SnapKeyring', () => {
               metamask: {
                 correlationId,
               },
-            } as InternalOptions),
+            } as MetaMaskOptions),
           },
         }),
       );
@@ -2221,7 +2221,7 @@ describe('SnapKeyring', () => {
               // default internal options values.
               metamask: {
                 correlationId: unknownCorrelationId,
-              } as InternalOptions,
+              } as MetaMaskOptions,
             },
           });
 
@@ -2246,7 +2246,7 @@ describe('SnapKeyring', () => {
               metamask: {
                 correlationId: expect.any(String),
               },
-            } as InternalOptions),
+            } as MetaMaskOptions),
           },
         }),
       );

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -455,8 +455,8 @@ describe('SnapKeyring', () => {
               ...(accountNameSuggestion !== undefined && {
                 accountNameSuggestion,
               }),
-              // Those flags have now been deprecated, but some older Snaps might still use them, so we
-              // must be able to use them in the `AccountCreated` without throwing any error.
+              // Those flags have now been deprecated, but some older Snaps might emit them, so we
+              // must accept/parse them `AccountCreated` without throwing any `superstruct` error.
               ...(displayConfirmation !== undefined && { displayConfirmation }),
               ...(displayAccountNameSuggestion !== undefined && {
                 displayAccountNameSuggestion,

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -10,6 +10,7 @@ import type {
   AccountBalancesUpdatedEventPayload,
   AccountTransactionsUpdatedEventPayload,
   AccountAssetListUpdatedEventPayload,
+  InternalOptions,
 } from '@metamask/keyring-api';
 import {
   EthScope,
@@ -23,14 +24,18 @@ import {
   BtcScope,
   SolScope,
   KeyringRpcMethod,
+  CreateAccountRequestStruct,
 } from '@metamask/keyring-api';
 import type { JsonRpcRequest } from '@metamask/keyring-utils';
 import type { HandleSnapRequest } from '@metamask/snaps-controllers';
 import { type SnapId } from '@metamask/snaps-sdk';
+import type { HandlerType } from '@metamask/snaps-utils';
+import { assert } from '@metamask/superstruct';
 import { KnownCaipNamespace, toCaipChainId } from '@metamask/utils';
+import { v4 as uuid } from 'uuid';
 
-import type { KeyringState } from '.';
-import { SnapKeyring } from '.';
+import type { KeyringState, SnapKeyringInternalOptions } from '.';
+import { getDefaultInternalOptions, SnapKeyring } from '.';
 import type { KeyringAccountV1 } from './account';
 import { DeferredPromise } from './DeferredPromise';
 import { migrateAccountV1, getScopesForAccountV1 } from './migrations';
@@ -39,6 +44,8 @@ import type {
   SnapKeyringEvents,
   SnapKeyringMessenger,
 } from './SnapKeyringMessenger';
+
+type SnapRpcRequest = Parameters<HandleSnapRequest['handler']>[0];
 
 const regexForUUIDInRequiredSyncErrorMessage =
   /Request '[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}' to Snap 'local:snap.mock' is pending and noPending is true/u;
@@ -168,6 +175,8 @@ describe('SnapKeyring', () => {
     scopes: [SolScope.Mainnet, SolScope.Testnet, SolScope.Devnet],
     type: SolAccountType.DataAccount,
   };
+
+  // This account can be used to create bad accounts.
   const unknownAccount: KeyringAccount = {
     id: 'b0cd527b-c936-4f6d-b4c0-2b776288a4cf',
     address: '?',
@@ -180,6 +189,16 @@ describe('SnapKeyring', () => {
     // migrate data upon the Snap keyring initialization, we want to cover edge-cases
     // like this one to avoid crashing and blocking everything...
     type: 'unknown:type' as KeyringAccount['type'],
+  };
+
+  // This account can be used when adding new account to the existing keyring.
+  const newEthEoaAccount = {
+    id: 'bd63063d-ed58-4b9b-b3da-4282ac2208a8',
+    options: {},
+    methods: ETH_EOA_METHODS,
+    scopes: [EthScope.Eoa],
+    type: EthAccountType.Eoa,
+    address: '0x6431726eee67570bf6f0cf892ae0a3988f03903f',
   };
 
   const accounts = [
@@ -216,10 +235,10 @@ describe('SnapKeyring', () => {
   const mockMessengerHandleRequest = (
     // We're using `string` here instead of `KeyringRpcMethod` to avoid having to map
     // every RPC methods
-    handlers: Record<string, () => unknown>,
+    handlers: Record<string, (request: JsonRpcRequest) => unknown>,
   ): void => {
     mockMessenger.handleRequest.mockImplementation(
-      (request: Parameters<HandleSnapRequest['handler']>[0]) => {
+      async (request: SnapRpcRequest) => {
         // First layer of transport is a Snap RPC request for 'OnKeyringRequest'.
         expect(request.handler).toBe('onKeyringRequest');
 
@@ -232,10 +251,26 @@ describe('SnapKeyring', () => {
             `Missing handleRequest handler for: ${keyringRequest.method}`,
           );
         }
-        return requestHandler();
+        return await requestHandler(keyringRequest);
       },
     );
   };
+
+  // Build a keyring RPC request that is being forward to `handleRequest`:
+  const mockKeyringRpcRequest = (
+    method: KeyringRpcMethod,
+    params: JsonRpcRequest['params'],
+  ): SnapRpcRequest => ({
+    handler: 'onKeyringRequest' as HandlerType,
+    origin: 'metamask',
+    snapId,
+    request: {
+      id: expect.any(String),
+      jsonrpc: '2.0',
+      method,
+      params,
+    },
+  });
 
   beforeEach(async () => {
     keyring = new SnapKeyring(mockSnapKeyringMessenger, mockCallbacks);
@@ -251,7 +286,7 @@ describe('SnapKeyring', () => {
         handleUserInput,
         _onceSaved,
         _accountNameSuggestion,
-        _displayConfirmation,
+        _internalOptions,
       ) => {
         await handleUserInput(true);
       },
@@ -271,15 +306,6 @@ describe('SnapKeyring', () => {
   });
 
   describe('handleKeyringSnapMessage', () => {
-    const newEthEoaAccount = {
-      id: 'bd63063d-ed58-4b9b-b3da-4282ac2208a8',
-      options: {},
-      methods: ETH_EOA_METHODS,
-      scopes: [EthScope.Eoa],
-      type: EthAccountType.Eoa,
-      address: '0x6431726eee67570bf6f0cf892ae0a3988f03903f',
-    };
-
     describe('#handleAccountCreated', () => {
       it('creates the account with a lower-cased address for EVM', async () => {
         const account = {
@@ -303,8 +329,7 @@ describe('SnapKeyring', () => {
           expect.any(Function),
           expect.any(Promise),
           undefined,
-          undefined,
-          undefined,
+          getDefaultInternalOptions(),
         );
       });
 
@@ -332,8 +357,7 @@ describe('SnapKeyring', () => {
           expect.any(Function),
           expect.any(Promise),
           undefined,
-          undefined,
-          undefined,
+          getDefaultInternalOptions(),
         );
       });
 
@@ -392,21 +416,21 @@ describe('SnapKeyring', () => {
             undefined,
           ],
           [
-            'handles account creation with displayConfirmation',
+            'handles account creation with displayConfirmation (retro-compatibility)',
             { ...ethEoaAccount2 },
             undefined,
             false,
             undefined,
           ],
           [
-            'handles account creation with both accountNameSuggestion and displayConfirmation',
+            'handles account creation with both accountNameSuggestion and displayConfirmation (retro-compatibility)',
             { ...ethEoaAccount3 },
             'New Account',
             false,
             undefined,
           ],
           [
-            'handles account creation with both accountNameSuggestion and displayAccountNameSuggestion',
+            'handles account creation with both accountNameSuggestion and displayAccountNameSuggestion (retro-compatibility)',
             { ...ethEoaAccount4 },
             'New Account',
             false,
@@ -427,11 +451,13 @@ describe('SnapKeyring', () => {
             keyring = new SnapKeyring(mockSnapKeyringMessenger, mockCallbacks);
 
             const params = {
-              account: account as unknown as KeyringAccount,
-              ...(displayConfirmation !== undefined && { displayConfirmation }),
+              account,
               ...(accountNameSuggestion !== undefined && {
                 accountNameSuggestion,
               }),
+              // Those flags have now been deprecated, but some older Snaps might still use them, so we
+              // must be able to use them in the `AccountCreated` without throwing any error.
+              ...(displayConfirmation !== undefined && { displayConfirmation }),
               ...(displayAccountNameSuggestion !== undefined && {
                 displayAccountNameSuggestion,
               }),
@@ -448,8 +474,9 @@ describe('SnapKeyring', () => {
               expect.any(Function),
               expect.any(Promise),
               accountNameSuggestion,
-              displayConfirmation,
-              displayAccountNameSuggestion,
+              // `display*` flags have now been deprecated on the `AccountCreated` event, meaning we expect
+              // to use the default value instead (at least, in this test).
+              getDefaultInternalOptions(),
             );
           },
         );
@@ -841,9 +868,8 @@ describe('SnapKeyring', () => {
           snapId,
           expect.any(Function),
           expect.any(Promise),
-          undefined,
-          undefined,
-          undefined,
+          undefined, // accountNameSuggestion
+          getDefaultInternalOptions(),
         );
         expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith({
           handler: 'onKeyringRequest',
@@ -2066,6 +2092,192 @@ describe('SnapKeyring', () => {
             keyring: { type: 'Snap Keyring' },
           },
         },
+      );
+    });
+  });
+
+  describe('createAccount', () => {
+    const account = newEthEoaAccount;
+
+    const options = {
+      some: 'options',
+      valid: true,
+    };
+
+    it('creates an account', async () => {
+      mockMessengerHandleRequest({
+        [KeyringRpcMethod.CreateAccount]: async () => {
+          // When calling `keyring_createAccount`, we expect the Snap to
+          // emit a `notify:accountCreated`.
+          await keyring.handleKeyringSnapMessage(snapId, {
+            method: KeyringEvent.AccountCreated,
+            params: {
+              account: account as unknown as KeyringAccount,
+            },
+          });
+
+          return account;
+        },
+      });
+
+      await keyring.createAccount(snapId, options);
+
+      expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccount, {
+          options,
+        }),
+      );
+      expect(mockCallbacks.addAccount).toHaveBeenLastCalledWith(
+        account.address.toLowerCase(),
+        snapId,
+        expect.any(Function),
+        expect.any(Promise),
+        undefined,
+        // Since no internal options have been given to `keyring.createAccount`, the default internal
+        // options will be used automatically!
+        getDefaultInternalOptions(),
+      );
+    });
+
+    it('creates an account with some internal options', async () => {
+      // We will extract it from the internal options when calling `keyring_createAccount`.
+      let correlationId: string = '';
+
+      mockMessengerHandleRequest({
+        [KeyringRpcMethod.CreateAccount]: async (request) => {
+          assert(request, CreateAccountRequestStruct);
+
+          // When using `createAccount` through the Snap keyring, some internal options context
+          // will be injected into the params (with the `metamask` key), so we expect to have
+          // them to be defined.
+          const params = request.params.options as InternalOptions;
+          expect(params.metamask).toBeDefined();
+          expect(params.metamask?.correlationId).toBeDefined();
+
+          // We know it's well-defined from here.
+          correlationId = params.metamask?.correlationId as string;
+
+          await keyring.handleKeyringSnapMessage(snapId, {
+            method: KeyringEvent.AccountCreated,
+            params: {
+              account: account as unknown as KeyringAccount,
+              // We need to forward this internal context back to the Snap keyring
+              // to be able to map the internal options.
+              // NOTE: It's safe to use type cast, since we have already checked that
+              // params.metamask is defined!
+              metamask: params.metamask as InternalOptions,
+            },
+          });
+
+          return account;
+        },
+      });
+
+      // Skip everything!
+      const internalOptions: SnapKeyringInternalOptions = {
+        displayConfirmation: false,
+        displayAccountNameSuggestion: false,
+      };
+
+      await keyring.createAccount(snapId, options, internalOptions);
+
+      expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccount, {
+          options: {
+            ...options,
+            // Internal options context being injected by the Snap keyring.
+            ...({
+              metamask: {
+                correlationId,
+              },
+            } as InternalOptions),
+          },
+        }),
+      );
+      expect(mockCallbacks.addAccount).toHaveBeenLastCalledWith(
+        account.address.toLowerCase(),
+        snapId,
+        expect.any(Function),
+        expect.any(Promise),
+        undefined,
+        // They must be matching the one we initially sent.
+        internalOptions,
+      );
+    });
+
+    it('fallbacks to the default internal options if the correlationId is incorrect', async () => {
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation();
+      const unknownCorrelationId = uuid();
+
+      mockMessengerHandleRequest({
+        [KeyringRpcMethod.CreateAccount]: async (request) => {
+          assert(request, CreateAccountRequestStruct);
+
+          await keyring.handleKeyringSnapMessage(snapId, {
+            method: KeyringEvent.AccountCreated,
+            params: {
+              account: account as unknown as KeyringAccount,
+              // If we don't forward the correct correlation ID, then we'll fallback to the
+              // default internal options values.
+              metamask: {
+                correlationId: unknownCorrelationId,
+              } as InternalOptions,
+            },
+          });
+
+          return account;
+        },
+      });
+
+      // Skip everything!
+      const internalOptions: SnapKeyringInternalOptions = {
+        displayConfirmation: false,
+        displayAccountNameSuggestion: false,
+      };
+
+      await keyring.createAccount(snapId, options, internalOptions);
+
+      expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccount, {
+          options: {
+            ...options,
+            // Internal options context being injected by the Snap keyring.
+            ...({
+              metamask: {
+                correlationId: expect.any(String),
+              },
+            } as InternalOptions),
+          },
+        }),
+      );
+      expect(mockCallbacks.addAccount).toHaveBeenLastCalledWith(
+        account.address.toLowerCase(),
+        snapId,
+        expect.any(Function),
+        expect.any(Promise),
+        undefined,
+        // Since the Snap tried to use an unknown correlation ID, we will log
+        // something and fallback to the default ones.
+        getDefaultInternalOptions(),
+      );
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        `SnapKeyring - Received unmapped correlation ID: "${unknownCorrelationId}"`,
+      );
+    });
+
+    it('cannot use reserved options field', async () => {
+      const reserved = 'metamask';
+
+      await expect(
+        keyring.createAccount(snapId, {
+          ...options,
+          [reserved]: {
+            thisOne: 'is reserved by us',
+          },
+        }),
+      ).rejects.toThrow(
+        `The '${reserved}' property is reserved for internal use`,
       );
     });
   });

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -28,7 +28,7 @@ import type {
   EthUserOperationPatch,
   ResolvedAccountAddress,
   CaipChainId,
-  InternalOptions,
+  MetaMaskOptions,
 } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client';
@@ -768,7 +768,7 @@ export class SnapKeyring extends EventEmitter {
         metamask: {
           correlationId,
         },
-      } as InternalOptions),
+      } as MetaMaskOptions),
     });
   }
 

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -28,6 +28,7 @@ import type {
   EthUserOperationPatch,
   ResolvedAccountAddress,
   CaipChainId,
+  InternalOptions,
 } from '@metamask/keyring-api';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client';
@@ -39,6 +40,7 @@ import { assert, mask, object, string } from '@metamask/superstruct';
 import type { Hex, Json } from '@metamask/utils';
 import {
   bigIntToHex,
+  hasProperty,
   KnownCaipNamespace,
   toCaipChainId,
 } from '@metamask/utils';
@@ -56,6 +58,10 @@ import {
 } from './events';
 import { projectLogger as log } from './logger';
 import { isAccountV1, migrateAccountV1 } from './migrations';
+import {
+  getDefaultInternalOptions,
+  type SnapKeyringInternalOptions,
+} from './options';
 import { SnapIdMap } from './SnapIdMap';
 import type {
   SnapKeyringEvents,
@@ -103,8 +109,7 @@ export type SnapKeyringCallbacks = {
     handleUserInput: (accepted: boolean) => Promise<void>,
     onceSaved: Promise<AccountId>,
     accountNameSuggestion?: string,
-    displayConfirmation?: boolean,
-    displayAccountNameSuggestion?: boolean,
+    internalOptions?: SnapKeyringInternalOptions,
   ): Promise<void>;
 
   removeAccount(
@@ -174,6 +179,14 @@ export class SnapKeyring extends EventEmitter {
   }>;
 
   /**
+   * Mapping between internal options, a correlation ID and a Snap ID.
+   */
+  readonly #options: SnapIdMap<{
+    options: SnapKeyringInternalOptions;
+    snapId: SnapId;
+  }>;
+
+  /**
    * Callbacks used to interact with other components.
    */
   readonly #callbacks: SnapKeyringCallbacks;
@@ -195,7 +208,34 @@ export class SnapKeyring extends EventEmitter {
     this.#snapClient = new KeyringInternalSnapClient({ messenger });
     this.#requests = new SnapIdMap();
     this.#accounts = new SnapIdMap();
+    this.#options = new SnapIdMap();
     this.#callbacks = callbacks;
+  }
+
+  /**
+   * Get internal options given a correlation ID.
+   *
+   * @param snapId - Snap ID
+   * @param correlationId - Correlation ID associated with the internal options.
+   * @returns Internal options if found, or defaults internal options values otherwise.
+   */
+  #getInternalOptionsOrDefaults(
+    snapId: SnapId,
+    correlationId: string | undefined,
+  ): SnapKeyringInternalOptions {
+    if (correlationId) {
+      // We still need to check if the correlation ID is valid and associated to
+      // some internal options.
+      const maybe = this.#options.get(snapId, correlationId);
+
+      if (maybe) {
+        return maybe.options;
+      }
+
+      console.warn(`Received unmapped correlation ID: "${correlationId}"`);
+    }
+
+    return getDefaultInternalOptions();
   }
 
   /**
@@ -211,10 +251,9 @@ export class SnapKeyring extends EventEmitter {
   ): Promise<null> {
     assert(message, AccountCreatedEventStruct);
     const {
+      metamask, // Used for internal options.
       account: newAccountFromEvent,
       accountNameSuggestion,
-      displayConfirmation,
-      displayAccountNameSuggestion,
     } = message.params;
 
     // READ THIS CAREFULLY:
@@ -295,8 +334,7 @@ export class SnapKeyring extends EventEmitter {
       },
       onceSaved.promise,
       accountNameSuggestion,
-      displayConfirmation,
-      displayAccountNameSuggestion,
+      this.#getInternalOptionsOrDefaults(snapId, metamask?.correlationId),
     );
 
     return null;
@@ -672,6 +710,63 @@ export class SnapKeyring extends EventEmitter {
         .filter(({ snapId: accountSnapId }) => accountSnapId === snapId)
         .map(({ account }) => normalizeAccountAddress(account)),
     );
+  }
+
+  /**
+   * Create an account.
+   *
+   * @param snapId - Snap ID to create the account for.
+   * @param options - Account creation options. Differs between keyrings.
+   * @param internalOptions - Internal Snap keyring options.
+   * @returns The account object.
+   */
+  async createAccount(
+    snapId: SnapId,
+    options: Record<string, Json>,
+    internalOptions?: SnapKeyringInternalOptions,
+  ): Promise<KeyringAccount> {
+    const client = new KeyringInternalSnapClient({
+      messenger: this.#messenger,
+      snapId,
+    });
+
+    // The 'metamask' field is reserved, so we have to prevent use of it on
+    // the "normal options".
+    const reserved = 'metamask';
+    if (hasProperty(options, reserved)) {
+      throw new Error(
+        `The '${reserved}' property is reserved for internal use`,
+      );
+    }
+
+    // Those internal options are optional. If not set, we avoid registering anything
+    // to internal map (to avoid holding resources for nothing). In this case, it's
+    // just a normal `keyring_createAccount`.
+    if (!internalOptions) {
+      return await client.createAccount(options);
+    }
+
+    // A unique ID to identify this execution flow which allows to associate the
+    // internal options and the current `keyring_createAccount` flow for that Snap.
+    const correlationId = uuid();
+
+    // Register those internal options to use them during the `keyring_createAccount`
+    // flow.
+    this.#options.set(correlationId, {
+      snapId,
+      options: internalOptions,
+    });
+
+    return await client.createAccount({
+      ...options,
+      // Create internal options context.
+      // NOTE: Those options HAVE TO be re-emitted during the `notify:accountCreated` event.
+      ...({
+        metamask: {
+          correlationId,
+        },
+      } as InternalOptions),
+    });
   }
 
   /**

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -229,6 +229,7 @@ export class SnapKeyring extends EventEmitter {
     if (correlationId) {
       // We still need to check if the correlation ID is valid and associated to
       // some internal options.
+      //
       // NOTE: `found` will be `undefined` if a Snap tried to use a correlation ID that
       // belongs to another Snap ID. However, if a Snap starts 2 parallel flow (which
       // will results in 2 different correlation IDs), we won't be able to prevent

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -184,6 +184,7 @@ export class SnapKeyring extends EventEmitter {
   readonly #options: SnapIdMap<{
     options: SnapKeyringInternalOptions;
     snapId: SnapId;
+    // TODO: Add TTL to avoid having too many "leaking" internal options.
   }>;
 
   /**

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -226,10 +226,10 @@ export class SnapKeyring extends EventEmitter {
     if (correlationId) {
       // We still need to check if the correlation ID is valid and associated to
       // some internal options.
-      const maybe = this.#options.get(snapId, correlationId);
+      const found = this.#options.get(snapId, correlationId);
 
-      if (maybe) {
-        return maybe.options;
+      if (found) {
+        return found.options;
       }
 
       console.warn(

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -232,7 +232,9 @@ export class SnapKeyring extends EventEmitter {
         return maybe.options;
       }
 
-      console.warn(`Received unmapped correlation ID: "${correlationId}"`);
+      console.warn(
+        `SnapKeyring - Received unmapped correlation ID: "${correlationId}"`,
+      );
     }
 
     return getDefaultInternalOptions();

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -229,6 +229,10 @@ export class SnapKeyring extends EventEmitter {
     if (correlationId) {
       // We still need to check if the correlation ID is valid and associated to
       // some internal options.
+      // NOTE: `found` will be `undefined` if a Snap tried to use a correlation ID that
+      // belongs to another Snap ID. However, if a Snap starts 2 parallel flow (which
+      // will results in 2 different correlation IDs), we won't be able to prevent
+      // the Snap from swapping/mixing up those correlation IDs he owns.
       const found = this.#options.pop(snapId, correlationId);
 
       if (found) {

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -216,6 +216,8 @@ export class SnapKeyring extends EventEmitter {
   /**
    * Get internal options given a correlation ID.
    *
+   * NOTE: The associated options will be deleted automatically.
+   *
    * @param snapId - Snap ID
    * @param correlationId - Correlation ID associated with the internal options.
    * @returns Internal options if found, or defaults internal options values otherwise.
@@ -227,7 +229,7 @@ export class SnapKeyring extends EventEmitter {
     if (correlationId) {
       // We still need to check if the correlation ID is valid and associated to
       // some internal options.
-      const found = this.#options.get(snapId, correlationId);
+      const found = this.#options.pop(snapId, correlationId);
 
       if (found) {
         return found.options;

--- a/packages/keyring-snap-bridge/src/events.ts
+++ b/packages/keyring-snap-bridge/src/events.ts
@@ -6,8 +6,8 @@ import {
   RequestRejectedEventStruct,
   KeyringAccountStruct,
 } from '@metamask/keyring-api';
-import { object } from '@metamask/keyring-utils';
-import { union } from '@metamask/superstruct';
+import { exactOptional, object } from '@metamask/keyring-utils';
+import { boolean, union } from '@metamask/superstruct';
 
 import { KeyringAccountV1Struct } from './account';
 
@@ -17,6 +17,12 @@ export const AccountCreatedEventStruct = object({
   params: object({
     ...OriginalAccountCreatedEventStruct.schema.params.schema,
     account: union([KeyringAccountV1Struct, KeyringAccountStruct]),
+
+    // Now deprecated, see `SnapKeyringInternalOptions` instead.
+    displayConfirmation: exactOptional(boolean()),
+
+    // Now deprecated, see `SnapKeyringInternalOptions` instead.
+    displayAccountNameSuggestion: exactOptional(boolean()),
   }),
 });
 

--- a/packages/keyring-snap-bridge/src/index.ts
+++ b/packages/keyring-snap-bridge/src/index.ts
@@ -1,3 +1,4 @@
+export * from './options';
 export * from './types';
 export * from './SnapKeyring';
 export type * from './SnapKeyringMessenger';

--- a/packages/keyring-snap-bridge/src/options.ts
+++ b/packages/keyring-snap-bridge/src/options.ts
@@ -23,7 +23,7 @@ export type SnapKeyringInternalOptions = {
  *
  * @returns The default internal options.
  */
-export function getDefaultInternalOptions(): SnapKeyringInternalOptions {
+export function getDefaultInternalOptions(): Required<SnapKeyringInternalOptions> {
   return {
     displayAccountNameSuggestion: true,
     displayConfirmation: true,

--- a/packages/keyring-snap-bridge/src/options.ts
+++ b/packages/keyring-snap-bridge/src/options.ts
@@ -1,0 +1,31 @@
+/**
+ * Internal options that can be used alongside some Snap keyring flow.
+ *
+ * They can be used to omit/skip some steps during flows.
+ */
+export type SnapKeyringInternalOptions = {
+  /**
+   * Instructs MetaMask to display the add account confirmation dialog in the UI.
+   */
+  displayConfirmation?: boolean;
+
+  /**
+   * Instructs MetaMask to display the name confirmation dialog in the UI.
+   * Otherwise, the account will be added with the suggested name, if it's not
+   * already in use; if it is, a suffix will be appended to the name to make it
+   * unique.
+   */
+  displayAccountNameSuggestion?: boolean;
+};
+
+/**
+ * Get the default internal options.
+ *
+ * @returns The default internal options.
+ */
+export function getDefaultInternalOptions(): SnapKeyringInternalOptions {
+  return {
+    displayAccountNameSuggestion: true,
+    displayConfirmation: true,
+  };
+}


### PR DESCRIPTION
Introducing a new way of handling internal options (`display*` flags) that were used to configure the account creation flow.

Initially those flags were being sent by the Snap (only interpreted for preinstalled Snaps) itself to allow to skip some specific steps of the flow (e.g display the account name input OR display the confirmation about the account creation action).

The main problem with the previous approach is that the caller (MetaMask here) of `keyring_createAccount` cannot skip those steps programmatically. It's up to the Snap to the Snap to emit the right flags with the correct values during the flow.

- - -

With the new approach, we "hide" those flags behind a context that is owned by the Snap keyring. In addition to that, we've added a new `SnapKeyring.createAccount` method that allows the caller (MetaMask here, again) to enable those flags if needed.

This way, we can configure the flow to behave differently:
```ts
const BITCOIN_SNAP_ID = 'npm:...';
const SOLANA_SNAP_ID = 'npm:...';

const keyring = new SnapKeyring(...);

// Basic flow
keyring.createAccount(SOLANA_SNAP_ID, { scope: '...' }, {
  // We don't want to display those intermediary screens.
  displayConfirmations: false,
});

// Creating a Solana account "on-the-fly" with a default name
keyring.createAccount(SOLANA_SNAP_ID, { scope: '...' }, {
  // We don't want to display those intermediary screens.
  displayConfirmations: false,
  // Will defaults to a generic account name.
  displayAccountNameSuggestion: false,
});
```

> [!CAUTION]
> The current flow will still select the newly created account at the end of the flow, but with this new approach we could easily extend our "internal options" and skip that step too, like
> ```ts
> // Could be used by the new bridge EVM <> Solana flow
> // OR could be used by profile-sync to create account without selecting them.
> keyring.createAccount(SOLANA_SNAP_ID, { scope: '...' }, {
>  displayConfirmations: false,
>  displayAccountNameSuggestion: false,
>  // The Snap keyring won't select this account automatically.
>  setSelectedAccount: false,
> });
> ```