### PR TITLE
feat(account-api): add `assertIsBip44Account`

### DIFF
--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `assertIsBip44Account` ([#339](https://github.com/MetaMask/accounts/pull/339))
+
 ## [0.7.0]
 
 ### Added

--- a/packages/account-api/src/api/bip44.ts
+++ b/packages/account-api/src/api/bip44.ts
@@ -31,3 +31,17 @@ export function isBip44Account<Account extends KeyringAccount>(
     KeyringAccountEntropyMnemonicOptionsStruct,
   );
 }
+
+/**
+ * Asserts a keyring account is BIP-44 compatible.
+ *
+ * @param account - Keyring account to check.
+ * @throws If the keyring account is not compatible.
+ */
+export function assertIsBip44Account<Account extends KeyringAccount>(
+  account: Account,
+): asserts account is Bip44Account<Account> {
+  if (!isBip44Account(account)) {
+    throw new Error('Account is not BIP-44 compatible');
+  }
+}

--- a/packages/account-api/src/index.test.ts
+++ b/packages/account-api/src/index.test.ts
@@ -20,6 +20,7 @@ import {
   toMultichainAccountWalletId,
   toMultichainAccountGroupId,
   isMultichainAccountGroupId,
+  assertIsBip44Account,
 } from './api';
 
 type MockedAccount = Bip44Account<InternalAccount>;
@@ -74,6 +75,7 @@ describe('index', () => {
     describe('isBip44Account', () => {
       it('returns true if the account is BIP-44 compatible', () => {
         expect(isBip44Account(mockEvmAccount)).toBe(true);
+        expect(() => assertIsBip44Account(mockEvmAccount)).not.toThrow();
       });
 
       it.each([
@@ -134,6 +136,9 @@ describe('index', () => {
           };
 
           expect(isBip44Account(account)).toBe(false);
+          expect(() => assertIsBip44Account(account)).toThrow(
+            'Account is not BIP-44 compatible',
+          );
         },
       );
     });


### PR DESCRIPTION
Add small helper to assert an account is BIP-44 compatible.