### PR TITLE
feat(keyring-snap-bridge): add `setSelectedAccount` internal option

### DIFF
--- a/packages/keyring-snap-bridge/src/options.ts
+++ b/packages/keyring-snap-bridge/src/options.ts
@@ -16,6 +16,12 @@ export type SnapKeyringInternalOptions = {
    * unique.
    */
   displayAccountNameSuggestion?: boolean;
+
+  /**
+   * Instructs MetaMask to not select the account at the end of a create account
+   * flow.
+   */
+  setSelectedAccount?: boolean;
 };
 
 /**
@@ -27,5 +33,6 @@ export function getDefaultInternalOptions(): Required<SnapKeyringInternalOptions
   return {
     displayAccountNameSuggestion: true,
     displayConfirmation: true,
+    setSelectedAccount: true,
   };
 }


### PR DESCRIPTION
Requires:
- [x] #252 

New flag to be able to not select the account at the end of the account creation flow.
