### PR TITLE
refactor: remove account.metadata.snap.{name,enabled}

### DIFF
--- a/packages/keyring-internal-api/src/types.test.ts
+++ b/packages/keyring-internal-api/src/types.test.ts
@@ -122,7 +122,7 @@ describe('InternalAccount', () => {
     );
   });
 
-  it('should contain snap name, id and enabled if the snap metadata exists', () => {
+  it('should contain snap id if the snap metadata exists', () => {
     const account: InternalAccount = {
       id: '606a7759-b0fb-48e4-9874-bab62ff8e7eb',
       address: '0x000',
@@ -138,45 +138,10 @@ describe('InternalAccount', () => {
         importTime: 1713153716,
         snap: {
           id: 'test-snap',
-          enabled: true,
-          name: 'Test Snap',
         },
       },
     };
 
     expect(() => assert(account, InternalAccountStruct)).not.toThrow();
   });
-
-  it.each([['name', 'enabled', 'id']])(
-    'should throw if snap.%s is not set',
-    (key: string) => {
-      const account: InternalAccount = {
-        id: '606a7759-b0fb-48e4-9874-bab62ff8e7eb',
-        address: '0x000',
-        options: {},
-        methods: [],
-        scopes: ['eip155:0'],
-        type: 'eip155:eoa',
-        metadata: {
-          keyring: {
-            type: 'Test Keyring',
-          },
-          name: 'Account 1',
-          importTime: 1713153716,
-          snap: {
-            id: 'test-snap',
-            enabled: true,
-            name: 'Test Snap',
-          },
-        },
-      };
-
-      // On `InternalAccount` the `metadata.snap` is optional, hence the `?.` here.
-      delete account.metadata.snap?.[key as keyof typeof account.metadata.snap];
-
-      const regex = new RegExp(`At path: metadata.snap.${key}`, 'u');
-
-      expect(() => assert(account, InternalAccountStruct)).toThrow(regex);
-    },
-  );
 });

--- a/packages/keyring-internal-api/src/types.ts
+++ b/packages/keyring-internal-api/src/types.ts
@@ -15,7 +15,7 @@ import {
 } from '@metamask/keyring-api';
 import { exactOptional, object } from '@metamask/keyring-utils';
 import type { Infer, Struct } from '@metamask/superstruct';
-import { boolean, string, number } from '@metamask/superstruct';
+import { string, number } from '@metamask/superstruct';
 
 export type InternalAccountType =
   | EthAccountType
@@ -29,8 +29,6 @@ export const InternalAccountMetadataStruct = object({
     snap: exactOptional(
       object({
         id: string(),
-        enabled: boolean(),
-        name: string(),
       }),
     ),
     lastSelected: exactOptional(number()),

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -2045,8 +2045,6 @@ describe('SnapKeyring', () => {
     it('returns the list of accounts', async () => {
       const snapMetadata = {
         id: snapId,
-        name: 'Snap Name',
-        enabled: true,
       };
       const snapObject = {
         id: snapId,
@@ -2095,7 +2093,7 @@ describe('SnapKeyring', () => {
           metadata: {
             name: '',
             importTime: 0,
-            snap: { id: snapId, name: 'snap-name', enabled: true },
+            snap: { id: snapId },
             keyring: { type: 'Snap Keyring' },
           },
         },

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -1395,9 +1395,7 @@ export class SnapKeyring extends EventEmitter {
     snapId: SnapId,
   ): InternalAccount['metadata']['snap'] | undefined {
     const snap = this.#getSnap(snapId);
-    return snap
-      ? { id: snapId, name: snap.manifest.proposedName, enabled: snap.enabled }
-      : undefined;
+    return snap ? { id: snapId } : undefined;
   }
 
   /**


### PR DESCRIPTION
Those metadata should be pulled out from the `SnapController` itself to avoid duplicated state and potential inconsistencies.

This would also remove some non-needed state-watch on the `AccountsController` (since we are listening to `SnapController:stateChange` to update those accordingly, thus triggering some other `AccountsController:stateChange` which could be avoided).
