### PR TITLE
feat(account-api): add reverse mapping + `AccountProvider` events

### DIFF
--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **BREAKING:** Added `AccountProvider.getAccount` ([#320](https://github.com/MetaMask/accounts/pull/320))
+
+### Changed
+
+- **BREAKING:** `AccountProvider` is now an abstract class ([#320](https://github.com/MetaMask/accounts/pull/320))
+  - It provides some internal messaging/event mechanism to publish `:accountAdded` to `MultichainAccount` and `MultichainAccountWallet`.
+- **BREAKING:** `AccountProvider.getAccounts` now uses `Bip44Account` ([#320](https://github.com/MetaMask/accounts/pull/320))
+  - This makes it easy to use `options.entropy` object.
+- Reduce heavy filtering in favor of event-based updated from the `AccountProvider`s. ([#320](https://github.com/MetaMask/accounts/pull/320))
+
 ## [0.2.0]
 
 ### Added

--- a/packages/account-api/package.json
+++ b/packages/account-api/package.json
@@ -46,6 +46,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@metamask/base-controller": "^8.0.1",
     "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-utils": "workspace:^",
     "@metamask/superstruct": "^3.1.0"

--- a/packages/account-api/src/api/index.ts
+++ b/packages/account-api/src/api/index.ts
@@ -1,6 +1,6 @@
 export * from './bip44';
 export * from './group';
 export * from './wallet';
-export type * from './provider';
+export * from './provider';
 export type * from './selector';
 export * from './multichain';

--- a/packages/account-api/src/api/provider.ts
+++ b/packages/account-api/src/api/provider.ts
@@ -1,13 +1,71 @@
+import type {
+  ExtractEventHandler,
+  ExtractEventPayload,
+} from '@metamask/base-controller';
+import { Messenger } from '@metamask/base-controller';
 import type { KeyringAccount } from '@metamask/keyring-api';
+
+import type { Bip44Account } from './bip44';
+
+type AccountProviderAccountAddedEvent<Account extends KeyringAccount> = {
+  type: 'AccountProvider:accountAdded';
+  payload: [Bip44Account<Account>];
+};
+
+type AccountProviderEvents<Account extends KeyringAccount> =
+  AccountProviderAccountAddedEvent<Account>;
+
+export type AccountProviderEventUnsubscriber = () => void;
 
 /**
  * An account provider is reponsible of providing accounts to an account group.
  */
-export type AccountProvider<Account extends KeyringAccount> = {
+export abstract class AccountProvider<Account extends KeyringAccount> {
+  readonly #messenger: Messenger<never, AccountProviderEvents<Account>>;
+
+  constructor() {
+    this.#messenger = new Messenger();
+  }
+
   /**
    * Gets all accounts for a given entropy source and group index.
    *
    * @returns A list of all account for this provider.
    */
-  getAccounts: () => Account[];
-};
+  abstract getAccount(id: Bip44Account<Account>['id']): Bip44Account<Account>;
+
+  /**
+   * Gets all accounts for a given entropy source and group index.
+   *
+   * @returns A list of all account for this provider.
+   */
+  abstract getAccounts(): Bip44Account<Account>[];
+
+  /**
+   * Registers event handler.
+   *
+   * @param event - Event type.
+   * @param handler - Event handler.
+   * @returns Callback to unsubscribe this handler.
+   */
+  subscribe<EventType extends AccountProviderEvents<Account>['type']>(
+    event: EventType,
+    handler: ExtractEventHandler<AccountProviderEvents<Account>, EventType>,
+  ): AccountProviderEventUnsubscriber {
+    this.#messenger.subscribe(event, handler);
+    return () => this.#messenger.unsubscribe(event, handler);
+  }
+
+  /**
+   * Publishes event.
+   *
+   * @param event - Event type.
+   * @param payload - Event payload.
+   */
+  protected publish<EventType extends AccountProviderEvents<Account>['type']>(
+    event: EventType,
+    ...payload: ExtractEventPayload<AccountProviderEvents<Account>, EventType>
+  ): void {
+    this.#messenger.publish(event, ...payload);
+  }
+}

--- a/packages/keyring-internal-snap-client/package.json
+++ b/packages/keyring-internal-snap-client/package.json
@@ -45,7 +45,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@metamask/base-controller": "^7.1.1",
+    "@metamask/base-controller": "^8.0.1",
     "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-internal-api": "workspace:^",
     "@metamask/keyring-snap-client": "workspace:^",

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "@ethereumjs/tx": "^5.4.0",
-    "@metamask/base-controller": "^7.1.1",
+    "@metamask/base-controller": "^8.0.1",
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-internal-api": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1362,6 +1362,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
+    "@metamask/base-controller": "npm:^8.0.1"
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-internal-api": "workspace:^"
     "@metamask/keyring-utils": "workspace:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1478,16 +1478,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^7.1.1":
-  version: 7.1.1
-  resolution: "@metamask/base-controller@npm:7.1.1"
-  dependencies:
-    "@metamask/utils": "npm:^11.0.1"
-    immer: "npm:^9.0.6"
-  checksum: 10/d45abc9e0f3f42a0ea7f0a52734f3749fafc5fefc73608230ab0815578e83a9fc28fe57dc7000f6f8df2cdcee5b53f68bb971091075bec9de6b7f747de627c60
-  languageName: node
-  linkType: hard
-
 "@metamask/base-controller@npm:^8.0.0, @metamask/base-controller@npm:^8.0.1":
   version: 8.0.1
   resolution: "@metamask/base-controller@npm:8.0.1"
@@ -1742,7 +1732,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/base-controller": "npm:^7.1.1"
+    "@metamask/base-controller": "npm:^8.0.1"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-internal-api": "workspace:^"
@@ -1918,7 +1908,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^3.4.4"
-    "@metamask/base-controller": "npm:^7.1.1"
+    "@metamask/base-controller": "npm:^8.0.1"
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-internal-api": "workspace:^"
     "@metamask/keyring-snap-client": "workspace:^"


### PR DESCRIPTION
Implement reverse-mapping + event mechanism for the `AccountProvider`.

This also solve the issue that a wallet might not know when a new multichain account got added to the wallet.

For now, we omitted any use of `:accountRemoved` event since we don't plan to remove those accounts for the moment.