### PR TITLE
feat(keyring-utils): add TypedObject

### DIFF
--- a/packages/keyring-utils/src/index.ts
+++ b/packages/keyring-utils/src/index.ts
@@ -2,6 +2,7 @@ export * from './btc';
 export * from './types';
 export * from './typing';
 export * from './scopes';
+export * from './object';
 export * from './superstruct';
 export * from './JsonRpcRequest';
 export type * from './keyring';

--- a/packages/keyring-utils/src/object.test.ts
+++ b/packages/keyring-utils/src/object.test.ts
@@ -1,0 +1,31 @@
+import { TypedObject } from './object';
+
+type Key = `${string}:${string}`;
+
+describe('TypedObject', () => {
+  const obj: Record<Key, boolean | string> = {
+    'foo:bar': true,
+    'bar:foo': 'barfoo',
+  } as const;
+
+  describe('keys', () => {
+    it('uses type key', () => {
+      expect(TypedObject.keys(obj)).toStrictEqual(['foo:bar', 'bar:foo']);
+    });
+  });
+
+  describe('entries', () => {
+    it('uses type key', () => {
+      expect(TypedObject.entries(obj)).toStrictEqual([
+        ['foo:bar', obj['foo:bar']],
+        ['bar:foo', obj['bar:foo']],
+      ]);
+    });
+  });
+
+  describe('values', () => {
+    it('gives the same values than Object.values', () => {
+      expect(TypedObject.values(obj)).toStrictEqual(Object.values(obj));
+    });
+  });
+});

--- a/packages/keyring-utils/src/object.ts
+++ b/packages/keyring-utils/src/object.ts
@@ -1,0 +1,22 @@
+export class TypedObject {
+  static keys<ObjectType extends object>(
+    obj: ObjectType,
+  ): (keyof ObjectType)[] {
+    return Object.keys(obj) as (keyof ObjectType)[];
+  }
+
+  static entries<ObjectType extends object>(
+    obj: ObjectType,
+  ): [keyof ObjectType, ObjectType[keyof ObjectType]][] {
+    return Object.entries(obj) as [
+      keyof ObjectType,
+      ObjectType[keyof ObjectType],
+    ][];
+  }
+
+  static values<ObjectType extends object>(
+    obj: ObjectType,
+  ): ObjectType[keyof ObjectType][] {
+    return Object.values(obj);
+  }
+}


### PR DESCRIPTION
Class helper that exposes a similar interface to `Object` which re-use the original/real-type of the object's key.

While using `Object.keys` all keys are down-casted to `string`, which sometimes require an up-cast to get back to the original key type.