### PR TITLE
feat(account-api): add `isBip44Account` helper

### DIFF
--- a/packages/account-api/package.json
+++ b/packages/account-api/package.json
@@ -47,7 +47,8 @@
   },
   "dependencies": {
     "@metamask/keyring-api": "workspace:^",
-    "@metamask/keyring-utils": "workspace:^"
+    "@metamask/keyring-utils": "workspace:^",
+    "@metamask/superstruct": "^3.1.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",

--- a/packages/account-api/src/api/bip44.ts
+++ b/packages/account-api/src/api/bip44.ts
@@ -1,0 +1,33 @@
+import type {
+  KeyringAccount,
+  KeyringAccountEntropyMnemonicOptions,
+} from '@metamask/keyring-api';
+import { KeyringAccountEntropyMnemonicOptionsStruct } from '@metamask/keyring-api';
+import { is } from '@metamask/superstruct';
+
+/**
+ * BIP-44 compatible account type.
+ */
+export type Bip44Account<Account extends KeyringAccount> = Account & {
+  // We force the option type for those accounts. (That's how we identify
+  // if an account is BIP-44 compatible).
+  options: {
+    entropy: KeyringAccountEntropyMnemonicOptions;
+  };
+};
+
+/**
+ * Checks if an account is BIP-44 compatible.
+ *
+ * @param account - The account to be tested.
+ * @returns True if the account is BIP-44 compatible.
+ */
+export function isBip44Account<Account extends KeyringAccount>(
+  account: Account,
+): account is Bip44Account<Account> {
+  // To be BIP-44 compatible, you just need to use this set of options:
+  return is(
+    account.options.entropy,
+    KeyringAccountEntropyMnemonicOptionsStruct,
+  );
+}

--- a/packages/account-api/src/api/index.ts
+++ b/packages/account-api/src/api/index.ts
@@ -1,3 +1,4 @@
+export * from './bip44';
 export * from './group';
 export * from './wallet';
 export type * from './provider';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,6 +1365,7 @@ __metadata:
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-internal-api": "workspace:^"
     "@metamask/keyring-utils": "workspace:^"
+    "@metamask/superstruct": "npm:^3.1.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"


### PR DESCRIPTION
Add `isBip44Account` which can be used to detect if an `Account` type (`KeyringAcccount` compatible) is compatible with BIP-44 (according to the new typed options).