### PR TITLE
fix(keyring-eth-ledger-bridge): increase ledger iframe timeout

### DIFF
--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
@@ -14,7 +14,7 @@ import {
 
 const LEDGER_IFRAME_ID = 'LEDGER-IFRAME';
 
-const IFRAME_MESSAGE_TIMEOUT = 4000;
+const IFRAME_MESSAGE_TIMEOUT = 8000;
 
 export enum IFrameMessageAction {
   LedgerIsIframeReady = 'ledger-is-iframe-ready',


### PR DESCRIPTION
### What is the current state of things and why does it need to change?
We get a lot of Sentry reports about a ledger iframe timeout error

### What is the solution your changes offer and how does it work?
As a first mitigation, we will increase the timeout duration and then evaluate if we need to come up with a more robust solution. On a side track, we are also making [ledger transport initialization non-blocking](https://github.com/MetaMask/metamask-extension/pull/34574).

### Are there any issues or other links reviewers should consult to understand this pull request better?

Relates to: https://github.com/MetaMask/metamask-extension/issues/33176