### PR TITLE
feat(keyring-eth-ledger-bridge): enhance error handling for Ledger signing operations

### DIFF
--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -23,10 +23,10 @@ module.exports = merge(baseConfig, {
   // An object that configures minimum threshold enforcement for coverage results
   coverageThreshold: {
     global: {
-      branches: 91.89,
+      branches: 92.77,
       functions: 97.87,
-      lines: 97.16,
-      statements: 97.19,
+      lines: 97.28,
+      statements: 97.31,
     },
   },
 });

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -94,6 +94,17 @@ export class LedgerKeyring implements Keyring {
 
   deviceId = '';
 
+  static #isLedgerError(
+    error: unknown,
+  ): error is { errorCode: string; message: string } {
+    return (
+      typeof error === 'object' &&
+      error !== null &&
+      'errorCode' in error &&
+      'message' in error
+    );
+  }
+
   readonly type: string = keyringType;
 
   page = 0;
@@ -414,6 +425,26 @@ export class LedgerKeyring implements Keyring {
         hdPath,
       });
     } catch (error) {
+      /**
+       * for user rejected the transaction error
+       */
+      if (
+        LedgerKeyring.#isLedgerError(error) &&
+        error.errorCode === '6985' &&
+        error.message === 'Condition not satisfied'
+      ) {
+        throw new Error('Ledger: User rejected the transaction');
+      }
+      /**
+       * for blind signing disabled error
+       */
+      if (
+        LedgerKeyring.#isLedgerError(error) &&
+        error.errorCode === '6a80' &&
+        error.message === 'Invalid data'
+      ) {
+        throw new Error('Ledger: Blind signing must be enabled');
+      }
       throw error instanceof Error
         ? error
         : new Error('Ledger: Unknown error while signing transaction');
@@ -449,6 +480,17 @@ export class LedgerKeyring implements Keyring {
         message: remove0x(message),
       });
     } catch (error) {
+      /**
+       * for user rejected the transaction error
+       */
+      if (
+        LedgerKeyring.#isLedgerError(error) &&
+        error.errorCode === '6985' &&
+        error.message === 'Condition not satisfied'
+      ) {
+        throw new Error('Ledger: User rejected the transaction');
+      }
+
       throw error instanceof Error
         ? error
         : new Error('Ledger: Unknown error while signing message');
@@ -541,6 +583,26 @@ export class LedgerKeyring implements Keyring {
         },
       });
     } catch (error) {
+      /**
+       * for user rejected the transaction error
+       */
+      if (
+        LedgerKeyring.#isLedgerError(error) &&
+        error.errorCode === '6985' &&
+        error.message === 'Condition not satisfied'
+      ) {
+        throw new Error('Ledger: User rejected the transaction');
+      }
+      /**
+       * for blind signing disabled error
+       */
+      if (
+        LedgerKeyring.#isLedgerError(error) &&
+        error.errorCode === '6a80' &&
+        error.message === 'Invalid data'
+      ) {
+        throw new Error('Ledger: Blind signing must be enabled');
+      }
       throw error instanceof Error
         ? error
         : new Error('Ledger: Unknown error while signing message');

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -95,17 +95,6 @@ export class LedgerKeyring implements Keyring {
 
   deviceId = '';
 
-  static #isLedgerError(
-    error: unknown,
-  ): error is { errorCode: string; message: string } {
-    return (
-      typeof error === 'object' &&
-      error !== null &&
-      'errorCode' in error &&
-      'message' in error
-    );
-  }
-
   readonly type: string = keyringType;
 
   page = 0;

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -5,6 +5,7 @@ import {
   type TypedTransaction,
 } from '@ethereumjs/tx';
 import { publicToAddress } from '@ethereumjs/util';
+import { TransportStatusError } from '@ledgerhq/hw-transport';
 import type { MessageTypes, TypedMessage } from '@metamask/eth-sig-util';
 import {
   recoverPersonalSignature,
@@ -424,27 +425,29 @@ export class LedgerKeyring implements Keyring {
         tx: remove0x(rawTxHex),
         hdPath,
       });
-    } catch (error) {
-      /**
-       * for user rejected the transaction error
-       */
-      if (
-        LedgerKeyring.#isLedgerError(error) &&
-        error.errorCode === '6985' &&
-        error.message === 'Condition not satisfied'
-      ) {
-        throw new Error('Ledger: User rejected the transaction');
+    } catch (error: unknown) {
+      // check whether error is TransportError
+      if (error instanceof TransportStatusError) {
+        // cast error to TransportError
+        const transportError: TransportStatusError = error;
+        if (
+          transportError.statusCode === 27013 &&
+          transportError.message.includes('(denied by the user?) (0x6985)')
+        ) {
+          throw new Error('Ledger: User rejected the transaction');
+        }
+
+        /**
+         * for user rejected the transaction error
+         */
+        if (
+          transportError.statusCode === 27013 &&
+          transportError.message.includes('(denied by the user?) (0x6985)')
+        ) {
+          throw new Error('Ledger: User rejected the transaction');
+        }
       }
-      /**
-       * for blind signing disabled error
-       */
-      if (
-        LedgerKeyring.#isLedgerError(error) &&
-        error.errorCode === '6a80' &&
-        error.message === 'Invalid data'
-      ) {
-        throw new Error('Ledger: Blind signing must be enabled');
-      }
+
       throw error instanceof Error
         ? error
         : new Error('Ledger: Unknown error while signing transaction');
@@ -479,7 +482,19 @@ export class LedgerKeyring implements Keyring {
         hdPath,
         message: remove0x(message),
       });
-    } catch (error) {
+    } catch (error: unknown) {
+      if (error instanceof TransportStatusError) {
+        const transportError: TransportStatusError = error;
+        /**
+         * for user rejected the transaction error
+         */
+        if (
+          transportError.statusCode === 27013 &&
+          transportError.message.includes('(denied by the user?) (0x6985)')
+        ) {
+          throw new Error('Ledger: User rejected the transaction');
+        }
+      }
       /**
        * for user rejected the transaction error
        */
@@ -582,26 +597,26 @@ export class LedgerKeyring implements Keyring {
           message,
         },
       });
-    } catch (error) {
-      /**
-       * for user rejected the transaction error
-       */
-      if (
-        LedgerKeyring.#isLedgerError(error) &&
-        error.errorCode === '6985' &&
-        error.message === 'Condition not satisfied'
-      ) {
-        throw new Error('Ledger: User rejected the transaction');
-      }
-      /**
-       * for blind signing disabled error
-       */
-      if (
-        LedgerKeyring.#isLedgerError(error) &&
-        error.errorCode === '6a80' &&
-        error.message === 'Invalid data'
-      ) {
-        throw new Error('Ledger: Blind signing must be enabled');
+    } catch (error: unknown) {
+      if (error instanceof TransportStatusError) {
+        // cast error to TransportError
+        const transportError: TransportStatusError = error;
+        if (
+          transportError.statusCode === 27013 &&
+          transportError.message.includes('(denied by the user?) (0x6985)')
+        ) {
+          throw new Error('Ledger: User rejected the transaction');
+        }
+
+        /**
+         * for user rejected the transaction error
+         */
+        if (
+          transportError.statusCode === 27013 &&
+          transportError.message.includes('(denied by the user?) (0x6985)')
+        ) {
+          throw new Error('Ledger: User rejected the transaction');
+        }
       }
       throw error instanceof Error
         ? error

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -437,14 +437,11 @@ export class LedgerKeyring implements Keyring {
           throw new Error('Ledger: User rejected the transaction');
         }
 
-        /**
-         * for user rejected the transaction error
-         */
         if (
-          transportError.statusCode === 27013 &&
-          transportError.message.includes('(denied by the user?) (0x6985)')
+          transportError.statusCode === 27264 &&
+          transportError.message.includes('Invalid data received (0x6a80)')
         ) {
-          throw new Error('Ledger: User rejected the transaction');
+          throw new Error('Ledger: Blind signing must be enabled');
         }
       }
 
@@ -494,16 +491,6 @@ export class LedgerKeyring implements Keyring {
         ) {
           throw new Error('Ledger: User rejected the transaction');
         }
-      }
-      /**
-       * for user rejected the transaction error
-       */
-      if (
-        LedgerKeyring.#isLedgerError(error) &&
-        error.errorCode === '6985' &&
-        error.message === 'Condition not satisfied'
-      ) {
-        throw new Error('Ledger: User rejected the transaction');
       }
 
       throw error instanceof Error
@@ -608,14 +595,11 @@ export class LedgerKeyring implements Keyring {
           throw new Error('Ledger: User rejected the transaction');
         }
 
-        /**
-         * for user rejected the transaction error
-         */
         if (
-          transportError.statusCode === 27013 &&
-          transportError.message.includes('(denied by the user?) (0x6985)')
+          transportError.statusCode === 27264 &&
+          transportError.message.includes('Invalid data received (0x6a80)')
         ) {
-          throw new Error('Ledger: User rejected the transaction');
+          throw new Error('Ledger: Blind signing must be enabled');
         }
       }
       throw error instanceof Error


### PR DESCRIPTION
Added static method to identify Ledger-specific errors and improved error handling in the LedgerKeyring class. Now, specific error messages are thrown for user-rejected transactions and when blind signing is disabled, providing clearer feedback to users during transaction signing.

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->
