### PR TITLE
chore(account-api): fixup changelog

### DIFF
--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add group/wallet ID parsing/validation support ([#360](https://github.com/MetaMask/accounts/pull/360))
 - Add `Bip44AccountProvider` type alias ([#361](https://github.com/MetaMask/accounts/pull/361))
 
+### Changed
+
+- **BREAKING:** Bump `@metamask/keyring-api` to `^21.0.0` ([#362](https://github.com/MetaMask/accounts/pull/362))
+
 ## [0.9.0]
 
 ### Changed


### PR DESCRIPTION
This entry was missing during the previous release.

> [!NOTE]
> I was waiting for this release too to re-align the `keyring-api` everywhere on `core`.