### PR TITLE
refactor(account-api)!: rename index to groupIndex

### DIFF
--- a/packages/account-api/src/api/multichain/group.ts
+++ b/packages/account-api/src/api/multichain/group.ts
@@ -43,7 +43,7 @@ export type MultichainAccountGroup<
   /**
    * Multichain account group index.
    */
-  get index(): number;
+  get groupIndex(): number;
 
   /**
    * Query an account matching the selector.


### PR DESCRIPTION
To avoid confusion, it's better if we just use a single term for the "group index". So renaming it now, makes more sense before introducing too many breaking changes.