### PR TITLE
fix(keyring-eth-ledger-bridge): trim `0x` prefix for  `signTransaction` (due to latest `@ethereumjs` upgrade)

### DIFF
--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
@@ -3,7 +3,7 @@ import { RLP } from '@ethereumjs/rlp';
 import { TransactionFactory } from '@ethereumjs/tx';
 import * as ethUtil from '@ethereumjs/util';
 import * as sigUtil from '@metamask/eth-sig-util';
-import { bytesToHex, Hex } from '@metamask/utils';
+import { bytesToHex, Hex, remove0x } from '@metamask/utils';
 import EthereumTx from 'ethereumjs-tx';
 import HDKey from 'hdkey';
 
@@ -719,7 +719,9 @@ describe('LedgerKeyring', function () {
             .mockImplementation(async (params) => {
               expect(params).toStrictEqual({
                 hdPath: "m/44'/60'/0'/0",
-                tx: bytesToHex(fakeTypeTwoTx.getMessageToSign() as Uint8Array),
+                tx: remove0x(
+                  bytesToHex(fakeTypeTwoTx.getMessageToSign() as Uint8Array),
+                ),
               });
               return expectedRSV;
             });
@@ -745,7 +747,7 @@ describe('LedgerKeyring', function () {
 
         await expect(
           keyring.signTransaction(fakeAccounts[0], fakeTx),
-        ).rejects.toThrow('Ledger: Unknown error while signing transaction');
+        ).rejects.toThrow('Ledger: hdPath is empty while signing transaction');
       });
 
       it('throws different error to the default one if the bridge error is an instance of the Error object', async function () {

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -403,13 +403,14 @@ export class LedgerKeyring implements Keyring {
     const hdPath = await this.unlockAccountByAddress(address);
 
     if (!hdPath) {
-      throw new Error('Ledger: Unknown error while signing transaction');
+      throw new Error('Ledger: hdPath is empty while signing transaction');
     }
 
     let payload;
+
     try {
       payload = await this.bridge.deviceSignTransaction({
-        tx: rawTxHex,
+        tx: remove0x(rawTxHex),
         hdPath,
       });
     } catch (error) {


### PR DESCRIPTION
This PR will fix the ledger sign transaction issue due to this ethereumjs upgrade PR https://github.com/MetaMask/accounts/pull/209 

and basically the ethereumjs upgrade code change make the transaction rawTxHex contain `0x` prefix which is not valid for to @ledgerhq/hw-eth-app clearSignTransaction function. that functions expect a rawTxHex without `0x` prefix.
 
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes [#31004](https://github.com/MetaMask/metamask-extension/issues/31004)
* See: #67890
-->


<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->
