### PR TITLE
chore: rename alias from `old-hd-keyring` to `@metamask/old-hd-keyring`

### DIFF
--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -61,11 +61,11 @@
     "@metamask/account-api": "^1.0.1",
     "@metamask/auto-changelog": "^3.4.4",
     "@metamask/bip39": "^4.0.0",
+    "@metamask/old-hd-keyring": "npm:@metamask/eth-hd-keyring@^4.0.1",
     "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
     "deepmerge": "^4.2.2",
-    "jest": "^29.5.0",
-    "old-hd-keyring": "npm:@metamask/eth-hd-keyring@^4.0.1"
+    "jest": "^29.5.0"
   },
   "engines": {
     "node": "^18.18 || >=20"

--- a/packages/keyring-eth-hd/src/hd-keyring.test.ts
+++ b/packages/keyring-eth-hd/src/hd-keyring.test.ts
@@ -20,13 +20,13 @@ import {
   type EIP7702Authorization,
 } from '@metamask/eth-sig-util';
 import { mnemonicPhraseToBytes } from '@metamask/key-tree';
+// eslint-disable-next-line @typescript-eslint/naming-convention
+import OldHdKeyring from '@metamask/old-hd-keyring';
 import { assert, bytesToHex, hexToBytes, type Hex } from '@metamask/utils';
 import { webcrypto } from 'crypto';
 // eslint-disable-next-line n/no-sync
 import { mnemonicToSeedSync } from 'ethereum-cryptography/bip39';
 import { keccak256 } from 'ethereum-cryptography/keccak';
-// eslint-disable-next-line @typescript-eslint/naming-convention
-import OldHdKeyring from 'old-hd-keyring';
 
 import { HdKeyring } from '.';
 

--- a/packages/keyring-eth-hd/types/old-hd-keyring.d.ts
+++ b/packages/keyring-eth-hd/types/old-hd-keyring.d.ts
@@ -1,2 +1,2 @@
 // eslint-disable-next-line import-x/unambiguous
-declare module 'old-hd-keyring';
+declare module '@metamask/old-hd-keyring';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,6 +1694,7 @@ __metadata:
     "@metamask/keyring-api": "npm:^22.0.0"
     "@metamask/keyring-sdk": "npm:^1.2.0"
     "@metamask/keyring-utils": "npm:^3.2.0"
+    "@metamask/old-hd-keyring": "npm:@metamask/eth-hd-keyring@^4.0.1"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.10.0"
@@ -1702,7 +1703,6 @@ __metadata:
     deepmerge: "npm:^4.2.2"
     ethereum-cryptography: "npm:^2.2.1"
     jest: "npm:^29.5.0"
-    old-hd-keyring: "npm:@metamask/eth-hd-keyring@^4.0.1"
   languageName: unknown
   linkType: soft
 
@@ -2285,6 +2285,19 @@ __metadata:
     "@metamask/safe-event-emitter": "npm:^3.0.0"
     readable-stream: "npm:^3.6.2"
   checksum: 10/fa37a0b9e1e25f54c93a8f16449b3fc771c15b70d79d590cf41e22f871a19d673bcfd0d08b044093235d10d0bb031b47b8209d89997def0cb256abe3e371064f
+  languageName: node
+  linkType: hard
+
+"@metamask/old-hd-keyring@npm:@metamask/eth-hd-keyring@^4.0.1":
+  version: 4.0.2
+  resolution: "@metamask/eth-hd-keyring@npm:4.0.2"
+  dependencies:
+    "@metamask/bip39": "npm:^4.0.0"
+    "@metamask/eth-sig-util": "npm:^4.0.0"
+    eth-simple-keyring: "npm:^4.2.0"
+    ethereumjs-util: "npm:^7.0.9"
+    ethereumjs-wallet: "npm:^1.0.1"
+  checksum: 10/50a44b8c87c55d834838e2ebc2d58ab85d0b83315a3ec22e266e7d24b2c5c9c8007c32d639a82e905ee6d66fe185ca595614026476c9849d373595bd55757805
   languageName: node
   linkType: hard
 
@@ -9940,19 +9953,6 @@ __metadata:
     has-symbols: "npm:^1.0.3"
     object-keys: "npm:^1.1.1"
   checksum: 10/fd82d45289df0a952d772817622ecbaeb4ec933d3abb53267aede083ee38f6a395af8fadfbc569ee575115b0b7c9b286e7cfb2b7a2557b1055f7acbce513bc29
-  languageName: node
-  linkType: hard
-
-"old-hd-keyring@npm:@metamask/eth-hd-keyring@^4.0.1":
-  version: 4.0.2
-  resolution: "@metamask/eth-hd-keyring@npm:4.0.2"
-  dependencies:
-    "@metamask/bip39": "npm:^4.0.0"
-    "@metamask/eth-sig-util": "npm:^4.0.0"
-    eth-simple-keyring: "npm:^4.2.0"
-    ethereumjs-util: "npm:^7.0.9"
-    ethereumjs-wallet: "npm:^1.0.1"
-  checksum: 10/50a44b8c87c55d834838e2ebc2d58ab85d0b83315a3ec22e266e7d24b2c5c9c8007c32d639a82e905ee6d66fe185ca595614026476c9849d373595bd55757805
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Rename the `old-hd-keyring` alias used in tests to include the `@metamask/` prefix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only renames a dev-only dependency alias and updates test/type import paths, with no runtime or production code changes.
> 
> **Overview**
> Updates the legacy keyring alias used for backwards-compatibility tests from `old-hd-keyring` to the scoped `@metamask/old-hd-keyring`.
> 
> This renames the devDependency alias in `package.json`, updates the `OldHdKeyring` import in `hd-keyring.test.ts`, adjusts the local module declaration in `types/old-hd-keyring.d.ts`, and refreshes `yarn.lock` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 027361d384e3fdbabccd2eaac483c85f3a76513f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->