### PR TITLE
fix: fix `tsd-test.sh` + add top-level `test:types` rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "release": "./scripts/release.sh",
     "setup": "yarn install",
     "test": "yarn foreach test",
-    "test:types": "yarn foreach test:types",
-    "test:clean": "yarn foreach test:clean"
+    "test:clean": "yarn foreach test:clean",
+    "test:types": "yarn foreach test:types"
   },
   "resolutions": {
     "@types/node": "^20.12.12",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "release": "./scripts/release.sh",
     "setup": "yarn install",
     "test": "yarn foreach test",
+    "test:types": "yarn foreach test:types",
     "test:clean": "yarn foreach test:clean"
   },
   "resolutions": {

--- a/packages/keyring-api/src/eth/types.test-d.ts
+++ b/packages/keyring-api/src/eth/types.test-d.ts
@@ -2,11 +2,11 @@ import type { Extends } from '@metamask/keyring-utils';
 import { expectTrue } from '@metamask/keyring-utils';
 import { expectAssignable, expectNotAssignable } from 'tsd';
 
+import { EthScope } from './constants';
 import type { EthEoaAccount, EthErc4337Account } from './types';
 import { EthMethod } from './types';
 import { EthAccountType } from '../api';
 import type { KeyringAccount } from '../api';
-import { EthScope } from './constants';
 
 const id = '606a7759-b0fb-48e4-9874-bab62ff8e7eb';
 const address = '0x000';

--- a/packages/keyring-api/src/eth/types.test-d.ts
+++ b/packages/keyring-api/src/eth/types.test-d.ts
@@ -6,6 +6,7 @@ import type { EthEoaAccount, EthErc4337Account } from './types';
 import { EthMethod } from './types';
 import { EthAccountType } from '../api';
 import type { KeyringAccount } from '../api';
+import { EthScope } from './constants';
 
 const id = '606a7759-b0fb-48e4-9874-bab62ff8e7eb';
 const address = '0x000';
@@ -13,6 +14,7 @@ const address = '0x000';
 // EOA account with no methods
 expectAssignable<EthEoaAccount>({
   type: EthAccountType.Eoa,
+  scopes: [EthScope.Eoa],
   id,
   address,
   options: {},
@@ -22,6 +24,7 @@ expectAssignable<EthEoaAccount>({
 // EOA account with all methods
 expectAssignable<EthEoaAccount>({
   type: EthAccountType.Eoa,
+  scopes: [EthScope.Eoa],
   id,
   address,
   options: {},
@@ -38,6 +41,7 @@ expectAssignable<EthEoaAccount>({
 // EOA account with ERC-4337 methods is an error
 expectNotAssignable<EthEoaAccount>({
   type: EthAccountType.Eoa,
+  scopes: [EthScope.Eoa],
   id,
   address,
   options: {},
@@ -51,6 +55,7 @@ expectNotAssignable<EthEoaAccount>({
 // EOA account with ERC-4337 type is an error
 expectNotAssignable<EthEoaAccount>({
   type: EthAccountType.Erc4337,
+  scopes: [EthScope.Testnet],
   id,
   address,
   options: {},
@@ -64,6 +69,7 @@ expectNotAssignable<EthEoaAccount>({
 // ERC-4337 account with no methods
 expectAssignable<EthErc4337Account>({
   type: EthAccountType.Erc4337,
+  scopes: [EthScope.Testnet],
   id,
   address,
   options: {},
@@ -73,6 +79,7 @@ expectAssignable<EthErc4337Account>({
 // ERC-4337 account with all methods
 expectAssignable<EthErc4337Account>({
   type: EthAccountType.Erc4337,
+  scopes: [EthScope.Testnet],
   id,
   address,
   options: {},
@@ -91,6 +98,7 @@ expectAssignable<EthErc4337Account>({
 // ERC-4337 account with only user-ops methods
 expectNotAssignable<EthErc4337Account>({
   type: EthAccountType.Eoa,
+  scopes: [EthScope.Eoa],
   id,
   address,
   options: {},
@@ -104,6 +112,7 @@ expectNotAssignable<EthErc4337Account>({
 // ERC-4337 account with EOA type is an error
 expectNotAssignable<EthErc4337Account>({
   type: EthAccountType.Eoa,
+  scopes: [EthScope.Eoa],
   id,
   address,
   options: {},

--- a/scripts/tsd-test.sh
+++ b/scripts/tsd-test.sh
@@ -9,17 +9,12 @@ if [[ $# -eq 0 ]]; then
 fi
 
 package_test_dir="$1"
+package_test_files=("${package_test_dir}"/**/*.test-d.ts)
 
-# For some reason, just running `tsd` with no arguments does not work properly. If you have some
-# static errors in your *.test-d.ts, they might not be evaluated. However, specifying each tests
-# with `--files` works everytime. So for now, we just use this wrapper for our typing tests.
-# NOTE: This directive is expected since we want the output to be splitted:
-# shellcheck disable=SC2046
-package_test_files="$(find "${package_test_dir}" -name "*.test-d.ts" -exec echo -n "--files {} " \;)"
-if [ "${package_test_files}" == "" ]; then
-  # If there's no files, we prevent from calling `tsd` with no arguments, otherwise it fallsback
-  # to the original behavior which is to test every `*d.ts` files.
-  echo "Nothing to test with tsd."
+# To avoid logging a tsd error message, we check if it exists any file for that
+# pattern:
+if [ -e "${package_test_files[0]}" ]; then
+  tsd --files "${package_test_dir}/**/*.test-d.ts"
 else
-  tsd "${package_test_files}"
+  echo "Nothing to test with tsd."
 fi


### PR DESCRIPTION
Simplify and fix the `tsd-test.sh` wrapper again. Also fixing the typing tests that went unnoticed with the introduciont of `scopes`.