### PR TITLE
feat(account-api): add typing utility + better typing for `Account{Wallet,Group}Id`

### DIFF
--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `Account{Wallet,Group}IdOf` type utility ([#331](https://github.com/MetaMask/accounts/pull/331))
+
+### Changed
+
+- Use generic type for `toAccount{Wallet,Group}Id` ([#331](https://github.com/MetaMask/accounts/pull/331))
+
 ## [0.4.0]
 
 ### Added

--- a/packages/account-api/src/api/group.ts
+++ b/packages/account-api/src/api/group.ts
@@ -98,7 +98,7 @@ export function toAccountGroupId<WalletType extends AccountWalletType>(
  */
 export function toDefaultAccountGroupId<WalletType extends AccountWalletType>(
   walletId: AccountWalletIdOf<WalletType>,
-): AccountGroupId {
+): AccountGroupIdOf<WalletType> {
   return toAccountGroupId<WalletType>(
     walletId,
     DEFAULT_ACCOUNT_GROUP_UNIQUE_ID,

--- a/packages/account-api/src/api/group.ts
+++ b/packages/account-api/src/api/group.ts
@@ -1,7 +1,12 @@
 import type { KeyringAccount } from '@metamask/keyring-api';
 
 // Circular import are allowed when using `import type`.
-import type { AccountWallet, AccountWalletId } from './wallet';
+import type {
+  AccountWallet,
+  AccountWalletId,
+  AccountWalletIdOf,
+  AccountWalletType,
+} from './wallet';
 
 /**
  * Default account group unique ID.
@@ -65,16 +70,23 @@ export type AccountGroup<Account extends KeyringAccount> = {
 };
 
 /**
+ * Type utility to compute a constrained {@link AccountGroupId} type given a
+ * specifc {@link AccountWalletType}.
+ */
+export type AccountGroupIdOf<WalletType extends AccountWalletType> =
+  `${AccountWalletIdOf<WalletType>}/${string}`;
+
+/**
  * Convert a wallet ID and a unique ID, to a group ID.
  *
  * @param walletId - A wallet ID.
  * @param id - A unique ID.
  * @returns A group ID.
  */
-export function toAccountGroupId(
-  walletId: AccountWalletId,
+export function toAccountGroupId<WalletType extends AccountWalletType>(
+  walletId: AccountWalletIdOf<WalletType>,
   id: string,
-): AccountGroupId {
+): AccountGroupIdOf<WalletType> {
   return `${walletId}/${id}`;
 }
 
@@ -84,8 +96,11 @@ export function toAccountGroupId(
  * @param walletId - A wallet ID.
  * @returns The default group ID.
  */
-export function toDefaultAccountGroupId(
-  walletId: AccountWalletId,
+export function toDefaultAccountGroupId<WalletType extends AccountWalletType>(
+  walletId: AccountWalletIdOf<WalletType>,
 ): AccountGroupId {
-  return toAccountGroupId(walletId, DEFAULT_ACCOUNT_GROUP_UNIQUE_ID);
+  return toAccountGroupId<WalletType>(
+    walletId,
+    DEFAULT_ACCOUNT_GROUP_UNIQUE_ID,
+  );
 }

--- a/packages/account-api/src/api/wallet.ts
+++ b/packages/account-api/src/api/wallet.ts
@@ -9,19 +9,13 @@ import type { AccountGroup, AccountGroupId } from './group';
  * Each wallet types groups accounts using different criterias.
  */
 export enum AccountWalletType {
-  /**
-   * Wallet grouping accounts based on their entropy source.
-   */
+  /** Wallet grouping accounts based on their entropy source. */
   Entropy = 'entropy',
 
-  /**
-   * Wallet grouping accounts based on their keyring's type.
-   */
+  /** Wallet grouping accounts based on their keyring's type. */
   Keyring = 'keyring',
 
-  /**
-   * Wallet grouping accounts associated with an account management Snap.
-   */
+  /** Wallet grouping accounts associated with an account management Snap. */
   Snap = 'snap',
 }
 
@@ -61,15 +55,22 @@ export type AccountWallet<Account extends KeyringAccount> = {
 };
 
 /**
+ * Type utility to compute a constrained {@link AccountWalletId} type given a
+ * specifc {@link AccountWalletType}.
+ */
+export type AccountWalletIdOf<WalletType extends AccountWalletType> =
+  `${WalletType}:${string}`;
+
+/**
  * Convert a unique ID to a wallet ID for a given type.
  *
  * @param type - A wallet type.
  * @param id - A unique ID.
  * @returns A wallet ID.
  */
-export function toAccountWalletId(
-  type: AccountWalletType,
+export function toAccountWalletId<WalletType extends AccountWalletType>(
+  type: WalletType,
   id: string,
-): AccountWalletId {
+): AccountWalletIdOf<WalletType> {
   return `${type}:${id}`;
 }


### PR DESCRIPTION
More utility type which allows for improved typing when using those functions.

This can help to not "generalize" the computed ID to be narrowed down to `Account{Wallet,Group}Id` only, using those new generics allows to keep the `AccountWalletType` within the computed typed.