### PR TITLE
feat: add `AccountGroupType` + `AccountGroup.type`

### DIFF
--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `AccountGroupType` + `AccountGroup.type` ([#329](https://github.com/MetaMask/accounts/pull/329))
+
 ### Changed
 
 - **BREAKING:** Rename `AccountWalletCategory` to `AccountWalletType` + `category` to `type` ([#328](https://github.com/MetaMask/accounts/pull/328))

--- a/packages/account-api/src/api/group.ts
+++ b/packages/account-api/src/api/group.ts
@@ -21,7 +21,7 @@ export enum AccountGroupType {
   MultichainAccount = 'multichain-account',
 
   /** Group that represents a single account. */
-  Account = 'account',
+  SingleAccount = 'single-account',
 }
 
 /**

--- a/packages/account-api/src/api/group.ts
+++ b/packages/account-api/src/api/group.ts
@@ -12,6 +12,19 @@ import type { AccountWallet, AccountWalletId } from './wallet';
 export const DEFAULT_ACCOUNT_GROUP_UNIQUE_ID: string = 'default';
 
 /**
+ * Account group object.
+ *
+ * Each group types groups accounts using different criterias.
+ */
+export enum AccountGroupType {
+  /** Group that represents a multichain account. */
+  MultichainAccount = 'multichain-account',
+
+  /** Group that represents a single account. */
+  Account = 'account',
+}
+
+/**
  * Account group ID.
  */
 export type AccountGroupId = `${AccountWalletId}/${string}`;
@@ -24,6 +37,11 @@ export type AccountGroup<Account extends KeyringAccount> = {
    * Account group ID.
    */
   get id(): AccountGroupId;
+
+  /**
+   * Account group type.
+   */
+  get type(): AccountGroupType;
 
   /**
    * Account wallet (parent).

--- a/packages/account-api/src/api/multichain/account.ts
+++ b/packages/account-api/src/api/multichain/account.ts
@@ -6,7 +6,8 @@ import type {
   MultichainAccountWalletId,
 } from './wallet';
 import type { Bip44Account } from '../bip44';
-import { AccountGroup, AccountGroupType } from '../group';
+import type { AccountGroup } from '../group';
+import { AccountGroupType } from '../group';
 import type { AccountProvider } from '../provider';
 import type { AccountSelector } from '../selector';
 import { AccountWalletType } from '../wallet';

--- a/packages/account-api/src/api/multichain/account.ts
+++ b/packages/account-api/src/api/multichain/account.ts
@@ -6,7 +6,7 @@ import type {
   MultichainAccountWalletId,
 } from './wallet';
 import type { Bip44Account } from '../bip44';
-import type { AccountGroup } from '../group';
+import { AccountGroup, AccountGroupType } from '../group';
 import type { AccountProvider } from '../provider';
 import type { AccountSelector } from '../selector';
 import { AccountWalletType } from '../wallet';
@@ -97,6 +97,15 @@ export class MultichainAccount<Account extends Bip44Account<KeyringAccount>>
    */
   get id(): MultichainAccountId {
     return this.#id;
+  }
+
+  /**
+   * Gets the multichain account type.
+   *
+   * @returns The multichain account type.
+   */
+  get type(): AccountGroupType.MultichainAccount {
+    return AccountGroupType.MultichainAccount;
   }
 
   /**

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -666,6 +666,7 @@ describe('index', () => {
 
       expect(group).toBeDefined();
       expect(group?.id).toStrictEqual(groupId);
+      expect(group?.type).toBeDefined();
     });
 
     it('gets the default account when using the default group id', async () => {


### PR DESCRIPTION
Similar to, but for groups.
- https://github.com/MetaMask/accounts/pull/328

This new "type" can be used to "tag" groups.