### PR TITLE
feat(keyring-snap-bridge): add TTL for internal options

### DIFF
--- a/packages/keyring-snap-bridge/src/SnapIdMap.ts
+++ b/packages/keyring-snap-bridge/src/SnapIdMap.ts
@@ -276,6 +276,30 @@ export class SnapIdMap<Value extends { snapId: SnapId }> {
   }
 
   /**
+   * Returns an iterable of the entries in the map.
+   *
+   * Example:
+   *
+   * ```ts
+   * const map = new SnapIdMap([
+   *   ['foo', { snapId: '1', name: 'foo' }],
+   *   ['bar', { snapId: '1', name: 'bar' }],
+   * ]);
+   * const entries = [...map.entries()];
+   * // Returns
+   * // [
+   * //   ['foo', { snapId: '1', name: 'foo' }],
+   * //   ['bar', { snapId: '1', name: 'bar' }],
+   * // ]
+   * ```
+   *
+   * @returns An iterable of the entries in the map.
+   */
+  entries(): MapIterator<[string, Value]> {
+    return this.#map.entries();
+  }
+
+  /**
    * Returns the number of key-value pairs in the map.
    *
    * @returns The number of key-value pairs in the map.

--- a/packages/keyring-snap-bridge/src/options.ts
+++ b/packages/keyring-snap-bridge/src/options.ts
@@ -1,4 +1,10 @@
 /**
+ * Default TTL for internal options. Past that time, the internal options will
+ * be considered outdated and will be removed automatically.
+ */
+export const DEFAULT_INTERNAL_OPTIONS_TTL_SECS = 60 * 60; // 1 hour
+
+/**
  * Internal options that can be used alongside some Snap keyring flow.
  *
  * They can be used to omit/skip some steps during flows.


### PR DESCRIPTION
Adding a TTL to the new internal options features to avoid having leaking resources if a Snap does not properly re-emit its correlation ID.