### PR TITLE
perf(account-api): faster isBip44Account function

### DIFF
--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make `isBip44Account` faster ([#369](https://github.com/MetaMask/accounts/pull/369))
+  - We mainly rely on the `options.entropy.type` now and no longer use `superstruct` for this function.
+
 ## [0.10.0]
 
 ### Added

--- a/packages/account-api/package.json
+++ b/packages/account-api/package.json
@@ -58,7 +58,6 @@
   "dependencies": {
     "@metamask/keyring-api": "workspace:^",
     "@metamask/keyring-utils": "workspace:^",
-    "@metamask/superstruct": "^3.1.0",
     "uuid": "^9.0.1"
   },
   "devDependencies": {

--- a/packages/account-api/src/api/bip44.ts
+++ b/packages/account-api/src/api/bip44.ts
@@ -2,8 +2,6 @@ import type {
   KeyringAccount,
   KeyringAccountEntropyMnemonicOptions,
 } from '@metamask/keyring-api';
-import { KeyringAccountEntropyMnemonicOptionsStruct } from '@metamask/keyring-api';
-import { is } from '@metamask/superstruct';
 
 /**
  * BIP-44 compatible account type.

--- a/packages/account-api/src/api/bip44.ts
+++ b/packages/account-api/src/api/bip44.ts
@@ -25,11 +25,9 @@ export type Bip44Account<Account extends KeyringAccount> = Account & {
 export function isBip44Account<Account extends KeyringAccount>(
   account: Account,
 ): account is Bip44Account<Account> {
-  // To be BIP-44 compatible, you just need to use this set of options:
-  return is(
-    account.options.entropy,
-    KeyringAccountEntropyMnemonicOptionsStruct,
-  );
+  // To be BIP-44 compatible, we just check for the entropy type (the
+  // the `entropy` shape will be inferred automatically).
+  return account.options.entropy?.type === 'mnemonic';
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1442,7 +1442,6 @@ __metadata:
     "@metamask/auto-changelog": "npm:^3.4.4"
     "@metamask/keyring-api": "workspace:^"
     "@metamask/keyring-utils": "workspace:^"
-    "@metamask/superstruct": "npm:^3.1.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"


### PR DESCRIPTION
Checking the `.type` is insanely faster and still provide the same type guarantee.