### PR TITLE
fix: ledger iframe messages timeout

### DIFF
--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -23,10 +23,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 90.97,
-      functions: 96,
-      lines: 95.03,
-      statements: 95.09,
+      branches: 92.36,
+      functions: 97.87,
+      lines: 97.15,
+      statements: 97.17,
     },
   },
 });

--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -23,10 +23,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 92.36,
-      functions: 97.87,
-      lines: 97.15,
-      statements: 97.17,
+      branches: 92.41,
+      functions: 97.89,
+      lines: 97.18,
+      statements: 97.21,
     },
   },
 });

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
@@ -83,6 +83,7 @@ describe('LedgerIframeBridge', function () {
       bridgeUrl: BRIDGE_URL,
     });
     await bridge.init();
+    jest.useFakeTimers();
   });
 
   afterEach(function () {
@@ -195,6 +196,16 @@ describe('LedgerIframeBridge', function () {
       expect(bridge.iframe?.contentWindow?.postMessage).toHaveBeenCalled();
     });
 
+    it('throws a timeout error when the message does not receive a response', async function () {
+      stubKeyringIFramePostMessage(bridge, () => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      await expect(bridge.attemptMakeApp()).rejects.toThrow(
+        'Ledger iframe message timeout',
+      );
+    });
+
     it('throws an error when unknown error occur', async function () {
       const errorMessage = 'Unknown error occurred';
 
@@ -251,6 +262,18 @@ describe('LedgerIframeBridge', function () {
 
       await expect(bridge.updateTransportMethod('u2f')).rejects.toThrow(
         'The iframe is not loaded yet',
+      );
+    });
+
+    it('throws a timeout error when the message does not receive a response', async function () {
+      bridge.iframeLoaded = true;
+      const transportType = 'u2f';
+      stubKeyringIFramePostMessage(bridge, () => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      await expect(bridge.updateTransportMethod(transportType)).rejects.toThrow(
+        'Ledger iframe message timeout',
       );
     });
 
@@ -410,6 +433,18 @@ describe('LedgerIframeBridge', function () {
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(bridge.iframe?.contentWindow?.postMessage).toHaveBeenCalled();
     });
+
+    it('throws a timeout error when the message does not receive a response', async function () {
+      const params = { hdPath: "m/44'/60'/0'/0", tx: '' };
+
+      stubKeyringIFramePostMessage(bridge, () => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      await expect(bridge.deviceSignTransaction(params)).rejects.toThrow(
+        'Ledger iframe message timeout',
+      );
+    });
   });
 
   describe('deviceSignMessage', function () {
@@ -471,6 +506,18 @@ describe('LedgerIframeBridge', function () {
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(bridge.iframe?.contentWindow?.postMessage).toHaveBeenCalled();
+    });
+
+    it('throws a timeout error when the message does not receive a response', async function () {
+      const params = { hdPath: "m/44'/60'/0'/0", message: '' };
+
+      stubKeyringIFramePostMessage(bridge, () => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      await expect(bridge.deviceSignMessage(params)).rejects.toThrow(
+        'Ledger iframe message timeout',
+      );
     });
   });
 
@@ -547,6 +594,16 @@ describe('LedgerIframeBridge', function () {
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(bridge.iframe?.contentWindow?.postMessage).toHaveBeenCalled();
+    });
+
+    it('throws a timeout error when the message does not receive a response', async function () {
+      stubKeyringIFramePostMessage(bridge, () => {
+        jest.advanceTimersByTime(5000);
+      });
+
+      await expect(bridge.deviceSignTypedData(params)).rejects.toThrow(
+        'Ledger iframe message timeout',
+      );
     });
   });
 

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
@@ -16,6 +16,10 @@ type HTMLIFrameElementShim = HTMLIFrameElement;
 // eslint-disable-next-line no-restricted-globals
 type WindowShim = Window;
 
+const LEDGER_IFRAME_ID = 'LEDGER-IFRAME';
+const BRIDGE_URL = 'https://metamask.github.io/eth-ledger-bridge-keyring';
+const INVALID_URL_ERROR = 'bridgeURL is not a valid URL';
+
 /**
  * Checks if the iframe provided has a valid contentWindow
  * and onload function.
@@ -36,9 +40,22 @@ function isIFrameValid(
   );
 }
 
-const LEDGER_IFRAME_ID = 'LEDGER-IFRAME';
-const BRIDGE_URL = 'https://metamask.github.io/eth-ledger-bridge-keyring';
-const INVALID_URL_ERROR = 'bridgeURL is not a valid URL';
+/**
+ * Sends a message to the bridge as it would be sent from the iframe.
+ *
+ * @param bridge - The bridge to send the message to.
+ * @param message - The message to send.
+ */
+function sendMessageToBridge(
+  bridge: LedgerIframeBridge,
+  message: IFrameMessageResponse,
+): void {
+  bridge.eventListener?.({
+    origin: new URL(BRIDGE_URL).origin,
+    data: message,
+  });
+}
+
 describe('LedgerIframeBridge', function () {
   let bridge: LedgerIframeBridge;
 
@@ -139,7 +156,7 @@ describe('LedgerIframeBridge', function () {
           target: LEDGER_IFRAME_ID,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerMakeApp,
           messageId: 1,
           success: true,
@@ -164,7 +181,7 @@ describe('LedgerIframeBridge', function () {
           target: LEDGER_IFRAME_ID,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerMakeApp,
           messageId: 1,
           success: false,
@@ -188,7 +205,7 @@ describe('LedgerIframeBridge', function () {
           target: LEDGER_IFRAME_ID,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerMakeApp,
           messageId: 1,
           success: false,
@@ -214,7 +231,7 @@ describe('LedgerIframeBridge', function () {
           params: { transportType },
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerUpdateTransport,
           messageId: 1,
           success: true,
@@ -250,7 +267,7 @@ describe('LedgerIframeBridge', function () {
           target: LEDGER_IFRAME_ID,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerUpdateTransport,
           messageId: 1,
           success: false,
@@ -285,7 +302,7 @@ describe('LedgerIframeBridge', function () {
           target: LEDGER_IFRAME_ID,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerUnlock,
           messageId: 1,
           success: true,
@@ -315,7 +332,7 @@ describe('LedgerIframeBridge', function () {
           params,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerUnlock,
           messageId: 1,
           success: false,
@@ -350,7 +367,7 @@ describe('LedgerIframeBridge', function () {
           params,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerSignTransaction,
           messageId: 1,
           success: true,
@@ -378,7 +395,7 @@ describe('LedgerIframeBridge', function () {
           params,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerSignTransaction,
           messageId: 1,
           success: false,
@@ -412,7 +429,7 @@ describe('LedgerIframeBridge', function () {
           params,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerSignPersonalMessage,
           messageId: 1,
           success: true,
@@ -440,7 +457,7 @@ describe('LedgerIframeBridge', function () {
           params,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerSignPersonalMessage,
           messageId: 1,
           success: false,
@@ -489,7 +506,7 @@ describe('LedgerIframeBridge', function () {
           params,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerSignTypedData,
           messageId: 1,
           success: true,
@@ -516,7 +533,7 @@ describe('LedgerIframeBridge', function () {
           params,
         });
 
-        bridge.messageCallbacks[message.messageId]?.({
+        sendMessageToBridge(bridge, {
           action: IFrameMessageAction.LedgerSignTypedData,
           messageId: 1,
           success: false,

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
@@ -1,4 +1,5 @@
 import { createDeferredPromise, DeferredPromise } from '@metamask/utils';
+
 import {
   GetPublicKeyParams,
   GetPublicKeyResponse,

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
@@ -13,6 +13,8 @@ import {
 
 const LEDGER_IFRAME_ID = 'LEDGER-IFRAME';
 
+const IFRAME_MESSAGE_TIMEOUT = 4000;
+
 export enum IFrameMessageAction {
   LedgerIsIframeReady = 'ledger-is-iframe-ready',
   LedgerConnectionChange = 'ledger-connection-change',
@@ -332,6 +334,15 @@ export class LedgerIframeBridge
     if (!this.iframeLoaded || !this.iframe?.contentWindow) {
       throw new Error('The iframe is not loaded yet');
     }
+
+    setTimeout(() => {
+      if (this.#messageResponseHandles.has(postMsg.messageId)) {
+        this.#messageResponseHandles.delete(postMsg.messageId);
+        messageResponseHandle.reject(
+          new Error('Ledger iframe message timeout'),
+        );
+      }
+    }, IFRAME_MESSAGE_TIMEOUT);
 
     this.iframe.contentWindow.postMessage(postMsg, '*');
 

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
@@ -171,8 +171,6 @@ export class LedgerIframeBridge
   }
 
   async updateTransportMethod(transportType: string): Promise<boolean> {
-    // If the iframe isn't loaded yet, let's store the desired transportType value and
-    // optimistically return a successful promise
     if (!this.iframeLoaded) {
       throw new Error('The iframe is not loaded yet');
     }


### PR DESCRIPTION
The Ledger iframe messaging system is being refactored to be promise based instead of using callbacks. Moreover, `#sendMessage` now throws a timeout error when the message takes to long to get replied by the iframe

Related to https://github.com/MetaMask/accounts/issues/258