### PR TITLE
feat(account-api): add `AccountProvider.{createAccounts,discoverAndCreateAccounts}`

### DIFF
--- a/packages/account-api/src/api/provider.ts
+++ b/packages/account-api/src/api/provider.ts
@@ -1,4 +1,4 @@
-import type { KeyringAccount } from '@metamask/keyring-api';
+import type { EntropySourceId, KeyringAccount } from '@metamask/keyring-api';
 
 /**
  * An account provider is reponsible of providing accounts to an account group.
@@ -12,9 +12,39 @@ export type AccountProvider<Account extends KeyringAccount> = {
   getAccount: (id: Account['id']) => Account | undefined;
 
   /**
-   * Gets all accounts for a given entropy source and group index.
+   * Gets all accounts for this provider.
    *
    * @returns A list of all account for this provider.
    */
   getAccounts: () => Account[];
+
+  /**
+   * Creates accounts for a given entropy source and a given group
+   * index.
+   *
+   * @param options - Options.
+   * @param options.entropySource - Entropy source to use.
+   * @param options.groupIndex - Group index to use.
+   * @returns The list of created accounts.
+   */
+  createAccounts: (options: {
+    entropySource: EntropySourceId;
+    groupIndex: number;
+  }) => Promise<Account[]>;
+
+  /**
+   * Discover accounts for a given entropy source and a given group
+   * index.
+   *
+   * NOTE: This method needs to also create the discovered accounts.
+   *
+   * @param options - Options.
+   * @param options.entropySource - Entropy source to use.
+   * @param options.groupIndex - Group index to use.
+   * @returns The list of discovered and created accounts.
+   */
+  discoverAndCreateAccounts: (options: {
+    entropySource: EntropySourceId;
+    groupIndex: number;
+  }) => Promise<Account[]>;
 };


### PR DESCRIPTION
Adding `createAccounts` and `discoverAndCreateAccounts` methods to the `AccountProvider` interface.