### PR TITLE
fix: increase ledger timeout for user action requests

### DIFF
--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -23,10 +23,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 91.78,
+      branches: 91.83,
       functions: 97.87,
-      lines: 97.15,
-      statements: 97.18,
+      lines: 97.16,
+      statements: 97.19,
     },
   },
 });

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.test.ts
@@ -198,7 +198,7 @@ describe('LedgerIframeBridge', function () {
 
     it('throws a timeout error when the message does not receive a response', async function () {
       stubKeyringIFramePostMessage(bridge, () => {
-        jest.advanceTimersByTime(5000);
+        jest.advanceTimersByTime(20_000);
       });
 
       await expect(bridge.attemptMakeApp()).rejects.toThrow(
@@ -269,7 +269,7 @@ describe('LedgerIframeBridge', function () {
       bridge.iframeLoaded = true;
       const transportType = 'u2f';
       stubKeyringIFramePostMessage(bridge, () => {
-        jest.advanceTimersByTime(5000);
+        jest.advanceTimersByTime(20_000);
       });
 
       await expect(bridge.updateTransportMethod(transportType)).rejects.toThrow(
@@ -438,7 +438,7 @@ describe('LedgerIframeBridge', function () {
       const params = { hdPath: "m/44'/60'/0'/0", tx: '' };
 
       stubKeyringIFramePostMessage(bridge, () => {
-        jest.advanceTimersByTime(5000);
+        jest.advanceTimersByTime(20_000);
       });
 
       await expect(bridge.deviceSignTransaction(params)).rejects.toThrow(
@@ -512,7 +512,7 @@ describe('LedgerIframeBridge', function () {
       const params = { hdPath: "m/44'/60'/0'/0", message: '' };
 
       stubKeyringIFramePostMessage(bridge, () => {
-        jest.advanceTimersByTime(5000);
+        jest.advanceTimersByTime(20_000);
       });
 
       await expect(bridge.deviceSignMessage(params)).rejects.toThrow(
@@ -598,7 +598,7 @@ describe('LedgerIframeBridge', function () {
 
     it('throws a timeout error when the message does not receive a response', async function () {
       stubKeyringIFramePostMessage(bridge, () => {
-        jest.advanceTimersByTime(5000);
+        jest.advanceTimersByTime(20_000);
       });
 
       await expect(bridge.deviceSignTypedData(params)).rejects.toThrow(


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
This PR increases the message response timeout for certain requests that require the user to interact with the device, or the timeout would be triggered too early, not giving enough time for the user to accept a signature request on its device

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->
