### PR TITLE
feat(account-api): add AccountWalletOptions

### DIFF
--- a/packages/account-api/package.json
+++ b/packages/account-api/package.json
@@ -55,6 +55,7 @@
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/keyring-internal-api": "workspace:^",
+    "@metamask/snaps-sdk": "^9.0.0",
     "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.12.12",

--- a/packages/account-api/src/api/multichain/wallet.ts
+++ b/packages/account-api/src/api/multichain/wallet.ts
@@ -12,7 +12,7 @@ import type { Bip44Account } from '../bip44';
 import type { AccountGroupId } from '../group';
 import { toDefaultAccountGroupId } from '../group';
 import type { AccountProvider } from '../provider';
-import type { AccountWallet } from '../wallet';
+import type { AccountWallet, AccountWalletOptions } from '../wallet';
 import { AccountWalletCategory } from '../wallet';
 
 /**
@@ -110,6 +110,20 @@ export class MultichainAccountWallet<
    */
   get category(): AccountWalletCategory.Entropy {
     return AccountWalletCategory.Entropy;
+  }
+
+  /**
+   * Gets the multichain account wallet options.
+   *
+   * @returns The multichain account wallet options.
+   */
+  get options(): AccountWalletOptions {
+    return {
+      type: AccountWalletCategory.Entropy,
+      entropy: {
+        id: this.#entropySource,
+      },
+    };
   }
 
   /**

--- a/packages/account-api/src/api/wallet.ts
+++ b/packages/account-api/src/api/wallet.ts
@@ -1,4 +1,5 @@
-import type { KeyringAccount } from '@metamask/keyring-api';
+import type { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
+import type { SnapId } from '@metamask/snaps-sdk';
 
 // Circular import are allowed when using `import type`.
 import type { AccountGroup, AccountGroupId } from './group';
@@ -29,6 +30,44 @@ export enum AccountWalletCategory {
 export type AccountWalletId = `${AccountWalletCategory}:${string}`;
 
 /**
+ * Account wallet options for the "entropy" wallet category.
+ */
+export type AccountWalletEntropyOptions = {
+  type: AccountWalletCategory.Entropy;
+  entropy: {
+    id: EntropySourceId;
+  };
+};
+
+/**
+ * Account wallet options for the "snap" wallet category.
+ */
+export type AccountWalletSnapOptions = {
+  type: AccountWalletCategory.Snap;
+  snap: {
+    id: SnapId;
+  };
+};
+
+/**
+ * Account wallet options for the "keyring" wallet category.
+ */
+export type AccountWalletKeyringOptions = {
+  type: AccountWalletCategory.Keyring;
+  keyring: {
+    type: string;
+  };
+};
+
+/**
+ * Account wallet options for the "keyring" wallet category.
+ */
+export type AccountWalletOptions =
+  | AccountWalletEntropyOptions
+  | AccountWalletSnapOptions
+  | AccountWalletKeyringOptions;
+
+/**
  * Account wallet that can hold multiple account groups.
  */
 export type AccountWallet<Account extends KeyringAccount> = {
@@ -41,6 +80,11 @@ export type AccountWallet<Account extends KeyringAccount> = {
    * Account wallet category.
    */
   get category(): AccountWalletCategory;
+
+  /**
+   * Account wallet category.
+   */
+  get options(): AccountWalletOptions;
 
   /**
    * Gets account group for a given ID.

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -557,6 +557,18 @@ describe('index', () => {
       expect(wallet.getMultichainAccounts()).toHaveLength(1); // All internal accounts are using index 0, so it means only 1 multichain account.
     });
 
+    it('provides wallet options', async () => {
+      const entropySource = mockEntropySource;
+      const wallet = await setupMultichainAccountWallet({ entropySource });
+
+      expect(wallet.options).toStrictEqual({
+        type: AccountWalletCategory.Entropy,
+        entropy: {
+          id: entropySource,
+        }
+      });
+    });
+
     it('gets a multichain account from its index', async () => {
       const wallet = await setupMultichainAccountWallet();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,6 +1365,7 @@ __metadata:
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-internal-api": "workspace:^"
     "@metamask/keyring-utils": "workspace:^"
+    "@metamask/snaps-sdk": "npm:^9.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"


### PR DESCRIPTION
Adding typed `options` similar to `account.options` for `AccountWallet` (and thus, `MultichainAccountWallet` too).

Those options describe common properties shared by all accounts within that wallet.