### PR TITLE
fix(keyring-snap-sdk)!: make `@metamask/keyring-api` a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ linkStyle default opacity:0.5
   eth_snap_keyring --> keyring_utils;
   keyring_snap_client --> keyring_api;
   keyring_snap_client --> keyring_utils;
-  keyring_snap_sdk --> keyring_utils;
   keyring_snap_sdk --> keyring_api;
+  keyring_snap_sdk --> keyring_utils;
 ```
 
 <!-- end dependency graph -->

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ linkStyle default opacity:0.5
   eth_snap_keyring --> keyring_utils;
   keyring_snap_client --> keyring_api;
   keyring_snap_client --> keyring_utils;
-  keyring_snap_sdk --> keyring_api;
   keyring_snap_sdk --> keyring_utils;
+  keyring_snap_sdk --> keyring_api;
 ```
 
 <!-- end dependency graph -->

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -45,7 +45,6 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-utils": "workspace:^",
     "@metamask/snaps-sdk": "^6.16.0",
     "@metamask/superstruct": "^3.1.0",
@@ -56,6 +55,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
+    "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^19.0.0",
     "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
@@ -72,6 +72,7 @@
     "typescript": "~5.6.3"
   },
   "peerDependencies": {
+    "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^19.0.0"
   },
   "engines": {

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -45,6 +45,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-utils": "workspace:^",
     "@metamask/snaps-sdk": "^6.16.0",
     "@metamask/superstruct": "^3.1.0",
@@ -55,7 +56,6 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
-    "@metamask/keyring-api": "workspace:^",
     "@metamask/providers": "^19.0.0",
     "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2024,6 +2024,7 @@ __metadata:
     typescript: "npm:~5.6.3"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
+    "@metamask/keyring-api": "workspace:^"
     "@metamask/providers": ^19.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
This dependency is needed at runtime (to access `*Struct`s).