### PR TITLE
feat: bitcoin account types

### DIFF
--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -48,8 +48,7 @@
   "dependencies": {
     "@metamask/keyring-utils": "workspace:^",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.1.0",
-    "bech32": "^2.0.0"
+    "@metamask/utils": "^11.1.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -48,7 +48,8 @@
   "dependencies": {
     "@metamask/keyring-utils": "workspace:^",
     "@metamask/superstruct": "^3.1.0",
-    "@metamask/utils": "^11.1.0"
+    "@metamask/utils": "^11.1.0",
+    "bitcoin-address-validation": "^2.2.3"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",

--- a/packages/keyring-api/src/api/account.ts
+++ b/packages/keyring-api/src/api/account.ts
@@ -17,7 +17,10 @@ export enum EthAccountType {
  * Supported Bitcoin account types.
  */
 export enum BtcAccountType {
+  P2pkh = 'bip122:p2pkh',
+  P2sh = 'bip122:p2sh',
   P2wpkh = 'bip122:p2wpkh',
+  P2tr = 'bip122:p2tr',
 }
 
 /**
@@ -33,7 +36,10 @@ export enum SolAccountType {
 export type KeyringAccountType =
   | `${EthAccountType.Eoa}`
   | `${EthAccountType.Erc4337}`
+  | `${BtcAccountType.P2pkh}`
+  | `${BtcAccountType.P2sh}`
   | `${BtcAccountType.P2wpkh}`
+  | `${BtcAccountType.P2tr}`
   | `${SolAccountType.DataAccount}`;
 
 /**
@@ -55,7 +61,10 @@ export const KeyringAccountStruct = object({
   type: enums([
     `${EthAccountType.Eoa}`,
     `${EthAccountType.Erc4337}`,
+    `${BtcAccountType.P2pkh}`,
+    `${BtcAccountType.P2sh}`,
     `${BtcAccountType.P2wpkh}`,
+    `${BtcAccountType.P2tr}`,
     `${SolAccountType.DataAccount}`,
   ]),
 

--- a/packages/keyring-api/src/btc/types.test-d.ts
+++ b/packages/keyring-api/src/btc/types.test-d.ts
@@ -1,8 +1,16 @@
 import type { Extends } from '@metamask/keyring-utils';
 import { expectTrue } from '@metamask/keyring-utils';
 
-import type { BtcP2wpkhAccount } from './types';
+import type {
+  BtcP2pkhAccount,
+  BtcP2shAccount,
+  BtcP2trAccount,
+  BtcP2wpkhAccount,
+} from './types';
 import type { KeyringAccount } from '../api';
 
-// `BtcP2wpkhAccount` extends `KeyringAccount`
+// BTC account types extend `KeyringAccount`
+expectTrue<Extends<BtcP2pkhAccount, KeyringAccount>>();
+expectTrue<Extends<BtcP2shAccount, KeyringAccount>>();
 expectTrue<Extends<BtcP2wpkhAccount, KeyringAccount>>();
+expectTrue<Extends<BtcP2trAccount, KeyringAccount>>();

--- a/packages/keyring-api/src/btc/types.test.ts
+++ b/packages/keyring-api/src/btc/types.test.ts
@@ -14,6 +14,18 @@ import {
 } from './types';
 import { BtcAccountType } from '../api';
 
+const BTC_P2PKH_MAINNET_ADDRESS = '1AXaVdPBb6zqrTMb6ebrBb9g3JmeAPGeCF';
+const BTC_P2SH_MAINNET_ADDRESS = '3KQPirCGGbVyWJLGuWN6VPC7uLeiarYB7x';
+const BTC_P2WPKH_MAINNET_ADDRESS = 'bc1q4degm5k044n9xv3ds7d8l6hfavydte6wn6sesw';
+const BTC_P2TR_MAINNET_ADDRESS =
+  'bc1pxfxst7zrkw39vzh0pchq5ey0q7z6u739cudhz5vmg89wa4kyyp9qzrf5sp';
+
+const BTC_P2PKH_TESTNET_ADDRESS = 'mrDHfcAPosFsabxBKe2U3EdxX5Kph8Zd4f';
+const BTC_P2SH_TESTNET_ADDRESS = '2N7AeKCw7p8uRRQjXPeHW7UPGhR8LYHEzBT';
+const BTC_P2WPKH_TESTNET_ADDRESS = 'tb1qqecaw32rvyjgez706t5chpr8gan49wfuk94t3g';
+const BTC_P2TR_TESTNET_ADDRESS =
+  'tb1p6epn3ctassfp54lnztshnpfjekn7khyarrnm6f0yv738lgc53xxsgevs8k';
+
 describe('types', () => {
   const mockAccount = {
     id: '55583f38-d81b-48f8-8494-fc543c2b5c95',
@@ -26,25 +38,36 @@ describe('types', () => {
     const p2pkhAccount: BtcP2pkhAccount = {
       ...mockAccount,
       type: BtcAccountType.P2pkh,
-      address: '15feVv7kK3z7jxA4RZZzY7Fwdu3yqFwzcT',
+      address: BTC_P2PKH_MAINNET_ADDRESS,
     };
 
-    it.each([
-      '15feVv7kK3z7jxA4RZZzY7Fwdu3yqFwzcT',
-      'mjPQaLkhZN3MxsYN8Nebzwevuz8vdTaRCq',
-    ])('is valid; %s', (address) => {
-      expect(() =>
-        BtcP2pkhAccountStruct.assert({ ...p2pkhAccount, address }),
-      ).not.toThrow();
-    });
+    it.each([BTC_P2PKH_MAINNET_ADDRESS, BTC_P2PKH_TESTNET_ADDRESS])(
+      'is valid; %s',
+      (address) => {
+        expect(() =>
+          BtcP2pkhAccountStruct.assert({ ...p2pkhAccount, address }),
+        ).not.toThrow();
+      },
+    );
 
-    it('throws an error if the address is invalid', () => {
+    it('throws an error if the address fails to be decoded', () => {
       expect(() =>
         BtcP2pkhAccountStruct.assert({
           ...p2pkhAccount,
           address: 'invalidAddress',
         }),
-      ).toThrow('At path: address -- Invalid p2pkh address: Invalid address');
+      ).toThrow(
+        'At path: address -- Failed to decode p2pkh address: Invalid address',
+      );
+    });
+
+    it('throws an error if the address type is invalid', () => {
+      expect(() =>
+        BtcP2pkhAccountStruct.assert({
+          ...p2pkhAccount,
+          address: BTC_P2WPKH_MAINNET_ADDRESS,
+        }),
+      ).toThrow('At path: address -- Invalid p2pkh address');
     });
 
     it('throws an error if there is no scope', () => {
@@ -60,25 +83,36 @@ describe('types', () => {
     const p2shAccount: BtcP2shAccount = {
       ...mockAccount,
       type: BtcAccountType.P2sh,
-      address: '3QVSaDYjxEh4L3K24eorrQjfVxPAKJMys2',
+      address: BTC_P2SH_MAINNET_ADDRESS,
     };
 
-    it.each([
-      '3QVSaDYjxEh4L3K24eorrQjfVxPAKJMys2',
-      '2NBG623WvXp1zxKB6gK2mnMe2mSDCur5qRU',
-    ])('is valid; %s', (address) => {
-      expect(() =>
-        BtcP2shAccountStruct.assert({ ...p2shAccount, address }),
-      ).not.toThrow();
-    });
+    it.each([BTC_P2SH_MAINNET_ADDRESS, BTC_P2SH_TESTNET_ADDRESS])(
+      'is valid; %s',
+      (address) => {
+        expect(() =>
+          BtcP2shAccountStruct.assert({ ...p2shAccount, address }),
+        ).not.toThrow();
+      },
+    );
 
-    it('throws an error if the address is invalid', () => {
+    it('throws an error if the address fails to be decoded', () => {
       expect(() =>
         BtcP2shAccountStruct.assert({
           ...p2shAccount,
           address: 'invalidAddress',
         }),
-      ).toThrow('At path: address -- Invalid p2sh address: Invalid address');
+      ).toThrow(
+        'At path: address -- Failed to decode p2sh address: Invalid address',
+      );
+    });
+
+    it('throws an error if the address type is invalid', () => {
+      expect(() =>
+        BtcP2shAccountStruct.assert({
+          ...p2shAccount,
+          address: BTC_P2PKH_MAINNET_ADDRESS,
+        }),
+      ).toThrow('At path: address -- Invalid p2sh address');
     });
 
     it('throws an error if there is no scope', () => {
@@ -94,25 +128,36 @@ describe('types', () => {
     const p2wpkhAccount: BtcP2wpkhAccount = {
       ...mockAccount,
       type: BtcAccountType.P2wpkh,
-      address: 'bc1qe2e3tdkqwytw7furyl2nlfy3sqs23acynn50d9',
+      address: BTC_P2WPKH_MAINNET_ADDRESS,
     };
 
-    it.each([
-      'bc1qe2e3tdkqwytw7furyl2nlfy3sqs23acynn50d9',
-      'tb1qmh8qny6ezjlg4phl68lj82drr76zume6txt032',
-    ])('is valid; %s', (address) => {
-      expect(() =>
-        BtcP2wpkhAccountStruct.assert({ ...p2wpkhAccount, address }),
-      ).not.toThrow();
-    });
+    it.each([BTC_P2WPKH_MAINNET_ADDRESS, BTC_P2WPKH_TESTNET_ADDRESS])(
+      'is valid; %s',
+      (address) => {
+        expect(() =>
+          BtcP2wpkhAccountStruct.assert({ ...p2wpkhAccount, address }),
+        ).not.toThrow();
+      },
+    );
 
-    it('throws an error if the address is invalid', () => {
+    it('throws an error if the address fails to be decoded', () => {
       expect(() =>
         BtcP2wpkhAccountStruct.assert({
           ...p2wpkhAccount,
           address: 'invalidAddress',
         }),
-      ).toThrow('At path: address -- Invalid p2wpkh address: Invalid address');
+      ).toThrow(
+        'At path: address -- Failed to decode p2wpkh address: Invalid address',
+      );
+    });
+
+    it('throws an error if the address type is invalid', () => {
+      expect(() =>
+        BtcP2wpkhAccountStruct.assert({
+          ...p2wpkhAccount,
+          address: BTC_P2PKH_MAINNET_ADDRESS,
+        }),
+      ).toThrow('At path: address -- Invalid p2wpkh address');
     });
 
     it('throws an error if there is no scope', () => {
@@ -128,25 +173,36 @@ describe('types', () => {
     const p2trAccount: BtcP2trAccount = {
       ...mockAccount,
       type: BtcAccountType.P2tr,
-      address: 'bc1p4rue37y0v9snd4z3fvw43d29u97qxf9j3fva72xy2t7hekg24dzsaz40mz',
+      address: BTC_P2TR_MAINNET_ADDRESS,
     };
 
-    it.each([
-      'bc1p4rue37y0v9snd4z3fvw43d29u97qxf9j3fva72xy2t7hekg24dzsaz40mz',
-      'tb1pwwjax3vpq6h69965hcr22vkpm4qdvyu2pz67wyj8eagp9vxkcz0q0ya20h',
-    ])('is valid address; %s', (address) => {
-      expect(() =>
-        BtcP2trAccountStruct.assert({ ...p2trAccount, address }),
-      ).not.toThrow();
-    });
+    it.each([BTC_P2TR_MAINNET_ADDRESS, BTC_P2TR_TESTNET_ADDRESS])(
+      'is valid address; %s',
+      (address) => {
+        expect(() =>
+          BtcP2trAccountStruct.assert({ ...p2trAccount, address }),
+        ).not.toThrow();
+      },
+    );
 
-    it('throws an error if the address is invalid', () => {
+    it('throws an error if the address fails to be decoded', () => {
       expect(() =>
         BtcP2trAccountStruct.assert({
           ...p2trAccount,
           address: 'invalidAddress',
         }),
-      ).toThrow('At path: address -- Invalid p2tr address: Invalid address');
+      ).toThrow(
+        'At path: address -- Failed to decode p2tr address: Invalid address',
+      );
+    });
+
+    it('throws an error if the address type is invalid', () => {
+      expect(() =>
+        BtcP2trAccountStruct.assert({
+          ...p2trAccount,
+          address: BTC_P2PKH_MAINNET_ADDRESS,
+        }),
+      ).toThrow('At path: address -- Invalid p2tr address');
     });
 
     it('throws an error if there is no scope', () => {

--- a/packages/keyring-api/src/btc/types.test.ts
+++ b/packages/keyring-api/src/btc/types.test.ts
@@ -1,10 +1,6 @@
 import { BtcScope } from './constants';
 import type { BtcP2wpkhAccount } from './types';
-import {
-  BtcMethod,
-  BtcP2wpkhAccountStruct,
-  BtcP2wpkhAddressStruct,
-} from './types';
+import { BtcMethod, BtcAccountStruct } from './types';
 import { BtcAccountType } from '../api';
 
 const MOCK_ACCOUNT = {
@@ -17,49 +13,13 @@ const MOCK_ACCOUNT = {
 };
 
 describe('types', () => {
-  describe('BtcP2wpkhAddressStruct', () => {
-    const errorPrefix = 'Could not decode P2WPKH address';
-
-    it.each([
-      'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
-      'tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx',
-    ])('is valid address; %s', (address) => {
-      expect(() => BtcP2wpkhAddressStruct.assert(address)).not.toThrow();
-    });
-
-    it.each([
-      // Too short
-      '',
-      'bc1q',
-      // Must have at least 6 characters after separator '1'
-      'bc1q000',
-    ])('throws an error if address is too short: %s', (address) => {
-      expect(() => BtcP2wpkhAddressStruct.assert(address)).toThrow(
-        `${errorPrefix}: ${address} too short`,
-      );
-    });
-
-    it('throws an error if address is too long', () => {
-      const address =
-        'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4w508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4w508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
-      expect(() => BtcP2wpkhAddressStruct.assert(address)).toThrow(
-        `${errorPrefix}: Exceeds length limit`,
-      );
-    });
-
-    it('throws an error if there no seperator', () => {
-      const address = 'bc0qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4';
-      expect(() => BtcP2wpkhAddressStruct.assert(address)).toThrow(
-        `${errorPrefix}: No separator character for ${address}`,
-      );
-    });
-
+  describe('BtcP2wpkhAccountStruct', () => {
     it('throws an error if there are multiple scopes', () => {
       const account: BtcP2wpkhAccount = {
         ...MOCK_ACCOUNT,
         scopes: [BtcScope.Mainnet, BtcScope.Testnet],
       };
-      expect(() => BtcP2wpkhAccountStruct.assert(account)).toThrow(
+      expect(() => BtcAccountStruct.assert(account)).toThrow(
         'At path: scopes -- Expected a array with a length of `1` but received one with a length of `2`',
       );
     });
@@ -69,7 +29,7 @@ describe('types', () => {
         ...MOCK_ACCOUNT,
         scopes: [],
       };
-      expect(() => BtcP2wpkhAccountStruct.assert(account)).toThrow(
+      expect(() => BtcAccountStruct.assert(account)).toThrow(
         'At path: scopes -- Expected a array with a length of `1` but received one with a length of `0`',
       );
     });

--- a/packages/keyring-api/src/btc/types.test.ts
+++ b/packages/keyring-api/src/btc/types.test.ts
@@ -1,36 +1,159 @@
 import { BtcScope } from './constants';
-import type { BtcP2wpkhAccount } from './types';
-import { BtcMethod, BtcAccountStruct } from './types';
+import type {
+  BtcP2pkhAccount,
+  BtcP2shAccount,
+  BtcP2trAccount,
+  BtcP2wpkhAccount,
+} from './types';
+import {
+  BtcMethod,
+  BtcP2pkhAccountStruct,
+  BtcP2shAccountStruct,
+  BtcP2trAccountStruct,
+  BtcP2wpkhAccountStruct,
+} from './types';
 import { BtcAccountType } from '../api';
 
-const MOCK_ACCOUNT = {
-  id: '55583f38-d81b-48f8-8494-fc543c2b5c95',
-  type: BtcAccountType.P2wpkh,
-  address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
-  methods: [BtcMethod.SendBitcoin],
-  options: {},
-  scopes: [BtcScope.Mainnet],
-};
-
 describe('types', () => {
-  describe('BtcP2wpkhAccountStruct', () => {
-    it('throws an error if there are multiple scopes', () => {
-      const account: BtcP2wpkhAccount = {
-        ...MOCK_ACCOUNT,
-        scopes: [BtcScope.Mainnet, BtcScope.Testnet],
-      };
-      expect(() => BtcAccountStruct.assert(account)).toThrow(
-        'At path: scopes -- Expected a array with a length of `1` but received one with a length of `2`',
-      );
+  const mockAccount = {
+    id: '55583f38-d81b-48f8-8494-fc543c2b5c95',
+    methods: [BtcMethod.SendBitcoin],
+    options: {},
+    scopes: [BtcScope.Mainnet],
+  };
+
+  describe('BtcP2pkhAccount', () => {
+    const p2pkhAccount: BtcP2pkhAccount = {
+      ...mockAccount,
+      type: BtcAccountType.P2pkh,
+      address: '15feVv7kK3z7jxA4RZZzY7Fwdu3yqFwzcT',
+    };
+
+    it.each([
+      '15feVv7kK3z7jxA4RZZzY7Fwdu3yqFwzcT',
+      'mjPQaLkhZN3MxsYN8Nebzwevuz8vdTaRCq',
+    ])('is valid; %s', (address) => {
+      expect(() =>
+        BtcP2pkhAccountStruct.assert({ ...p2pkhAccount, address }),
+      ).not.toThrow();
+    });
+
+    it('throws an error if the address is invalid', () => {
+      expect(() =>
+        BtcP2pkhAccountStruct.assert({
+          ...p2pkhAccount,
+          address: 'invalidAddress',
+        }),
+      ).toThrow('At path: address -- Invalid p2pkh address: Invalid address');
     });
 
     it('throws an error if there is no scope', () => {
-      const account: BtcP2wpkhAccount = {
-        ...MOCK_ACCOUNT,
-        scopes: [],
-      };
-      expect(() => BtcAccountStruct.assert(account)).toThrow(
-        'At path: scopes -- Expected a array with a length of `1` but received one with a length of `0`',
+      expect(() =>
+        BtcP2pkhAccountStruct.assert({ ...p2pkhAccount, scopes: [] }),
+      ).toThrow(
+        'At path: scopes -- Expected a nonempty array but received an empty one',
+      );
+    });
+  });
+
+  describe('BtcP2shAccount', () => {
+    const p2shAccount: BtcP2shAccount = {
+      ...mockAccount,
+      type: BtcAccountType.P2sh,
+      address: '3QVSaDYjxEh4L3K24eorrQjfVxPAKJMys2',
+    };
+
+    it.each([
+      '3QVSaDYjxEh4L3K24eorrQjfVxPAKJMys2',
+      '2NBG623WvXp1zxKB6gK2mnMe2mSDCur5qRU',
+    ])('is valid; %s', (address) => {
+      expect(() =>
+        BtcP2shAccountStruct.assert({ ...p2shAccount, address }),
+      ).not.toThrow();
+    });
+
+    it('throws an error if the address is invalid', () => {
+      expect(() =>
+        BtcP2shAccountStruct.assert({
+          ...p2shAccount,
+          address: 'invalidAddress',
+        }),
+      ).toThrow('At path: address -- Invalid p2sh address: Invalid address');
+    });
+
+    it('throws an error if there is no scope', () => {
+      expect(() =>
+        BtcP2shAccountStruct.assert({ ...p2shAccount, scopes: [] }),
+      ).toThrow(
+        'At path: scopes -- Expected a nonempty array but received an empty one',
+      );
+    });
+  });
+
+  describe('BtcP2wpkhAccount', () => {
+    const p2wpkhAccount: BtcP2wpkhAccount = {
+      ...mockAccount,
+      type: BtcAccountType.P2wpkh,
+      address: 'bc1qe2e3tdkqwytw7furyl2nlfy3sqs23acynn50d9',
+    };
+
+    it.each([
+      'bc1qe2e3tdkqwytw7furyl2nlfy3sqs23acynn50d9',
+      'tb1qmh8qny6ezjlg4phl68lj82drr76zume6txt032',
+    ])('is valid; %s', (address) => {
+      expect(() =>
+        BtcP2wpkhAccountStruct.assert({ ...p2wpkhAccount, address }),
+      ).not.toThrow();
+    });
+
+    it('throws an error if the address is invalid', () => {
+      expect(() =>
+        BtcP2wpkhAccountStruct.assert({
+          ...p2wpkhAccount,
+          address: 'invalidAddress',
+        }),
+      ).toThrow('At path: address -- Invalid p2wpkh address: Invalid address');
+    });
+
+    it('throws an error if there is no scope', () => {
+      expect(() =>
+        BtcP2wpkhAccountStruct.assert({ ...p2wpkhAccount, scopes: [] }),
+      ).toThrow(
+        'At path: scopes -- Expected a nonempty array but received an empty one',
+      );
+    });
+  });
+
+  describe('BtcP2trAccount', () => {
+    const p2trAccount: BtcP2trAccount = {
+      ...mockAccount,
+      type: BtcAccountType.P2tr,
+      address: 'bc1p4rue37y0v9snd4z3fvw43d29u97qxf9j3fva72xy2t7hekg24dzsaz40mz',
+    };
+
+    it.each([
+      'bc1p4rue37y0v9snd4z3fvw43d29u97qxf9j3fva72xy2t7hekg24dzsaz40mz',
+      'tb1pwwjax3vpq6h69965hcr22vkpm4qdvyu2pz67wyj8eagp9vxkcz0q0ya20h',
+    ])('is valid address; %s', (address) => {
+      expect(() =>
+        BtcP2trAccountStruct.assert({ ...p2trAccount, address }),
+      ).not.toThrow();
+    });
+
+    it('throws an error if the address is invalid', () => {
+      expect(() =>
+        BtcP2trAccountStruct.assert({
+          ...p2trAccount,
+          address: 'invalidAddress',
+        }),
+      ).toThrow('At path: address -- Invalid p2tr address: Invalid address');
+    });
+
+    it('throws an error if there is no scope', () => {
+      expect(() =>
+        BtcP2trAccountStruct.assert({ ...p2trAccount, scopes: [] }),
+      ).toThrow(
+        'At path: scopes -- Expected a nonempty array but received an empty one',
       );
     });
   });

--- a/packages/keyring-api/src/btc/types.ts
+++ b/packages/keyring-api/src/btc/types.ts
@@ -18,9 +18,14 @@ const validateAddress = (
   type: AddressType,
 ): boolean | Error => {
   try {
-    return isBtcAddress(address, type);
+    if (isBtcAddress(address, type)) {
+      return true;
+    }
+    return new Error(`Invalid ${type} address`);
   } catch (error) {
-    return new Error(`Invalid ${type} address: ${(error as Error).message}`);
+    return new Error(
+      `Failed to decode ${type} address: ${(error as Error).message}`,
+    );
   }
 };
 

--- a/packages/keyring-api/src/btc/types.ts
+++ b/packages/keyring-api/src/btc/types.ts
@@ -1,4 +1,4 @@
-import { isBtcAddress, object } from '@metamask/keyring-utils';
+import { object } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 import {
   string,
@@ -8,17 +8,21 @@ import {
   literal,
   nonempty,
 } from '@metamask/superstruct';
-import { AddressType } from 'bitcoin-address-validation';
+import { AddressType, getAddressInfo } from 'bitcoin-address-validation';
 
-import { BtcScope } from './constants';
-import { BtcAccountType, KeyringAccountStruct } from '../api';
+import {
+  BtcAccountType,
+  CaipChainIdStruct,
+  KeyringAccountStruct,
+} from '../api';
 
 const validateAddress = (
   address: string,
   type: AddressType,
 ): boolean | Error => {
   try {
-    if (isBtcAddress(address, type)) {
+    const addressInfo = getAddressInfo(address);
+    if (addressInfo.type === type) {
       return true;
     }
     return new Error(`Invalid ${type} address`);
@@ -75,7 +79,7 @@ const BtcAccountStruct = object({
   /**
    * Account supported scopes (CAIP-2 chain ID).
    */
-  scopes: nonempty(array(enums(Object.values(BtcScope)))),
+  scopes: nonempty(array(CaipChainIdStruct)),
 
   /**
    * Account supported methods.

--- a/packages/keyring-api/src/btc/types.ts
+++ b/packages/keyring-api/src/btc/types.ts
@@ -1,35 +1,12 @@
 import { object } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
-import {
-  string,
-  array,
-  enums,
-  refine,
-  literal,
-  size,
-} from '@metamask/superstruct';
-import { bech32 } from 'bech32';
+import { string, array, enums, size } from '@metamask/superstruct';
 
 import {
   BtcAccountType,
   KeyringAccountStruct,
   CaipChainIdStruct,
 } from '../api';
-
-export const BtcP2wpkhAddressStruct = refine(
-  string(),
-  'BtcP2wpkhAddressStruct',
-  (address: string) => {
-    try {
-      bech32.decode(address);
-    } catch (error) {
-      return new Error(
-        `Could not decode P2WPKH address: ${(error as Error).message}`,
-      );
-    }
-    return true;
-  },
-);
 
 /**
  * Supported Bitcoin methods.
@@ -39,18 +16,18 @@ export enum BtcMethod {
   SendBitcoin = 'sendBitcoin',
 }
 
-export const BtcP2wpkhAccountStruct = object({
+export const BtcAccountStruct = object({
   ...KeyringAccountStruct.schema,
 
   /**
    * Account address.
    */
-  address: BtcP2wpkhAddressStruct,
+  address: string(),
 
   /**
    * Account type.
    */
-  type: literal(`${BtcAccountType.P2wpkh}`),
+  type: enums(Object.values(BtcAccountType)),
 
   /**
    * Account supported scope (CAIP-2 chain ID).
@@ -65,4 +42,4 @@ export const BtcP2wpkhAccountStruct = object({
   methods: array(enums([`${BtcMethod.SendBitcoin}`])),
 });
 
-export type BtcP2wpkhAccount = Infer<typeof BtcP2wpkhAccountStruct>;
+export type BtcP2wpkhAccount = Infer<typeof BtcAccountStruct>;

--- a/packages/keyring-api/src/eth/utils.test.ts
+++ b/packages/keyring-api/src/eth/utils.test.ts
@@ -5,7 +5,10 @@ describe('isEvmAccountType', () => {
   it.each([
     [EthAccountType.Eoa, true],
     [EthAccountType.Erc4337, true],
+    [BtcAccountType.P2pkh, false],
+    [BtcAccountType.P2sh, false],
     [BtcAccountType.P2wpkh, false],
+    [BtcAccountType.P2tr, false],
     [SolAccountType.DataAccount, false],
     [{}, false],
     [null, false],

--- a/packages/keyring-internal-api/src/types.ts
+++ b/packages/keyring-internal-api/src/types.ts
@@ -8,7 +8,7 @@ import {
   EthAccountType,
   KeyringAccountStruct,
   SolAccountType,
-  BtcP2wpkhAccountStruct,
+  BtcAccountStruct,
   EthEoaAccountStruct,
   EthErc4337AccountStruct,
   SolDataAccountStruct,
@@ -51,8 +51,8 @@ export const InternalEthErc4337AccountStruct = object({
   ...InternalAccountMetadataStruct.schema,
 });
 
-export const InternalBtcP2wpkhAccountStruct = object({
-  ...BtcP2wpkhAccountStruct.schema,
+export const InternalBtcAccountStruct = object({
+  ...BtcAccountStruct.schema,
   ...InternalAccountMetadataStruct.schema,
 });
 
@@ -67,9 +67,7 @@ export type InternalEthErc4337Account = Infer<
   typeof InternalEthErc4337AccountStruct
 >;
 
-export type InternalBtcP2wpkhAccount = Infer<
-  typeof InternalBtcP2wpkhAccountStruct
->;
+export type InternalBtcAccount = Infer<typeof InternalBtcAccountStruct>;
 
 export type InternalSolDataAccount = Infer<typeof InternalSolDataAccountStruct>;
 
@@ -77,19 +75,22 @@ export const InternalAccountStructs: Record<
   string,
   | Struct<InternalEthEoaAccount>
   | Struct<InternalEthErc4337Account>
-  | Struct<InternalBtcP2wpkhAccount>
+  | Struct<InternalBtcAccount>
   | Struct<InternalSolDataAccount>
 > = {
   [`${EthAccountType.Eoa}`]: InternalEthEoaAccountStruct,
   [`${EthAccountType.Erc4337}`]: InternalEthErc4337AccountStruct,
-  [`${BtcAccountType.P2wpkh}`]: InternalBtcP2wpkhAccountStruct,
+  [`${BtcAccountType.P2pkh}`]: InternalBtcAccountStruct,
+  [`${BtcAccountType.P2sh}`]: InternalBtcAccountStruct,
+  [`${BtcAccountType.P2wpkh}`]: InternalBtcAccountStruct,
+  [`${BtcAccountType.P2tr}`]: InternalBtcAccountStruct,
   [`${SolAccountType.DataAccount}`]: InternalSolDataAccountStruct,
 };
 
 export type InternalAccountTypes =
   | InternalEthEoaAccount
   | InternalEthErc4337Account
-  | InternalBtcP2wpkhAccount
+  | InternalBtcAccount
   | InternalSolDataAccount;
 
 export const InternalAccountStruct = object({

--- a/packages/keyring-internal-api/src/types.ts
+++ b/packages/keyring-internal-api/src/types.ts
@@ -8,7 +8,10 @@ import {
   EthAccountType,
   KeyringAccountStruct,
   SolAccountType,
-  BtcAccountStruct,
+  BtcP2pkhAccountStruct,
+  BtcP2shAccountStruct,
+  BtcP2wpkhAccountStruct,
+  BtcP2trAccountStruct,
   EthEoaAccountStruct,
   EthErc4337AccountStruct,
   SolDataAccountStruct,
@@ -51,8 +54,23 @@ export const InternalEthErc4337AccountStruct = object({
   ...InternalAccountMetadataStruct.schema,
 });
 
-export const InternalBtcAccountStruct = object({
-  ...BtcAccountStruct.schema,
+export const InternalBtcP2pkhAccountStruct = object({
+  ...BtcP2pkhAccountStruct.schema,
+  ...InternalAccountMetadataStruct.schema,
+});
+
+export const InternalBtcP2shAccountStruct = object({
+  ...BtcP2shAccountStruct.schema,
+  ...InternalAccountMetadataStruct.schema,
+});
+
+export const InternalBtcP2wpkhAccountStruct = object({
+  ...BtcP2wpkhAccountStruct.schema,
+  ...InternalAccountMetadataStruct.schema,
+});
+
+export const InternalBtcP2trAccountStruct = object({
+  ...BtcP2trAccountStruct.schema,
   ...InternalAccountMetadataStruct.schema,
 });
 
@@ -67,7 +85,17 @@ export type InternalEthErc4337Account = Infer<
   typeof InternalEthErc4337AccountStruct
 >;
 
-export type InternalBtcAccount = Infer<typeof InternalBtcAccountStruct>;
+export type InternalBtcP2pkhAccount = Infer<
+  typeof InternalBtcP2pkhAccountStruct
+>;
+
+export type InternalBtcP2shAccount = Infer<typeof InternalBtcP2shAccountStruct>;
+
+export type InternalBtcP2wpkhAccount = Infer<
+  typeof InternalBtcP2wpkhAccountStruct
+>;
+
+export type InternalBtcP2trAccount = Infer<typeof InternalBtcP2trAccountStruct>;
 
 export type InternalSolDataAccount = Infer<typeof InternalSolDataAccountStruct>;
 
@@ -75,22 +103,28 @@ export const InternalAccountStructs: Record<
   string,
   | Struct<InternalEthEoaAccount>
   | Struct<InternalEthErc4337Account>
-  | Struct<InternalBtcAccount>
+  | Struct<InternalBtcP2pkhAccount>
+  | Struct<InternalBtcP2shAccount>
+  | Struct<InternalBtcP2wpkhAccount>
+  | Struct<InternalBtcP2trAccount>
   | Struct<InternalSolDataAccount>
 > = {
   [`${EthAccountType.Eoa}`]: InternalEthEoaAccountStruct,
   [`${EthAccountType.Erc4337}`]: InternalEthErc4337AccountStruct,
-  [`${BtcAccountType.P2pkh}`]: InternalBtcAccountStruct,
-  [`${BtcAccountType.P2sh}`]: InternalBtcAccountStruct,
-  [`${BtcAccountType.P2wpkh}`]: InternalBtcAccountStruct,
-  [`${BtcAccountType.P2tr}`]: InternalBtcAccountStruct,
+  [`${BtcAccountType.P2pkh}`]: InternalBtcP2pkhAccountStruct,
+  [`${BtcAccountType.P2sh}`]: InternalBtcP2shAccountStruct,
+  [`${BtcAccountType.P2wpkh}`]: InternalBtcP2wpkhAccountStruct,
+  [`${BtcAccountType.P2tr}`]: InternalBtcP2trAccountStruct,
   [`${SolAccountType.DataAccount}`]: InternalSolDataAccountStruct,
 };
 
 export type InternalAccountTypes =
   | InternalEthEoaAccount
   | InternalEthErc4337Account
-  | InternalBtcAccount
+  | InternalBtcP2pkhAccount
+  | InternalBtcP2shAccount
+  | InternalBtcP2wpkhAccount
+  | InternalBtcP2trAccount
   | InternalSolDataAccount;
 
 export const InternalAccountStruct = object({

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -151,17 +151,35 @@ describe('SnapKeyring', () => {
     scopes: [EthScope.Testnet],
     type: EthAccountType.Erc4337,
   };
-  const btcP2wpkhAccount = {
+  const btcAccount = {
     id: '11cffca0-12cc-4779-8f82-23273c062e29',
-    address: 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh',
+    address: 'bc1q4degm5k044n9xv3ds7d8l6hfavydte6wn6sesw',
     options: {},
     methods: [...Object.values(BtcMethod)],
     scopes: [BtcScope.Mainnet],
     type: BtcAccountType.P2wpkh,
   };
-  const btcP2wpkhTestnetAccount = {
+  const btcAccountP2pkh = {
+    ...btcAccount,
+    id: '12cffca0-12cc-4779-8f82-23273c062e29',
+    address: '1AXaVdPBb6zqrTMb6ebrBb9g3JmeAPGeCF',
+    type: BtcAccountType.P2pkh,
+  };
+  const btcAccountP2sh = {
+    ...btcAccount,
+    id: '13cffca0-12cc-4779-8f82-23273c062e29',
+    address: '3KQPirCGGbVyWJLGuWN6VPC7uLeiarYB7x',
+    type: BtcAccountType.P2sh,
+  };
+  const btcAccountP2tr = {
+    ...btcAccount,
+    id: '14cffca0-12cc-4779-8f82-23273c062e29',
+    address: 'bc1pxfxst7zrkw39vzh0pchq5ey0q7z6u739cudhz5vmg89wa4kyyp9qzrf5sp',
+    type: BtcAccountType.P2tr,
+  };
+  const btcTestnetAccount = {
     id: 'cac9ecb8-94de-442f-8e19-6b2439b2deb1',
-    address: 'tb1q6rmsq3vlfdhjdhtkxlqtuhhlr6pmj09y6w43g8',
+    address: 'tb1qqecaw32rvyjgez706t5chpr8gan49wfuk94t3g',
     options: {},
     methods: [...Object.values(BtcMethod)],
     scopes: [BtcScope.Testnet],
@@ -206,7 +224,10 @@ describe('SnapKeyring', () => {
     ethEoaAccount2,
     ethEoaAccount3,
     ethErc4337Account,
-    btcP2wpkhAccount,
+    btcAccount,
+    btcAccountP2pkh,
+    btcAccountP2sh,
+    btcAccountP2tr,
     solDataAccount,
   ] as const;
 
@@ -538,7 +559,7 @@ describe('SnapKeyring', () => {
         keyring = new SnapKeyring(mockSnapKeyringMessenger, mockCallbacks);
 
         // Omit `scopes` from non-EVM `account`.
-        const account = noScopes(btcP2wpkhAccount);
+        const account = noScopes(btcAccount);
         await expect(
           keyring.handleKeyringSnapMessage(snapId, {
             method: KeyringEvent.AccountCreated,
@@ -1068,7 +1089,7 @@ describe('SnapKeyring', () => {
 
       it('updates a non-EVM account with the no scope will throw an error', async () => {
         // Omit `scopes` from non-EVM `account`.
-        const account = noScopes(btcP2wpkhAccount);
+        const account = noScopes(btcAccount);
 
         // Return the updated list of accounts when the keyring requests it.
         mockMessenger.handleRequest.mockResolvedValue([{ ...account }]);
@@ -1102,7 +1123,10 @@ describe('SnapKeyring', () => {
           ethEoaAccount2.address.toLowerCase(),
           ethEoaAccount3.address.toLowerCase(),
           ethErc4337Account.address.toLowerCase(),
-          btcP2wpkhAccount.address,
+          btcAccount.address,
+          btcAccountP2pkh.address,
+          btcAccountP2sh.address,
+          btcAccountP2tr.address,
           solDataAccount.address,
         ]);
       });
@@ -1117,7 +1141,10 @@ describe('SnapKeyring', () => {
           ethEoaAccount2.address.toLowerCase(),
           ethEoaAccount3.address.toLowerCase(),
           ethErc4337Account.address.toLowerCase(),
-          btcP2wpkhAccount.address,
+          btcAccount.address,
+          btcAccountP2pkh.address,
+          btcAccountP2sh.address,
+          btcAccountP2tr.address,
           solDataAccount.address,
         ]);
       });
@@ -1293,7 +1320,10 @@ describe('SnapKeyring', () => {
         ethEoaAccount2.address.toLowerCase(),
         ethEoaAccount3.address.toLowerCase(),
         ethErc4337Account.address.toLowerCase(),
-        btcP2wpkhAccount.address,
+        btcAccount.address,
+        btcAccountP2pkh.address,
+        btcAccountP2sh.address,
+        btcAccountP2tr.address,
         solDataAccount.address,
       ]);
     });
@@ -1307,7 +1337,10 @@ describe('SnapKeyring', () => {
           [ethEoaAccount2.id]: { account: ethEoaAccount2, snapId },
           [ethEoaAccount3.id]: { account: ethEoaAccount3, snapId },
           [ethErc4337Account.id]: { account: ethErc4337Account, snapId },
-          [btcP2wpkhAccount.id]: { account: btcP2wpkhAccount, snapId },
+          [btcAccount.id]: { account: btcAccount, snapId },
+          [btcAccountP2pkh.id]: { account: btcAccountP2pkh, snapId },
+          [btcAccountP2sh.id]: { account: btcAccountP2sh, snapId },
+          [btcAccountP2tr.id]: { account: btcAccountP2tr, snapId },
           [solDataAccount.id]: { account: solDataAccount, snapId },
         },
       };
@@ -1349,8 +1382,11 @@ describe('SnapKeyring', () => {
     it.each([
       ethEoaAccount1,
       ethErc4337Account,
-      btcP2wpkhAccount,
-      btcP2wpkhTestnetAccount,
+      btcAccount,
+      btcAccountP2pkh,
+      btcAccountP2sh,
+      btcAccountP2tr,
+      btcTestnetAccount,
       solDataAccount,
     ])('migrates accounts v1: %s', async (expectedAccount: KeyringAccount) => {
       // A v1 account has no scopes, so remove it.
@@ -1371,8 +1407,8 @@ describe('SnapKeyring', () => {
     it.each([
       ethEoaAccount1,
       ethErc4337Account,
-      btcP2wpkhAccount,
-      btcP2wpkhTestnetAccount,
+      btcAccount,
+      btcTestnetAccount,
       solDataAccount,
     ])(
       'migrates v2 accounts to v1 accounts is noop: %s',
@@ -2019,6 +2055,9 @@ describe('SnapKeyring', () => {
         accounts[3].address,
         accounts[4].address,
         accounts[5].address,
+        accounts[6].address,
+        accounts[7].address,
+        accounts[8].address,
       ]);
     });
 
@@ -2032,6 +2071,9 @@ describe('SnapKeyring', () => {
         accounts[3].address,
         accounts[4].address,
         accounts[5].address,
+        accounts[6].address,
+        accounts[7].address,
+        accounts[8].address,
       ]);
       expect(console.error).toHaveBeenCalledWith(
         "Account '0xc728514df8a7f9271f4b7a4dd2aa6d2d723d3ee3' may not have been removed from snap 'local:snap.mock':",

--- a/packages/keyring-snap-bridge/src/account.ts
+++ b/packages/keyring-snap-bridge/src/account.ts
@@ -34,10 +34,10 @@ export function assertKeyringAccount<
   // the `KeyringAccount`. This would also required to have a "generic `KeyringAccount`"
   // definition.
   switch (account.type) {
-    case BtcAccountType.P2pkh ||
-      BtcAccountType.P2sh ||
-      BtcAccountType.P2wpkh ||
-      BtcAccountType.P2tr: {
+    case BtcAccountType.P2pkh:
+    case BtcAccountType.P2sh:
+    case BtcAccountType.P2wpkh:
+    case BtcAccountType.P2tr: {
       assert(account, BtcAccountStruct);
       return account;
     }

--- a/packages/keyring-snap-bridge/src/account.ts
+++ b/packages/keyring-snap-bridge/src/account.ts
@@ -1,7 +1,7 @@
 import type { KeyringAccount, KeyringAccountType } from '@metamask/keyring-api';
 import {
   BtcAccountType,
-  BtcP2wpkhAccountStruct,
+  BtcAccountStruct,
   EthAccountType,
   EthEoaAccountStruct,
   EthErc4337AccountStruct,
@@ -34,8 +34,11 @@ export function assertKeyringAccount<
   // the `KeyringAccount`. This would also required to have a "generic `KeyringAccount`"
   // definition.
   switch (account.type) {
-    case BtcAccountType.P2wpkh: {
-      assert(account, BtcP2wpkhAccountStruct);
+    case BtcAccountType.P2pkh ||
+      BtcAccountType.P2sh ||
+      BtcAccountType.P2wpkh ||
+      BtcAccountType.P2tr: {
+      assert(account, BtcAccountStruct);
       return account;
     }
     case SolAccountType.DataAccount: {

--- a/packages/keyring-snap-bridge/src/account.ts
+++ b/packages/keyring-snap-bridge/src/account.ts
@@ -1,7 +1,10 @@
 import type { KeyringAccount, KeyringAccountType } from '@metamask/keyring-api';
 import {
   BtcAccountType,
-  BtcAccountStruct,
+  BtcP2pkhAccountStruct,
+  BtcP2shAccountStruct,
+  BtcP2wpkhAccountStruct,
+  BtcP2trAccountStruct,
   EthAccountType,
   EthEoaAccountStruct,
   EthErc4337AccountStruct,
@@ -34,11 +37,20 @@ export function assertKeyringAccount<
   // the `KeyringAccount`. This would also required to have a "generic `KeyringAccount`"
   // definition.
   switch (account.type) {
-    case BtcAccountType.P2pkh:
-    case BtcAccountType.P2sh:
-    case BtcAccountType.P2wpkh:
+    case BtcAccountType.P2pkh: {
+      assert(account, BtcP2pkhAccountStruct);
+      return account;
+    }
+    case BtcAccountType.P2sh: {
+      assert(account, BtcP2shAccountStruct);
+      return account;
+    }
+    case BtcAccountType.P2wpkh: {
+      assert(account, BtcP2wpkhAccountStruct);
+      return account;
+    }
     case BtcAccountType.P2tr: {
-      assert(account, BtcAccountStruct);
+      assert(account, BtcP2trAccountStruct);
       return account;
     }
     case SolAccountType.DataAccount: {

--- a/packages/keyring-snap-bridge/src/migrations/v1.ts
+++ b/packages/keyring-snap-bridge/src/migrations/v1.ts
@@ -54,7 +54,10 @@ export function getScopesForAccountV1(
       // in production.
       return [EthScope.Testnet];
     }
-    case BtcAccountType.P2wpkh: {
+    case BtcAccountType.P2pkh ||
+      BtcAccountType.P2sh ||
+      BtcAccountType.P2wpkh ||
+      BtcAccountType.P2tr: {
       // Bitcoin uses different accounts for testnet and mainnet
       return [
         isBtcMainnetAddress(accountV1.address)

--- a/packages/keyring-snap-bridge/src/migrations/v1.ts
+++ b/packages/keyring-snap-bridge/src/migrations/v1.ts
@@ -54,10 +54,10 @@ export function getScopesForAccountV1(
       // in production.
       return [EthScope.Testnet];
     }
-    case BtcAccountType.P2pkh ||
-      BtcAccountType.P2sh ||
-      BtcAccountType.P2wpkh ||
-      BtcAccountType.P2tr: {
+    case BtcAccountType.P2pkh:
+    case BtcAccountType.P2sh:
+    case BtcAccountType.P2wpkh:
+    case BtcAccountType.P2tr: {
       // Bitcoin uses different accounts for testnet and mainnet
       return [
         isBtcMainnetAddress(accountV1.address)

--- a/packages/keyring-utils/src/btc/address.test.ts
+++ b/packages/keyring-utils/src/btc/address.test.ts
@@ -1,25 +1,35 @@
-import { isBtcMainnetAddress, isBtcTestnetAddress } from './address';
+import { AddressType } from 'bitcoin-address-validation';
+
+import {
+  isBtcAddress,
+  isBtcMainnetAddress,
+  isBtcTestnetAddress,
+} from './address';
+
+const BTC_P2PKH_MAINNET_ADDRESS = '1AXaVdPBb6zqrTMb6ebrBb9g3JmeAPGeCF';
+const BTC_P2SH_MAINNET_ADDRESS = '3KQPirCGGbVyWJLGuWN6VPC7uLeiarYB7x';
+const BTC_P2WPKH_MAINNET_ADDRESS = 'bc1q4degm5k044n9xv3ds7d8l6hfavydte6wn6sesw';
+const BTC_P2TR_MAINNET_ADDRESS =
+  'bc1pxfxst7zrkw39vzh0pchq5ey0q7z6u739cudhz5vmg89wa4kyyp9qzrf5sp';
+
+const BTC_P2PKH_TESTNET_ADDRESS = 'mrDHfcAPosFsabxBKe2U3EdxX5Kph8Zd4f';
+const BTC_P2SH_TESTNET_ADDRESS = '2N7AeKCw7p8uRRQjXPeHW7UPGhR8LYHEzBT';
+const BTC_P2WPKH_TESTNET_ADDRESS = 'tb1qqecaw32rvyjgez706t5chpr8gan49wfuk94t3g';
+const BTC_P2TR_TESTNET_ADDRESS =
+  'tb1p6epn3ctassfp54lnztshnpfjekn7khyarrnm6f0yv738lgc53xxsgevs8k';
 
 const BTC_MAINNET_ADDRESSES = [
-  // P2PKH
-  '1AXaVdPBb6zqrTMb6ebrBb9g3JmeAPGeCF',
-  // P2WPKH-P2SH
-  '3KQPirCGGbVyWJLGuWN6VPC7uLeiarYB7x',
-  // P2WPKH
-  'bc1q4degm5k044n9xv3ds7d8l6hfavydte6wn6sesw',
-  // P2TR
-  'bc1pxfxst7zrkw39vzh0pchq5ey0q7z6u739cudhz5vmg89wa4kyyp9qzrf5sp',
+  BTC_P2PKH_MAINNET_ADDRESS,
+  BTC_P2SH_MAINNET_ADDRESS,
+  BTC_P2WPKH_MAINNET_ADDRESS,
+  BTC_P2TR_MAINNET_ADDRESS,
 ];
 
 const BTC_TESTNET_ADDRESSES = [
-  // P2PKH
-  'mrDHfcAPosFsabxBKe2U3EdxX5Kph8Zd4f',
-  // P2WPKH-P2SH
-  '2N7AeKCw7p8uRRQjXPeHW7UPGhR8LYHEzBT',
-  // P2WPKH
-  'tb1qqecaw32rvyjgez706t5chpr8gan49wfuk94t3g',
-  // P2TR
-  'tb1p6epn3ctassfp54lnztshnpfjekn7khyarrnm6f0yv738lgc53xxsgevs8k',
+  BTC_P2PKH_TESTNET_ADDRESS,
+  BTC_P2SH_TESTNET_ADDRESS,
+  BTC_P2WPKH_TESTNET_ADDRESS,
+  BTC_P2TR_TESTNET_ADDRESS,
 ];
 
 const ETH_ADDRESSES = ['0x6431726EEE67570BF6f0Cf892aE0a3988F03903F'];
@@ -30,6 +40,47 @@ const SOL_ADDRESSES = [
 ];
 
 describe('address', () => {
+  describe('isBtcAddress', () => {
+    it.each([BTC_P2PKH_MAINNET_ADDRESS, BTC_P2PKH_TESTNET_ADDRESS])(
+      'returns false if address is valid p2pkh: %s',
+      (address: string) => {
+        expect(isBtcAddress(address, AddressType.p2pkh)).toBe(true);
+      },
+    );
+
+    it.each([BTC_P2SH_MAINNET_ADDRESS, BTC_P2SH_TESTNET_ADDRESS])(
+      'returns true if address is valid p2sh: %s',
+      (address: string) => {
+        expect(isBtcAddress(address, AddressType.p2sh)).toBe(true);
+      },
+    );
+
+    it.each([BTC_P2WPKH_MAINNET_ADDRESS, BTC_P2WPKH_TESTNET_ADDRESS])(
+      'returns true if address is valid p2wpkh: %s',
+      (address: string) => {
+        expect(isBtcAddress(address, AddressType.p2wpkh)).toBe(true);
+      },
+    );
+
+    it.each([BTC_P2TR_MAINNET_ADDRESS, BTC_P2TR_TESTNET_ADDRESS])(
+      'returns true if address is valid p2tr: %s',
+      (address: string) => {
+        expect(isBtcAddress(address, AddressType.p2tr)).toBe(true);
+      },
+    );
+
+    it.each([
+      BTC_P2PKH_MAINNET_ADDRESS,
+      BTC_P2PKH_TESTNET_ADDRESS,
+      BTC_P2SH_MAINNET_ADDRESS,
+      BTC_P2SH_TESTNET_ADDRESS,
+      BTC_P2WPKH_MAINNET_ADDRESS,
+      BTC_P2WPKH_TESTNET_ADDRESS,
+    ])('returns false if address is invalid: %s', (address: string) => {
+      expect(isBtcAddress(address, AddressType.p2tr)).toBe(false);
+    });
+  });
+
   describe('isBtcMainnetAddress', () => {
     it.each(BTC_MAINNET_ADDRESSES)(
       'returns true if address is compatible with BTC mainnet: %s',

--- a/packages/keyring-utils/src/btc/address.test.ts
+++ b/packages/keyring-utils/src/btc/address.test.ts
@@ -1,15 +1,25 @@
 import { isBtcMainnetAddress, isBtcTestnetAddress } from './address';
 
 const BTC_MAINNET_ADDRESSES = [
-  // P2WPKH
-  'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
   // P2PKH
-  '1P5ZEDWTKTFGxQjZphgWPQUpe554WKDfHQ',
+  '1AXaVdPBb6zqrTMb6ebrBb9g3JmeAPGeCF',
+  // P2WPKH-P2SH
+  '3KQPirCGGbVyWJLGuWN6VPC7uLeiarYB7x',
+  // P2WPKH
+  'bc1q4degm5k044n9xv3ds7d8l6hfavydte6wn6sesw',
+  // P2TR
+  'bc1pxfxst7zrkw39vzh0pchq5ey0q7z6u739cudhz5vmg89wa4kyyp9qzrf5sp',
 ];
 
 const BTC_TESTNET_ADDRESSES = [
+  // P2PKH
+  'mrDHfcAPosFsabxBKe2U3EdxX5Kph8Zd4f',
+  // P2WPKH-P2SH
+  '2N7AeKCw7p8uRRQjXPeHW7UPGhR8LYHEzBT',
   // P2WPKH
-  'tb1q6rmsq3vlfdhjdhtkxlqtuhhlr6pmj09y6w43g8',
+  'tb1qqecaw32rvyjgez706t5chpr8gan49wfuk94t3g',
+  // P2TR
+  'tb1p6epn3ctassfp54lnztshnpfjekn7khyarrnm6f0yv738lgc53xxsgevs8k',
 ];
 
 const ETH_ADDRESSES = ['0x6431726EEE67570BF6f0Cf892aE0a3988F03903F'];

--- a/packages/keyring-utils/src/btc/address.test.ts
+++ b/packages/keyring-utils/src/btc/address.test.ts
@@ -1,35 +1,25 @@
-import { AddressType } from 'bitcoin-address-validation';
-
-import {
-  isBtcAddress,
-  isBtcMainnetAddress,
-  isBtcTestnetAddress,
-} from './address';
-
-const BTC_P2PKH_MAINNET_ADDRESS = '1AXaVdPBb6zqrTMb6ebrBb9g3JmeAPGeCF';
-const BTC_P2SH_MAINNET_ADDRESS = '3KQPirCGGbVyWJLGuWN6VPC7uLeiarYB7x';
-const BTC_P2WPKH_MAINNET_ADDRESS = 'bc1q4degm5k044n9xv3ds7d8l6hfavydte6wn6sesw';
-const BTC_P2TR_MAINNET_ADDRESS =
-  'bc1pxfxst7zrkw39vzh0pchq5ey0q7z6u739cudhz5vmg89wa4kyyp9qzrf5sp';
-
-const BTC_P2PKH_TESTNET_ADDRESS = 'mrDHfcAPosFsabxBKe2U3EdxX5Kph8Zd4f';
-const BTC_P2SH_TESTNET_ADDRESS = '2N7AeKCw7p8uRRQjXPeHW7UPGhR8LYHEzBT';
-const BTC_P2WPKH_TESTNET_ADDRESS = 'tb1qqecaw32rvyjgez706t5chpr8gan49wfuk94t3g';
-const BTC_P2TR_TESTNET_ADDRESS =
-  'tb1p6epn3ctassfp54lnztshnpfjekn7khyarrnm6f0yv738lgc53xxsgevs8k';
+import { isBtcMainnetAddress, isBtcTestnetAddress } from './address';
 
 const BTC_MAINNET_ADDRESSES = [
-  BTC_P2PKH_MAINNET_ADDRESS,
-  BTC_P2SH_MAINNET_ADDRESS,
-  BTC_P2WPKH_MAINNET_ADDRESS,
-  BTC_P2TR_MAINNET_ADDRESS,
+  // P2PKH
+  '1AXaVdPBb6zqrTMb6ebrBb9g3JmeAPGeCF',
+  // P2WPKH-P2SH
+  '3KQPirCGGbVyWJLGuWN6VPC7uLeiarYB7x',
+  // P2WPKH
+  'bc1q4degm5k044n9xv3ds7d8l6hfavydte6wn6sesw',
+  // P2TR
+  'bc1pxfxst7zrkw39vzh0pchq5ey0q7z6u739cudhz5vmg89wa4kyyp9qzrf5sp',
 ];
 
 const BTC_TESTNET_ADDRESSES = [
-  BTC_P2PKH_TESTNET_ADDRESS,
-  BTC_P2SH_TESTNET_ADDRESS,
-  BTC_P2WPKH_TESTNET_ADDRESS,
-  BTC_P2TR_TESTNET_ADDRESS,
+  // P2PKH
+  'mrDHfcAPosFsabxBKe2U3EdxX5Kph8Zd4f',
+  // P2WPKH-P2SH
+  '2N7AeKCw7p8uRRQjXPeHW7UPGhR8LYHEzBT',
+  // P2WPKH
+  'tb1qqecaw32rvyjgez706t5chpr8gan49wfuk94t3g',
+  // P2TR
+  'tb1p6epn3ctassfp54lnztshnpfjekn7khyarrnm6f0yv738lgc53xxsgevs8k',
 ];
 
 const ETH_ADDRESSES = ['0x6431726EEE67570BF6f0Cf892aE0a3988F03903F'];
@@ -40,47 +30,6 @@ const SOL_ADDRESSES = [
 ];
 
 describe('address', () => {
-  describe('isBtcAddress', () => {
-    it.each([BTC_P2PKH_MAINNET_ADDRESS, BTC_P2PKH_TESTNET_ADDRESS])(
-      'returns false if address is valid p2pkh: %s',
-      (address: string) => {
-        expect(isBtcAddress(address, AddressType.p2pkh)).toBe(true);
-      },
-    );
-
-    it.each([BTC_P2SH_MAINNET_ADDRESS, BTC_P2SH_TESTNET_ADDRESS])(
-      'returns true if address is valid p2sh: %s',
-      (address: string) => {
-        expect(isBtcAddress(address, AddressType.p2sh)).toBe(true);
-      },
-    );
-
-    it.each([BTC_P2WPKH_MAINNET_ADDRESS, BTC_P2WPKH_TESTNET_ADDRESS])(
-      'returns true if address is valid p2wpkh: %s',
-      (address: string) => {
-        expect(isBtcAddress(address, AddressType.p2wpkh)).toBe(true);
-      },
-    );
-
-    it.each([BTC_P2TR_MAINNET_ADDRESS, BTC_P2TR_TESTNET_ADDRESS])(
-      'returns true if address is valid p2tr: %s',
-      (address: string) => {
-        expect(isBtcAddress(address, AddressType.p2tr)).toBe(true);
-      },
-    );
-
-    it.each([
-      BTC_P2PKH_MAINNET_ADDRESS,
-      BTC_P2PKH_TESTNET_ADDRESS,
-      BTC_P2SH_MAINNET_ADDRESS,
-      BTC_P2SH_TESTNET_ADDRESS,
-      BTC_P2WPKH_MAINNET_ADDRESS,
-      BTC_P2WPKH_TESTNET_ADDRESS,
-    ])('returns false if address is invalid: %s', (address: string) => {
-      expect(isBtcAddress(address, AddressType.p2tr)).toBe(false);
-    });
-  });
-
   describe('isBtcMainnetAddress', () => {
     it.each(BTC_MAINNET_ADDRESSES)(
       'returns true if address is compatible with BTC mainnet: %s',

--- a/packages/keyring-utils/src/btc/address.ts
+++ b/packages/keyring-utils/src/btc/address.ts
@@ -1,4 +1,17 @@
-import { validate, Network } from 'bitcoin-address-validation';
+import type { AddressType } from 'bitcoin-address-validation';
+import { validate, Network, getAddressInfo } from 'bitcoin-address-validation';
+
+/**
+ * Returns whether an address is on the Bitcoin mainnet.
+ *
+ * @param address - The address to check.
+ * @param type - The address type to check.
+ * @returns `true` if the address is valid, `false` otherwise.
+ */
+export function isBtcAddress(address: string, type: AddressType): boolean {
+  const addressInfo = getAddressInfo(address);
+  return addressInfo.type === type;
+}
 
 /**
  * Returns whether an address is on the Bitcoin mainnet.

--- a/packages/keyring-utils/src/btc/address.ts
+++ b/packages/keyring-utils/src/btc/address.ts
@@ -1,17 +1,4 @@
-import type { AddressType } from 'bitcoin-address-validation';
-import { validate, Network, getAddressInfo } from 'bitcoin-address-validation';
-
-/**
- * Returns whether an address is on the Bitcoin mainnet.
- *
- * @param address - The address to check.
- * @param type - The address type to check.
- * @returns `true` if the address is valid, `false` otherwise.
- */
-export function isBtcAddress(address: string, type: AddressType): boolean {
-  const addressInfo = getAddressInfo(address);
-  return addressInfo.type === type;
-}
+import { validate, Network } from 'bitcoin-address-validation';
 
 /**
  * Returns whether an address is on the Bitcoin mainnet.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,7 +1893,6 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/webextension-polyfill": "npm:^0.12.1"
-    bech32: "npm:^2.0.0"
     deepmerge: "npm:^4.2.2"
     depcheck: "npm:^1.4.7"
     jest: "npm:^29.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1893,6 +1893,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
     "@types/webextension-polyfill": "npm:^0.12.1"
+    bitcoin-address-validation: "npm:^2.2.3"
     deepmerge: "npm:^4.2.2"
     depcheck: "npm:^1.4.7"
     jest: "npm:^29.5.0"


### PR DESCRIPTION
- Adds support for remaining Bitcoin account types.
- Adds stricter validation checks for the decoding of the addresses. Removes `bech32` dependency in favor of `bitcoin-address-validation`. 
- Removes size limit of scopes for Bitcoin accounts as testnet accounts span multiple scopes. `testnet`, `testnet4` and `signet` are the same account (same address).

`p2sh` is a shortcut for `p2wpkh-p2sh` (nested segwit).

* Fixes: https://consensyssoftware.atlassian.net/browse/NNT-329