### PR TITLE
feat(keyring-snap-bridge)!: implement `AnyAccountType` handling in `SnapKeyring`

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Add `isAnyAccountTypeAllowed` flag to `SnapKeyring` constructor ([#322](https://github.com/MetaMask/accounts/pull/322))
+  - The `SnapKeyring` constructor now accepts an options object instead of individual parameters.
+  - The new `isAnyAccountTypeAllowed` flag defaults to `false`.
+
 ## [14.0.0]
 
 ### Changed

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -2784,7 +2784,7 @@ describe('SnapKeyring', () => {
           },
         }),
       ).rejects.toThrow(
-        `Cannot create account '${anyGenericAccount.id}' with a generic account type`,
+        `Cannot create generic account '${anyGenericAccount.id}'`,
       );
     });
 

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -428,7 +428,7 @@ export class SnapKeyring extends EventEmitter {
     // The `AnyAccountType.Account` generic account type is allowed only during
     // development, so we check whether it's allowed before continuing.
     //
-    // An account cannot be update if the `isAnyAccountTypeAllowed` flag is set
+    // An account cannot be updated if the `isAnyAccountTypeAllowed` flag is set
     // to `false` and the new or old account is a generic account.
     const isGenericAccountInvolved =
       newAccount.type === AnyAccountType.Account ||

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -205,17 +205,21 @@ export class SnapKeyring extends EventEmitter {
   /**
    * Create a new Snap keyring.
    *
-   * @param messenger - Snap keyring messenger.
-   * @param callbacks - Callbacks used to interact with other components.
-   * @param isAnyAccountTypeAllowed - Whether to allow the `AnyAccountType`
-   * generic account type.
+   * @param options - Constructor options.
+   * @param options.messenger - Snap keyring messenger.
+   * @param options.callbacks - Callbacks used to interact with other components.
+   * @param options.isAnyAccountTypeAllowed - Whether to allow the `AnyAccountType` generic account type.
    * @returns A new Snap keyring.
    */
-  constructor(
-    messenger: SnapKeyringMessenger,
-    callbacks: SnapKeyringCallbacks,
-    isAnyAccountTypeAllowed: boolean,
-  ) {
+  constructor({
+    messenger,
+    callbacks,
+    isAnyAccountTypeAllowed = false,
+  }: {
+    messenger: SnapKeyringMessenger;
+    callbacks: SnapKeyringCallbacks;
+    isAnyAccountTypeAllowed?: boolean;
+  }) {
     super();
     this.type = SnapKeyring.type;
     this.#messenger = messenger;
@@ -720,6 +724,7 @@ export class SnapKeyring extends EventEmitter {
 
     // Running Snap keyring migrations. We might have some accounts that have a
     // different "version" than the one we expect.
+    //
     // In this case, we "transform" then directly when deserializing to convert
     // them in the final account version.
     const accounts: KeyringState['accounts'] = {};

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -316,9 +316,7 @@ export class SnapKeyring extends EventEmitter {
       !this.#isAnyAccountTypeAllowed &&
       account.type === AnyAccountType.Account
     ) {
-      throw new Error(
-        `Cannot create generic account '${account.id}'`,
-      );
+      throw new Error(`Cannot create generic account '${account.id}'`);
     }
 
     // The UI still uses the account address to identify accounts, so we need
@@ -428,8 +426,8 @@ export class SnapKeyring extends EventEmitter {
     // The `AnyAccountType.Account` generic account type is allowed only during
     // development, so we check whether it's allowed before continuing.
     //
-    // An account cannot be updated if the `isAnyAccountTypeAllowed` flag is set
-    // to `false` and the new or old account is a generic account.
+    // An account cannot be updated if the `isAnyAccountTypeAllowed` flag is
+    // set to `false` and the new or old account is a generic account.
     const isGenericAccountInvolved =
       newAccount.type === AnyAccountType.Account ||
       oldAccount.type === AnyAccountType.Account;

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -317,7 +317,7 @@ export class SnapKeyring extends EventEmitter {
       account.type === AnyAccountType.Account
     ) {
       throw new Error(
-        `Cannot create account '${account.id}' with a generic account type`,
+        `Cannot create generic account '${account.id}'`,
       );
     }
 

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -200,6 +200,11 @@ export class SnapKeyring extends EventEmitter {
    */
   readonly #callbacks: SnapKeyringCallbacks;
 
+  /**
+   * Whether to allow the creation and update of generic accounts.
+   *
+   * Account deletion is not affected by this flag and is always allowed.
+   */
   readonly #isAnyAccountTypeAllowed: boolean;
 
   /**


### PR DESCRIPTION
This PR introduces a flag to control whether the `AnyAccountType.Account` generic account type is allowed by the `SnapKeyring`, with validation checks during account creation and updates.

**BREAKING**: The constructor now takes an options object.