### PR TITLE
refactor(account-api)!: rename `getGroupIndexFromMultichainAccountId` -> `getGroupIndexFromMultichainAccountGroupId`

### DIFF
--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Rename `getGroupIndexFromMultichainAccountId` to `getGroupIndexFromMultichainAccountGroupId` ([#336](https://github.com/MetaMask/accounts/pull/336))
+  - This function was not following the same naming convention (this is an oversight from previous release).
+
 ## [0.6.0]
 
 ### Changed

--- a/packages/account-api/src/api/multichain/group.ts
+++ b/packages/account-api/src/api/multichain/group.ts
@@ -95,7 +95,7 @@ export function isMultichainAccountGroupId(
  * @param id - Multichain account ID.
  * @returns The multichain account index if extractable, undefined otherwise.
  */
-export function getGroupIndexFromMultichainAccountId(
+export function getGroupIndexFromMultichainAccountGroupId(
   id: MultichainAccountGroupId,
 ): number {
   const matched = id.match(MULTICHAIN_ACCOUNT_GROUP_ID_REGEX);

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -15,7 +15,7 @@ import {
   toAccountGroupId,
   toAccountWalletId,
   toDefaultAccountGroupId,
-  getGroupIndexFromMultichainAccountId,
+  getGroupIndexFromMultichainAccountGroupId,
   isBip44Account,
   toMultichainAccountWalletId,
   toMultichainAccountGroupId,
@@ -163,7 +163,9 @@ describe('index', () => {
         const walletId = toMultichainAccountWalletId('test');
         const groupId = toMultichainAccountGroupId(walletId, groupIndex);
 
-        expect(getGroupIndexFromMultichainAccountId(groupId)).toBe(groupIndex);
+        expect(getGroupIndexFromMultichainAccountGroupId(groupId)).toBe(
+          groupIndex,
+        );
       });
 
       it('throws if it cannot extract group index', () => {
@@ -171,7 +173,7 @@ describe('index', () => {
         const groupId = toAccountGroupId(walletId, 'test');
 
         expect(() =>
-          getGroupIndexFromMultichainAccountId(
+          getGroupIndexFromMultichainAccountGroupId(
             // Force the error case even though, type wise, this should not
             // be possible!
             groupId as unknown as MultichainAccountGroupId,


### PR DESCRIPTION
We forgot to rename this function when removing the old implementation.