### PR TITLE
refactor(keyring-snap-bridge): re-allow Snap to some internal options

### DIFF
--- a/packages/keyring-api/src/events.ts
+++ b/packages/keyring-api/src/events.ts
@@ -5,7 +5,7 @@ import {
   AccountIdStruct,
 } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
-import { array, literal, record, string } from '@metamask/superstruct';
+import { array, boolean, literal, record, string } from '@metamask/superstruct';
 import {
   CaipAssetTypeStruct,
   CaipAssetTypeOrIdStruct,
@@ -54,6 +54,23 @@ export const AccountCreatedEventStruct = object({
      * client decides to use a different name.
      */
     accountNameSuggestion: exactOptional(string()),
+
+    /**
+     * Instructs MetaMask to display the add account confirmation dialog in the UI.
+     *
+     * **Note:** This is not guaranteed to be honored by the MetaMask client.
+     */
+    displayConfirmation: exactOptional(boolean()),
+
+    /**
+     * Instructs MetaMask to display the name confirmation dialog in the UI.
+     * Otherwise, the account will be added with the suggested name, if it's not
+     * already in use; if it is, a suffix will be appended to the name to make it
+     * unique.
+     *
+     * **Note:** This is not guaranteed to be honored by the MetaMask client.
+     */
+    displayAccountNameSuggestion: exactOptional(boolean()),
 
     /**
      * Metamask internal options.

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -416,21 +416,21 @@ describe('SnapKeyring', () => {
             undefined,
           ],
           [
-            'handles account creation with displayConfirmation (retro-compatibility)',
+            'handles account creation with displayConfirmation',
             { ...ethEoaAccount2 },
             undefined,
             false,
             undefined,
           ],
           [
-            'handles account creation with both accountNameSuggestion and displayConfirmation (retro-compatibility)',
+            'handles account creation with both accountNameSuggestion and displayConfirmation',
             { ...ethEoaAccount3 },
             'New Account',
             false,
             undefined,
           ],
           [
-            'handles account creation with both accountNameSuggestion and displayAccountNameSuggestion (retro-compatibility)',
+            'handles account creation with both accountNameSuggestion and displayAccountNameSuggestion',
             { ...ethEoaAccount4 },
             'New Account',
             false,
@@ -468,15 +468,22 @@ describe('SnapKeyring', () => {
               params,
             });
 
+            const defaultOptions = getDefaultInternalOptions();
             expect(mockCallbacks.addAccount).toHaveBeenCalledWith(
               account.address.toLowerCase(),
               snapId,
               expect.any(Function),
               expect.any(Promise),
               accountNameSuggestion,
-              // `display*` flags have now been deprecated on the `AccountCreated` event, meaning we expect
-              // to use the default value instead (at least, in this test).
-              getDefaultInternalOptions(),
+              {
+                displayConfirmation:
+                  displayConfirmation ?? defaultOptions.displayConfirmation,
+                displayAccountNameSuggestion:
+                  displayAccountNameSuggestion ??
+                  defaultOptions.displayAccountNameSuggestion,
+                // This one is not overloaded, so use the defaults here.
+                setSelectedAccount: defaultOptions.setSelectedAccount,
+              },
             );
           },
         );
@@ -2177,6 +2184,7 @@ describe('SnapKeyring', () => {
       const internalOptions: SnapKeyringInternalOptions = {
         displayConfirmation: false,
         displayAccountNameSuggestion: false,
+        setSelectedAccount: false,
       };
 
       await keyring.createAccount(snapId, options, internalOptions);

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -59,7 +59,7 @@ import {
 import { projectLogger as log } from './logger';
 import { isAccountV1, migrateAccountV1 } from './migrations';
 import {
-  getDefaultInternalOptions,
+  getInternalOptionsOf,
   type SnapKeyringInternalOptions,
 } from './options';
 import { SnapIdMap } from './SnapIdMap';
@@ -222,10 +222,10 @@ export class SnapKeyring extends EventEmitter {
    * @param correlationId - Correlation ID associated with the internal options.
    * @returns Internal options if found, or defaults internal options values otherwise.
    */
-  #getInternalOptionsOrDefaults(
+  #getInternalOptions(
     snapId: SnapId,
     correlationId: string | undefined,
-  ): SnapKeyringInternalOptions {
+  ): SnapKeyringInternalOptions | undefined {
     if (correlationId) {
       // We still need to check if the correlation ID is valid and associated to
       // some internal options.
@@ -245,7 +245,7 @@ export class SnapKeyring extends EventEmitter {
       );
     }
 
-    return getDefaultInternalOptions();
+    return undefined;
   }
 
   /**
@@ -264,6 +264,8 @@ export class SnapKeyring extends EventEmitter {
       metamask, // Used for internal options.
       account: newAccountFromEvent,
       accountNameSuggestion,
+      displayAccountNameSuggestion,
+      displayConfirmation,
     } = message.params;
 
     // READ THIS CAREFULLY:
@@ -344,7 +346,17 @@ export class SnapKeyring extends EventEmitter {
       },
       onceSaved.promise,
       accountNameSuggestion,
-      this.#getInternalOptionsOrDefaults(snapId, metamask?.correlationId),
+      getInternalOptionsOf([
+        // 1. We use the internal options from the Snap keyring.
+        this.#getInternalOptions(snapId, metamask?.correlationId),
+        // 2. We use the ones coming from the Snap.
+        {
+          displayConfirmation,
+          displayAccountNameSuggestion,
+        },
+        // 3. Lastly, the default options will be automatically used
+        // by `getInternalOptionsOf`.
+      ]),
     );
 
     return null;

--- a/packages/keyring-snap-bridge/src/events.ts
+++ b/packages/keyring-snap-bridge/src/events.ts
@@ -6,8 +6,8 @@ import {
   RequestRejectedEventStruct,
   KeyringAccountStruct,
 } from '@metamask/keyring-api';
-import { exactOptional, object } from '@metamask/keyring-utils';
-import { boolean, union } from '@metamask/superstruct';
+import { object } from '@metamask/keyring-utils';
+import { union } from '@metamask/superstruct';
 
 import { KeyringAccountV1Struct } from './account';
 
@@ -17,12 +17,6 @@ export const AccountCreatedEventStruct = object({
   params: object({
     ...OriginalAccountCreatedEventStruct.schema.params.schema,
     account: union([KeyringAccountV1Struct, KeyringAccountStruct]),
-
-    // Now deprecated, see `SnapKeyringInternalOptions` instead.
-    displayConfirmation: exactOptional(boolean()),
-
-    // Now deprecated, see `SnapKeyringInternalOptions` instead.
-    displayAccountNameSuggestion: exactOptional(boolean()),
   }),
 });
 

--- a/packages/keyring-snap-bridge/src/options.ts
+++ b/packages/keyring-snap-bridge/src/options.ts
@@ -36,3 +36,52 @@ export function getDefaultInternalOptions(): Required<SnapKeyringInternalOptions
     setSelectedAccount: true,
   };
 }
+
+/**
+ * Makes any field potentially `undefined`.
+ */
+export type PotentiallyUndefined<Type> = {
+  [Key in keyof Type]: Type[Key] | undefined;
+};
+
+/**
+ * Compute internal options based on a list. If some options are still not defined, it
+ * will fallback to the default ones.
+ *
+ * @param internalOptions - List of internal options to combine.
+ * @returns Computed internal options.
+ */
+export function getInternalOptionsOf(
+  internalOptions: (
+    | PotentiallyUndefined<SnapKeyringInternalOptions>
+    | undefined
+  )[],
+): Required<SnapKeyringInternalOptions> {
+  const defaults: Required<SnapKeyringInternalOptions> =
+    getDefaultInternalOptions();
+
+  const combined: PotentiallyUndefined<SnapKeyringInternalOptions> = {};
+  for (const key of Object.keys(
+    defaults,
+  ) as (keyof SnapKeyringInternalOptions)[]) {
+    // We start of with `undefined` and check every options of the list, if
+    // we find any that is defined, we used it. In the end, we will fallback
+    // to the default ones that are guaranteed to be defined (thanks to the
+    // use of `Required`).
+    combined[key] = undefined;
+
+    // We use `defaults` as the last element, so we are guaranteed to have
+    // a defined value.
+    for (const options of [...internalOptions, defaults]) {
+      if (options === undefined) {
+        continue;
+      }
+
+      if (options[key] !== undefined && combined[key] === undefined) {
+        combined[key] = options[key];
+      }
+    }
+  }
+
+  return combined as Required<SnapKeyringInternalOptions>;
+}


### PR DESCRIPTION
Re-allow a Snap to send `display*` flags during the `notify:accountCreated` event.