### PR TITLE
chore: update tsconfig package types

### DIFF
--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add explicit `types` to tsconfig to restore DOM type access after root tsconfig restriction ([#510](https://github.com/MetaMask/accounts/pull/510))
+
 ### Changed
 
 - Add new dependency `@metamask/keyring-sdk@1.1.0` ([#478](https://github.com/MetaMask/accounts/pull/478)), ([#482](https://github.com/MetaMask/accounts/pull/482)), ([#496](https://github.com/MetaMask/accounts/pull/496))

--- a/packages/keyring-eth-ledger-bridge/tsconfig.build.json
+++ b/packages/keyring-eth-ledger-bridge/tsconfig.build.json
@@ -4,7 +4,8 @@
     "baseUrl": "./",
     "outDir": "dist",
     "rootDir": "src",
-    "exactOptionalPropertyTypes": false
+    "exactOptionalPropertyTypes": false,
+    "types": ["node", "web"]
   },
   "references": [
     { "path": "../hw-wallet-sdk/tsconfig.build.json" },

--- a/packages/keyring-eth-ledger-bridge/tsconfig.json
+++ b/packages/keyring-eth-ledger-bridge/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "baseUrl": "./",
     "exactOptionalPropertyTypes": false,
-    "target": "es2017"
+    "target": "es2017",
+    "types": ["jest", "node", "web"]
   },
   "references": [
     { "path": "../hw-wallet-sdk" },

--- a/tsconfig.packages.build.json
+++ b/tsconfig.packages.build.json
@@ -6,7 +6,7 @@
     "noEmit": false,
     "inlineSources": true,
     "sourceMap": true,
-    "types": []
+    "types": ["node"]
   },
   "exclude": ["./jest.config.packages.ts", "**/*.test.ts", "**/jest.config.ts"]
 }

--- a/tsconfig.packages.build.json
+++ b/tsconfig.packages.build.json
@@ -5,7 +5,8 @@
     "declarationMap": true,
     "noEmit": false,
     "inlineSources": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "types": []
   },
   "exclude": ["./jest.config.packages.ts", "**/*.test.ts", "**/jest.config.ts"]
 }

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -20,6 +20,7 @@
     "target": "es2020",
     "module": "Node16",
     "moduleResolution": "Node16",
+    "types": ["jest"],
     /**
      * Here we ensure that TypeScript resolves `@metamask/*` imports to the
      * uncompiled source code for packages that live in this repo.

--- a/tsconfig.packages.json
+++ b/tsconfig.packages.json
@@ -20,7 +20,7 @@
     "target": "es2020",
     "module": "Node16",
     "moduleResolution": "Node16",
-    "types": ["jest"],
+    "types": ["jest", "node"],
     /**
      * Here we ensure that TypeScript resolves `@metamask/*` imports to the
      * uncompiled source code for packages that live in this repo.


### PR DESCRIPTION
## Summary
- Add `jest` types to `tsconfig.packages.json`
- Add empty `types` array to `tsconfig.packages.build.json`

## Why
Ensures Jest globals are available for type checking in development, while preventing ambient types from being included in production builds.