### PR TITLE
feat(account-api): enforce `Bip44Account` for `MultichainAccount*` + add `MultichainAccount*.sync`

### DIFF
--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `MultichainAccountWallet.sync` method ([#321](https://github.com/MetaMask/accounts/pull/321))
+  - This can be used to force wallet synchronization if new accounts are available on the account providers.
+
+### Changed
+
+- **BREAKING:** Force `Bip44Account<Account>` for `Multichain*` types ([#321](https://github.com/MetaMask/accounts/pull/321))
+  - This requires the `AccountProvider`s to also use new `Bip44Account` type constraint.
+
 ## [0.2.0]
 
 ### Added

--- a/packages/account-api/src/api/multichain/account.ts
+++ b/packages/account-api/src/api/multichain/account.ts
@@ -78,15 +78,6 @@ export class MultichainAccount<Account extends Bip44Account<KeyringAccount>>
   }
 
   /**
-   * Checks if there's any underlying accounts for this multichain accounts.
-   *
-   * @returns True if there's any underlying accounts, false otherwise.
-   */
-  hasAccounts(): boolean {
-    return this.getAccounts().length > 0;
-  }
-
-  /**
    * Gets the accounts for this multichain account.
    *
    * @returns The accounts.

--- a/packages/account-api/src/api/multichain/account.ts
+++ b/packages/account-api/src/api/multichain/account.ts
@@ -65,6 +65,10 @@ export class MultichainAccount<Account extends Bip44Account<KeyringAccount>>
    * account doesn't know about.
    */
   sync(): void {
+    // Clear reverse mapping and re-construct it entirely based on the refreshed
+    // list of accounts from each providers.
+    this.#reverse.clear();
+
     for (const provider of this.#providers) {
       // Filter account only for that index.
       const accounts = [];
@@ -111,6 +115,16 @@ export class MultichainAccount<Account extends Bip44Account<KeyringAccount>>
    */
   get index(): number {
     return this.#index;
+  }
+
+  /**
+   * Checks if there's any underlying accounts for this multichain accounts.
+   *
+   * @returns True if there's any underlying accounts, false otherwise.
+   */
+  hasAccounts(): boolean {
+    // If there's anything in the reverse-map, it means we have some accounts.
+    return this.#reverse.size > 0;
   }
 
   /**

--- a/packages/account-api/src/api/multichain/account.ts
+++ b/packages/account-api/src/api/multichain/account.ts
@@ -133,12 +133,19 @@ export class MultichainAccount<Account extends Bip44Account<KeyringAccount>>
    * @returns The accounts.
    */
   getAccounts(): Account[] {
-    let allAccounts: Account[] = [];
+    const allAccounts: Account[] = [];
 
     for (const [provider, accounts] of this.#accounts.entries()) {
-      allAccounts = allAccounts.concat(
-        accounts.map((id) => provider.getAccount(id)),
-      );
+      for (const id of accounts) {
+        const account = provider.getAccount(id);
+
+        if (account) {
+          // If for some reason we cannot get this account from the provider, it
+          // might means it has been deleted or something, so we just filter it
+          // out.
+          allAccounts.push(account);
+        }
+      }
     }
 
     return allAccounts;

--- a/packages/account-api/src/api/multichain/account.ts
+++ b/packages/account-api/src/api/multichain/account.ts
@@ -1,13 +1,11 @@
-import {
-  KeyringAccountEntropyTypeOption,
-  type KeyringAccount,
-} from '@metamask/keyring-api';
+import { type KeyringAccount } from '@metamask/keyring-api';
 import { isScopeEqualToAny } from '@metamask/keyring-utils';
 
 import type {
   MultichainAccountWallet,
   MultichainAccountWalletId,
 } from './wallet';
+import type { Bip44Account } from '../bip44';
 import type { AccountGroup } from '../group';
 import type { AccountProvider } from '../provider';
 import type { AccountSelector } from '../selector';
@@ -26,7 +24,7 @@ export type MultichainAccountId = `${MultichainAccountWalletId}/${number}`; // U
 /**
  * A multichain account that holds multiple accounts.
  */
-export class MultichainAccount<Account extends KeyringAccount>
+export class MultichainAccount<Account extends Bip44Account<KeyringAccount>>
   implements AccountGroup<Account>
 {
   readonly #id: MultichainAccountId;
@@ -104,9 +102,6 @@ export class MultichainAccount<Account extends KeyringAccount>
           // we might wanna consider adding a state to that object and store
           // the list of account IDs here.
           (account) =>
-            account.options.entropy &&
-            account.options.entropy.type ===
-              KeyringAccountEntropyTypeOption.Mnemonic &&
             account.options.entropy.id === this.wallet.entropySource &&
             account.options.entropy.groupIndex === this.index,
         ),

--- a/packages/account-api/src/api/multichain/wallet.ts
+++ b/packages/account-api/src/api/multichain/wallet.ts
@@ -62,18 +62,23 @@ export class MultichainAccountWallet<
   sync(): void {
     for (const provider of this.#providers) {
       for (const account of provider.getAccounts()) {
-        const { groupIndex } = account.options.entropy;
+        const { entropy } = account.options;
+
+        // Filter for this wallet only.
+        if (entropy.id !== this.entropySource) {
+          continue;
+        }
 
         // This multichain account might exists already.
-        let multichainAccount = this.#accounts.get(groupIndex);
+        let multichainAccount = this.#accounts.get(entropy.groupIndex);
         if (!multichainAccount) {
           multichainAccount = new MultichainAccount<Account>({
-            groupIndex,
+            groupIndex: entropy.groupIndex,
             wallet: this,
             providers: this.#providers,
           });
 
-          this.#accounts.set(groupIndex, multichainAccount);
+          this.#accounts.set(entropy.groupIndex, multichainAccount);
         }
       }
     }

--- a/packages/account-api/src/api/multichain/wallet.ts
+++ b/packages/account-api/src/api/multichain/wallet.ts
@@ -60,6 +60,10 @@ export class MultichainAccountWallet<
    * doesn't know about.
    */
   sync(): void {
+    // We keep track of all existing indexes to see if some of them are no
+    // longer in use after the sync.
+    const outdatedIndexes = new Set(this.#accounts.keys());
+
     for (const provider of this.#providers) {
       for (const account of provider.getAccounts()) {
         const { entropy } = account.options;
@@ -68,6 +72,10 @@ export class MultichainAccountWallet<
         if (entropy.id !== this.entropySource) {
           continue;
         }
+
+        // We still got an account for this index, thus we can mark this index
+        // as "in use" (to not clean it up later on).
+        outdatedIndexes.delete(entropy.groupIndex);
 
         // This multichain account might exists already.
         let multichainAccount = this.#accounts.get(entropy.groupIndex);
@@ -81,6 +89,11 @@ export class MultichainAccountWallet<
           this.#accounts.set(entropy.groupIndex, multichainAccount);
         }
       }
+    }
+
+    // Clean up old multichain accounts.
+    for (const outdatedIndex of outdatedIndexes) {
+      this.#accounts.delete(outdatedIndex);
     }
   }
 

--- a/packages/account-api/src/api/multichain/wallet.ts
+++ b/packages/account-api/src/api/multichain/wallet.ts
@@ -9,6 +9,7 @@ import {
   isMultichainAccountId,
   MultichainAccount,
 } from './account';
+import type { Bip44Account } from '../bip44';
 import type { AccountGroupId } from '../group';
 import { toDefaultAccountGroupId } from '../group';
 import type { AccountProvider } from '../provider';
@@ -25,8 +26,9 @@ export type MultichainAccountWalletId =
  * A multichain account wallet that holds multiple multichain accounts (one multichain account per
  * group index).
  */
-export class MultichainAccountWallet<Account extends KeyringAccount>
-  implements AccountWallet<Account>
+export class MultichainAccountWallet<
+  Account extends Bip44Account<KeyringAccount>,
+> implements AccountWallet<Account>
 {
   readonly #id: MultichainAccountWalletId;
 

--- a/packages/account-api/src/api/provider.ts
+++ b/packages/account-api/src/api/provider.ts
@@ -5,6 +5,14 @@ import type { KeyringAccount } from '@metamask/keyring-api';
  */
 export type AccountProvider<Account extends KeyringAccount> = {
   /**
+   * Gets an account for a given ID.
+   *
+   * @throws If the account ID does not belong to this provider.
+   * @returns An account.
+   */
+  getAccount: (id: Account['id']) => Account;
+
+  /**
    * Gets all accounts for a given entropy source and group index.
    *
    * @returns A list of all account for this provider.

--- a/packages/account-api/src/api/provider.ts
+++ b/packages/account-api/src/api/provider.ts
@@ -7,10 +7,9 @@ export type AccountProvider<Account extends KeyringAccount> = {
   /**
    * Gets an account for a given ID.
    *
-   * @throws If the account ID does not belong to this provider.
-   * @returns An account.
+   * @returns An account, or undefined if not found.
    */
-  getAccount: (id: Account['id']) => Account;
+  getAccount: (id: Account['id']) => Account | undefined;
 
   /**
    * Gets all accounts for a given entropy source and group index.

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -154,14 +154,10 @@ class MockAccountProvider implements AccountProvider<MockedAccount> {
     return this.#accounts;
   });
 
-  getAccount = jest
-    .fn()
-    .mockImplementation(
-      (id: MockedAccount['id']): MockedAccount | undefined => {
-        // Assuming this never fails.
-        return this.#accounts.find((account) => account.id === id);
-      },
-    );
+  getAccount = jest.fn().mockImplementation((id: MockedAccount['id']) => {
+    // Assuming this never fails.
+    return this.#accounts.find((account) => account.id === id);
+  });
 
   createAccounts = jest
     .fn()

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -45,7 +45,7 @@ type MockedAccount = Bip44Account<InternalAccount>;
 
 const mockEntropySource = 'mock-entropy-source';
 
-const mockAccountOptions = {
+const mockAccountOptions: MockedAccount['options'] = {
   entropy: {
     type: KeyringAccountEntropyTypeOption.Mnemonic,
     id: mockEntropySource,

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -581,6 +581,38 @@ describe('index', () => {
       wallet.sync();
       expect(wallet.getMultichainAccounts()).toHaveLength(2);
     });
+
+    it('skips non-matching wallet during sync', async () => {
+      const provider = new MockAccountProvider(
+        () => [mockEvmAccount],
+        [mockEvmAccount],
+      );
+      const wallet = await setupMultichainAccountWallet({
+        providers: [provider],
+      });
+
+      expect(wallet.getMultichainAccounts()).toHaveLength(1);
+
+      provider.getAccounts.mockReturnValue([
+        mockEvmAccount,
+        {
+          ...mockEvmAccount,
+          options: {
+            ...mockEvmAccount.options,
+            entropy: {
+              ...mockEvmAccount.options.entropy,
+              id: 'mock-unknown-entropy-id',
+              groupIndex: 1,
+            },
+          },
+        },
+      ]);
+
+      // Even if we have a new account, it's not for this wallet, so it should
+      // not create a new multichain account!
+      wallet.sync();
+      expect(wallet.getMultichainAccounts()).toHaveLength(1);
+    });
   });
 
   describe('AccountGroup', () => {

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -156,12 +156,12 @@ class MockAccountProvider implements AccountProvider<MockedAccount> {
 
   getAccount = jest
     .fn()
-    .mockImplementation((id: MockedAccount['id']): MockedAccount => {
-      // Assuming this never fails.
-      return this.#accounts.find(
-        (account) => account.id === id,
-      ) as MockedAccount;
-    });
+    .mockImplementation(
+      (id: MockedAccount['id']): MockedAccount | undefined => {
+        // Assuming this never fails.
+        return this.#accounts.find((account) => account.id === id);
+      },
+    );
 
   createAccounts = jest
     .fn()

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -154,6 +154,15 @@ class MockAccountProvider implements AccountProvider<MockedAccount> {
     return this.#accounts;
   });
 
+  getAccount = jest
+    .fn()
+    .mockImplementation((id: MockedAccount['id']): MockedAccount => {
+      // Assuming this never fails.
+      return this.#accounts.find(
+        (account) => account.id === id,
+      ) as MockedAccount;
+    });
+
   createAccounts = jest
     .fn()
     .mockImplementation(
@@ -308,6 +317,13 @@ describe('index', () => {
       expect(multichainAccount.getAccount(mockEvmAccount.id)).toStrictEqual(
         mockEvmAccount,
       );
+    });
+
+    it('returns undefined if the account ID does not belong to the multichain account', async () => {
+      const { wallet } = setup();
+      const multichainAccount = await setupMultichainAccount({ wallet });
+
+      expect(multichainAccount.getAccount('unknown-id')).toBeUndefined();
     });
 
     it.each([

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -563,6 +563,7 @@ describe('index', () => {
 
       expect(wallet.getMultichainAccounts()).toHaveLength(1);
 
+      // Add a new account for the next index.
       provider.getAccounts.mockReturnValue([
         mockEvmAccount,
         {
@@ -593,6 +594,7 @@ describe('index', () => {
 
       expect(wallet.getMultichainAccounts()).toHaveLength(1);
 
+      // Add a new account for another index but not for this wallet.
       provider.getAccounts.mockReturnValue([
         mockEvmAccount,
         {
@@ -612,6 +614,26 @@ describe('index', () => {
       // not create a new multichain account!
       wallet.sync();
       expect(wallet.getMultichainAccounts()).toHaveLength(1);
+    });
+
+    it('cleans up old multichain account during sync', async () => {
+      const provider = new MockAccountProvider(
+        () => [mockEvmAccount],
+        [mockEvmAccount],
+      );
+      const wallet = await setupMultichainAccountWallet({
+        providers: [provider],
+      });
+
+      expect(wallet.getMultichainAccounts()).toHaveLength(1);
+
+      // Account for index 0 got removed, thus, the multichain account for index 0
+      // will also be removed.
+      provider.getAccounts.mockReturnValue([]);
+
+      // We should not have any multichain account anymore.
+      wallet.sync();
+      expect(wallet.getMultichainAccounts()).toHaveLength(0);
     });
   });
 

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -195,7 +195,9 @@ class MockAccountProvider implements AccountProvider<MockedAccount> {
       async ({ groupIndex }): Promise<MockedAccount['id'][]> => {
         return this.#accounts
           .flatMap((account) => account)
-          .filter((account) => account.options.index === groupIndex)
+          .filter(
+            (account) => account.options.entropy.groupIndex === groupIndex,
+          )
           .map((account) => account.id);
       },
     );

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -551,6 +551,36 @@ describe('index', () => {
       expect(multichainAccount).toBeDefined();
       expect(multichainAccount?.index).toBe(groupIndex);
     });
+
+    it('force sync wallet after account provider got new account', async () => {
+      const provider = new MockAccountProvider(
+        () => [mockEvmAccount],
+        [mockEvmAccount],
+      );
+      const wallet = await setupMultichainAccountWallet({
+        providers: [provider],
+      });
+
+      expect(wallet.getMultichainAccounts()).toHaveLength(1);
+
+      provider.getAccounts.mockReturnValue([
+        mockEvmAccount,
+        {
+          ...mockEvmAccount,
+          options: {
+            ...mockEvmAccount.options,
+            entropy: {
+              ...mockEvmAccount.options.entropy,
+              groupIndex: 1,
+            },
+          },
+        },
+      ]);
+
+      // Force sync, so the wallet will "find" a new multichain account.
+      wallet.sync();
+      expect(wallet.getMultichainAccounts()).toHaveLength(2);
+    });
   });
 
   describe('AccountGroup', () => {


### PR DESCRIPTION
To avoid adding an event-based mechanism to the `AccountProvider` we (for now) rely on external wallet sync's (which will be handle by the new `MultichainAccountService`.

This allow existing wallets to "find" new accounts and potentially create new missing multichan accounts.

Also, we now enforce `Bip44Account<Account>` for all `Multichain*` classes. This allows us to use `options.entropy.groupIndex` and quickly index multichain accounts based on that, thus, forcing the `AccountProvider` to only provide valid BIP-44 accounts too.