### PR TITLE
chore(keyring-api): fix typo in changelog

### DIFF
--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add generic account type ([#318](https://github.com/metamask/accounts/pull/318))
   - This account type can be used during the integration of new chains.
-  - It's allowed only Flask builds of MetaMask clients.
+  - It's allowed only in Flask builds of MetaMask clients.
 
 ## [19.0.0]
 


### PR DESCRIPTION
Fix a small typo in the changelog of release 19.1.0.