### PR TITLE
build: use major `keyring-api` version for peer deps

### DIFF
--- a/.syncpackrc
+++ b/.syncpackrc
@@ -29,7 +29,7 @@
   "versionGroups": [
     {
       "label": "use workspace version of packages in the monorepo",
-      "dependencyTypes": ["!local"],
+      "dependencyTypes": ["!local", "!peer"],
       "dependencies": [
         "@metamask/keyring-**",
         "@metamask/eth-**-keyring"

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -70,7 +70,7 @@
     "typescript": "~5.6.3"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": "^18.0.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -72,7 +72,7 @@
     "typescript": "~5.6.3"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "workspace:^",
+    "@metamask/keyring-api": "^18.0.0",
     "@metamask/providers": "^19.0.0"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1763,7 +1763,7 @@ __metadata:
     typescript: "npm:~5.6.3"
     uuid: "npm:^9.0.1"
   peerDependencies:
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": ^18.0.0
   languageName: unknown
   linkType: soft
 
@@ -1999,7 +1999,7 @@ __metadata:
     typescript: "npm:~5.6.3"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/keyring-api": "workspace:^"
+    "@metamask/keyring-api": ^18.0.0
     "@metamask/providers": ^19.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
We were wrongly using `workspace:^` when referencing the `@metamask/keyring-api` package as a peer dep. Thus, any small bump to that package would have make the packages (that depends on it) to be major bump every time (given that bumping a peer dep, results in a breaking change for the end-consumer).

We instead reference the current major version, thus allowing to not introduce breaking changes for every `@metamask/keyring-api` releases.