### PR TITLE
fix: fix browserify compatibility for /v2 subpath export

### DIFF
--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [23.0.0]
 
 ### Added

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -43,7 +43,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-api/v2.js
+++ b/packages/keyring-api/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [14.0.0]
 
 ### Added

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -42,7 +42,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-eth-hd/v2.js
+++ b/packages/keyring-eth-hd/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [12.0.0]
 
 ### Added

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -44,7 +44,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-eth-ledger-bridge/v2.js
+++ b/packages/keyring-eth-ledger-bridge/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-eth-qr/CHANGELOG.md
+++ b/packages/keyring-eth-qr/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [2.0.0]
 
 ### Added

--- a/packages/keyring-eth-qr/package.json
+++ b/packages/keyring-eth-qr/package.json
@@ -44,7 +44,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-eth-qr/v2.js
+++ b/packages/keyring-eth-qr/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [12.0.0]
 
 ### Added

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -42,7 +42,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-eth-simple/v2.js
+++ b/packages/keyring-eth-simple/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [10.0.0]
 
 ### Added

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -44,7 +44,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-eth-trezor/v2.js
+++ b/packages/keyring-eth-trezor/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-internal-snap-client/CHANGELOG.md
+++ b/packages/keyring-internal-snap-client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [10.0.0]
 
 ### Added

--- a/packages/keyring-internal-snap-client/package.json
+++ b/packages/keyring-internal-snap-client/package.json
@@ -42,7 +42,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-internal-snap-client/v2.js
+++ b/packages/keyring-internal-snap-client/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [2.0.0]
 
 ### Added

--- a/packages/keyring-sdk/package.json
+++ b/packages/keyring-sdk/package.json
@@ -42,7 +42,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-sdk/v2.js
+++ b/packages/keyring-sdk/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [21.0.0]
 
 ### Added

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -43,7 +43,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-snap-bridge/v2.js
+++ b/packages/keyring-snap-bridge/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-snap-client/CHANGELOG.md
+++ b/packages/keyring-snap-client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [9.0.0]
 
 ### Added

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -42,7 +42,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-snap-client/v2.js
+++ b/packages/keyring-snap-client/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');

--- a/packages/keyring-snap-sdk/CHANGELOG.md
+++ b/packages/keyring-snap-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Workaround Browserify subpath export for `/v2` ([#516](https://github.com/MetaMask/accounts/pull/516))
+
 ## [9.0.0]
 
 ### Added

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -42,7 +42,8 @@
   "main": "./dist/index.cjs",
   "types": "./dist/index.d.cts",
   "files": [
-    "dist/"
+    "dist/",
+    "v2.js"
   ],
   "scripts": {
     "build": "ts-bridge --project tsconfig.build.json --verbose --clean --no-references",

--- a/packages/keyring-snap-sdk/v2.js
+++ b/packages/keyring-snap-sdk/v2.js
@@ -1,0 +1,3 @@
+// Re-exported for compatibility with Browserify.
+// eslint-disable-next-line
+module.exports = require('./dist/v2/index.cjs');


### PR DESCRIPTION
It seems that `browserify` is not able to use our `/v2` export automatically. So to workaround this, we just add this thin wrapper that resolve to the proper `dist/v2/index.cjs` file.

This is inspired from `@metamask/json-rpc-engine`:
- https://github.com/MetaMask/core/blob/fa4d7d7a4b253cb2b2500ae9332e8a70d478fbfc/packages/json-rpc-engine/v2.js#L1-L3 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to package publishing/entrypoint wiring by adding a thin CommonJS `v2.js` re-export, with no runtime logic changes beyond module resolution.
> 
> **Overview**
> **Improves Browserify compatibility for `/v2` imports** across the keyring packages.
> 
> Each affected package now ships a top-level `v2.js` CommonJS wrapper that re-exports `./dist/v2/index.cjs`, and `package.json` `files` is updated to include this wrapper so it gets published. Changelogs are updated under *Unreleased* to note the Browserify workaround.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc8eda05a050d3d0d86449fb545ba9b02a20e02b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->