### PR TITLE
fix(keyring-snap-bridge)!: set Snap ID during `deserialize`

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** No longer use `snapId` as constructor parameter for `SnapKeyring` (v2) ([#519](https://github.com/MetaMask/accounts/pull/519))
+  - The `snapId` is now passed and bound to the keyring upon the first `deserialize` call, to better integrate with `KeyringController` keyrings lifecyle and keyring builders.
+
 ## [21.0.1]
 
 ### Changed

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -3236,6 +3236,51 @@ describe('SnapKeyring', () => {
       // Verify saveState was called for each batch (3 times)
       expect(mockCallbacks.saveState).toHaveBeenCalledTimes(3);
     });
+
+    it('does not create duplicate keyrings for concurrent calls targeting a new snap', async () => {
+      const newSnapId = 'local:snap.concurrent-new' as SnapId;
+
+      const batch1Account: KeyringAccount = {
+        ...newEthEoaAccount,
+        id: 'd1000000-0000-4000-a000-000000000001',
+        address: '0xd100000000000000000000000000000000000001',
+      };
+      const batch2Account: KeyringAccount = {
+        ...newEthEoaAccount,
+        id: 'e2000000-0000-4000-a000-000000000002',
+        address: '0xe200000000000000000000000000000000000002',
+      };
+
+      mockCallbacks.addressExists.mockResolvedValue(false);
+      mockCallbacks.saveState.mockClear();
+
+      mockMessengerHandleRequest({
+        [KeyringRpcMethod.CreateAccounts]: jest
+          .fn()
+          .mockResolvedValueOnce([batch1Account])
+          .mockResolvedValueOnce([batch2Account]),
+      });
+
+      const options: CreateAccountOptions = {
+        type: AccountCreationType.Bip44DeriveIndex,
+        entropySource,
+        groupIndex: 0,
+      };
+
+      // Two concurrent calls for a snap that has no keyring yet — exercises the
+      // double-check inside #getOrCreateKeyringLock so only one SnapKeyringV2
+      // is ever created for newSnapId.
+      const [result1, result2] = await Promise.all([
+        keyring.createAccounts(newSnapId, options),
+        keyring.createAccounts(newSnapId, options),
+      ]);
+
+      expect(result1).toStrictEqual([batch1Account]);
+      expect(result2).toStrictEqual([batch2Account]);
+
+      expect(keyring.getAccountByAddress(batch1Account.address)).toBeDefined();
+      expect(keyring.getAccountByAddress(batch2Account.address)).toBeDefined();
+    });
   });
 
   describe('resolveAccountAddress', () => {

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -127,6 +127,16 @@ export class SnapKeyring {
   readonly #lock: Mutex;
 
   /**
+   * Serializes lazy keyring initialization in {@link SnapKeyring.#getOrCreateKeyring}.
+   *
+   * Kept separate from {@link SnapKeyring.#lock} (which guards `createAccounts`
+   * uniqueness checks) to avoid mixing concerns. The lock is held only for the
+   * duration of a single keyring's initialization - released before the caller
+   * proceeds with its operation.
+   */
+  readonly #getOrCreateKeyringLock: Mutex;
+
+  /**
    * Create a new Snap keyring.
    *
    * @param options - Constructor options.
@@ -151,6 +161,7 @@ export class SnapKeyring {
     this.#callbacks = callbacks;
     this.#isAnyAccountTypeAllowed = isAnyAccountTypeAllowed;
     this.#lock = new Mutex();
+    this.#getOrCreateKeyringLock = new Mutex();
   }
 
   /**
@@ -169,9 +180,21 @@ export class SnapKeyring {
    * @returns The SnapKeyringEntry for the given Snap.
    */
   async #getOrCreateKeyring(snapId: SnapId): Promise<SnapKeyringV2> {
-    let keyring = this.#snapKeyrings.get(snapId);
-    if (!keyring) {
-      keyring = new SnapKeyringV2({
+    // Fast path: keyring already exists, no lock needed.
+    const existing = this.#snapKeyrings.get(snapId);
+    if (existing) {
+      return existing;
+    }
+
+    return this.#getOrCreateKeyringLock.runExclusive(async () => {
+      // Double-check: a concurrent caller may have created the keyring while
+      // we were waiting for the lock.
+      const keyring = this.#snapKeyrings.get(snapId);
+      if (keyring) {
+        return keyring;
+      }
+
+      const newKeyring = new SnapKeyringV2({
         messenger: this.#messenger,
         isAnyAccountTypeAllowed: this.#isAnyAccountTypeAllowed,
         callbacks: {
@@ -210,12 +233,14 @@ export class SnapKeyring {
       });
 
       // Initialize the keyring with its snap ID (no accounts yet).
-      await keyring.deserialize({ snapId, accounts: {} });
+      await newKeyring.deserialize({ snapId, accounts: {} });
 
-      // Now the keyring is fully-ready, we can add it to the map.
-      this.#snapKeyrings.set(snapId, keyring);
-    }
-    return keyring;
+      // Keyring is fully initialized; register it before releasing the lock so
+      // that no concurrent caller can create a duplicate.
+      this.#snapKeyrings.set(snapId, newKeyring);
+
+      return newKeyring;
+    });
   }
 
   /**

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -209,9 +209,11 @@ export class SnapKeyring {
         },
       });
 
-      this.#snapKeyrings.set(snapId, keyring);
       // Initialize the keyring with its snap ID (no accounts yet).
       await keyring.deserialize({ snapId, accounts: {} });
+
+      // Now the keyring is fully-ready, we can add it to the map.
+      this.#snapKeyrings.set(snapId, keyring);
     }
     return keyring;
   }

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -154,7 +154,12 @@ export class SnapKeyring {
   }
 
   /**
-   * Get the SnapKeyringEntry for a Snap, creating it if it does not exist yet.
+   * Get the SnapKeyringEntry for a Snap, creating and initializing it if it
+   * does not exist yet.
+   *
+   * When a new keyring is created it is immediately initialized by calling
+   * `deserialize({ snapId, accounts: {} })` so that `snapId` and the internal
+   * snap client are available before any event handler or method runs.
    *
    * Both v1 and v2 share the same KeyringAccountRegistry instance. The
    * onRegister / onUnregister callbacks keep #accountIndex in sync regardless
@@ -163,11 +168,10 @@ export class SnapKeyring {
    * @param snapId - Snap ID.
    * @returns The SnapKeyringEntry for the given Snap.
    */
-  #getOrCreateKeyring(snapId: SnapId): SnapKeyringV2 {
+  async #getOrCreateKeyring(snapId: SnapId): Promise<SnapKeyringV2> {
     let keyring = this.#snapKeyrings.get(snapId);
     if (!keyring) {
       keyring = new SnapKeyringV2({
-        snapId,
         messenger: this.#messenger,
         isAnyAccountTypeAllowed: this.#isAnyAccountTypeAllowed,
         callbacks: {
@@ -206,6 +210,8 @@ export class SnapKeyring {
       });
 
       this.#snapKeyrings.set(snapId, keyring);
+      // Initialize the keyring with its snap ID (no accounts yet).
+      await keyring.deserialize({ snapId, accounts: {} });
     }
     return keyring;
   }
@@ -284,7 +290,7 @@ export class SnapKeyring {
     const isAccountCreated =
       message.method === `${KeyringEvent.AccountCreated}`;
     if (!keyring && isAccountCreated) {
-      keyring = this.#getOrCreateKeyring(snapId);
+      keyring = await this.#getOrCreateKeyring(snapId);
     }
 
     if (!keyring) {
@@ -356,10 +362,11 @@ export class SnapKeyring {
     this.#snapKeyrings.clear();
     this.#accountIndex.clear();
 
-    // Rebuild per-snap keyrings. Each keyrings handles its own validation
-    // and migration internally.
+    // Rebuild per-snap keyrings. Each keyring handles its own validation
+    // and migration internally. #getOrCreateKeyring initializes the keyring
+    // with an empty state; the second deserialize call loads the real accounts.
     for (const [snapId, accounts] of bySnap) {
-      const keyring = this.#getOrCreateKeyring(snapId);
+      const keyring = await this.#getOrCreateKeyring(snapId);
       await keyring.deserialize({ snapId, accounts });
       // onRegister callbacks fired above have repopulated #accountIndex.
       await this.#removeSnapKeyringIfEmpty(snapId);
@@ -429,10 +436,8 @@ export class SnapKeyring {
     options: Record<string, Json>,
     internalOptions?: SnapKeyringInternalOptions,
   ): Promise<KeyringAccount> {
-    return this.#getOrCreateKeyring(snapId).createAccount(
-      options,
-      internalOptions,
-    );
+    const keyring = await this.#getOrCreateKeyring(snapId);
+    return keyring.createAccount(options, internalOptions);
   }
 
   /**
@@ -449,7 +454,8 @@ export class SnapKeyring {
     snapId: SnapId,
     options: CreateAccountOptions,
   ): Promise<KeyringAccount[]> {
-    return this.#getOrCreateKeyring(snapId).createAccounts(options);
+    const keyring = await this.#getOrCreateKeyring(snapId);
+    return keyring.createAccounts(options);
   }
 
   /**
@@ -484,10 +490,8 @@ export class SnapKeyring {
       );
     }
 
-    return this.#getOrCreateKeyring(snapId).resolveAccountAddress(
-      scope,
-      request,
-    );
+    const keyring = await this.#getOrCreateKeyring(snapId);
+    return keyring.resolveAccountAddress(scope, request);
   }
 
   /**

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
@@ -77,6 +77,15 @@ import {
 export type AccountMethod = EthMethod | BtcMethod;
 
 /**
+ * Holds the snap ID and its RPC client once a {@link SnapKeyringV1} instance
+ * has been bound via {@link SnapKeyringV1.bindSnapId}.
+ */
+type SnapKeyringV1Context = {
+  snapId: SnapId;
+  client: KeyringInternalSnapClient;
+};
+
+/**
  * Callback type to filter unknown account ID from a mapping account ID mapping.
  */
 type FilterAccountIdFunction = <Entry>(
@@ -166,11 +175,8 @@ export type SnapKeyringV1Options = {
  * `KeyringV2` interface on top, sharing the same registry and client.
  */
 export class SnapKeyringV1 {
-  /** The snap ID this instance is scoped to. Set via {@link bindSnapId}. */
-  #snapId: SnapId | undefined;
-
-  /** Snap client for keyring RPC calls. Initialized alongside `#snapId`. */
-  #client: KeyringInternalSnapClient | undefined;
+  /** Snap ID and RPC client. Set via {@link bindSnapId}. */
+  #context: SnapKeyringV1Context | undefined;
 
   /** Account registry — shared with subclass (e.g. SnapKeyringV2). */
   protected readonly registry: KeyringAccountRegistry;
@@ -202,31 +208,38 @@ export class SnapKeyringV1 {
   #selectedAccounts: AccountId[];
 
   /**
-   * The snap ID this instance is scoped to.
+   * Initialized context (snap ID + RPC client).
    *
-   * Throws if the keyring has not yet been initialized via
-   * {@link bindSnapId} (i.e. before `deserialize` is called).
+   * @throws If the keyring has not been initialized yet.
+   * @returns The initialized context.
+   */
+  protected get context(): SnapKeyringV1Context {
+    if (this.#context === undefined) {
+      throw new Error(
+        'SnapKeyring has not been initialized: call deserialize() first',
+      );
+    }
+    return this.#context;
+  }
+
+  /**
+   * The snap ID this instance is scoped to.
    *
    * @throws If the keyring has not been initialized yet.
    * @returns The snap ID.
    */
   get snapId(): SnapId {
-    this.assertIsInitialized();
-    return this.#snapId as SnapId;
+    return this.context.snapId;
   }
 
   /**
    * Snap client for keyring RPC calls.
    *
-   * Throws if the keyring has not yet been initialized via
-   * {@link bindSnapId} (i.e. before `deserialize` is called).
-   *
    * @throws If the keyring has not been initialized yet.
    * @returns The internal snap client.
    */
   protected get client(): KeyringInternalSnapClient {
-    this.assertIsInitialized();
-    return this.#client as KeyringInternalSnapClient;
+    return this.context.client;
   }
 
   constructor({
@@ -244,19 +257,6 @@ export class SnapKeyringV1 {
   }
 
   /**
-   * Assert that this keyring has been initialized (i.e. `snapId` is set).
-   *
-   * @throws If the keyring has not been initialized yet.
-   */
-  protected assertIsInitialized(): void {
-    if (this.#snapId === undefined) {
-      throw new Error(
-        'SnapKeyring has not been initialized: call deserialize() first',
-      );
-    }
-  }
-
-  /**
    * Bind this keyring to a snap ID and create the internal snap client.
    *
    * Idempotent for the same `snapId`; throws if called again with a different
@@ -266,19 +266,19 @@ export class SnapKeyringV1 {
    * @throws If the keyring is already bound to a different snap ID.
    */
   protected bindSnapId(snapId: SnapId): void {
-    if (this.#snapId !== undefined && this.#snapId !== snapId) {
+    if (this.#context !== undefined && this.#context.snapId !== snapId) {
       throw new Error(
-        `SnapKeyring bound to '${
-          this.#snapId
-        }' cannot be rebound to '${snapId}'`,
+        `SnapKeyring bound to '${this.#context.snapId}' cannot be rebound to '${snapId}'`,
       );
     }
-    if (this.#snapId === undefined) {
-      this.#snapId = snapId;
-      this.#client = new KeyringInternalSnapClient({
-        messenger: this.messenger,
+    if (this.#context === undefined) {
+      this.#context = {
         snapId,
-      });
+        client: new KeyringInternalSnapClient({
+          messenger: this.messenger,
+          snapId,
+        }),
+      };
     }
   }
 

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
@@ -146,7 +146,6 @@ export type SnapKeyringV1Callbacks = {
  * Options for creating a `SnapKeyringV1` instance.
  */
 export type SnapKeyringV1Options = {
-  snapId: SnapId;
   messenger: SnapKeyringMessenger;
   callbacks: SnapKeyringV1Callbacks;
   /**
@@ -167,17 +166,17 @@ export type SnapKeyringV1Options = {
  * `KeyringV2` interface on top, sharing the same registry and client.
  */
 export class SnapKeyringV1 {
-  /** The snap ID this instance is scoped to. */
-  readonly snapId: SnapId;
+  /** The snap ID this instance is scoped to. Set via {@link bindSnapId}. */
+  #snapId: SnapId | undefined;
+
+  /** Snap client for keyring RPC calls. Initialized alongside `#snapId`. */
+  #client: KeyringInternalSnapClient | undefined;
 
   /** Account registry — shared with subclass (e.g. SnapKeyringV2). */
   protected readonly registry: KeyringAccountRegistry;
 
   /** Messenger for snap controller calls and event publishing. */
   protected readonly messenger: SnapKeyringMessenger;
-
-  /** Snap client for keyring RPC calls. */
-  protected readonly client: KeyringInternalSnapClient;
 
   /** Injected callbacks for parent-level coordination. */
   readonly #callbacks: SnapKeyringV1Callbacks;
@@ -202,21 +201,85 @@ export class SnapKeyringV1 {
    */
   #selectedAccounts: AccountId[];
 
+  /**
+   * The snap ID this instance is scoped to.
+   *
+   * Throws if the keyring has not yet been initialized via
+   * {@link bindSnapId} (i.e. before `deserialize` is called).
+   *
+   * @throws If the keyring has not been initialized yet.
+   * @returns The snap ID.
+   */
+  get snapId(): SnapId {
+    this.assertIsInitialized();
+    return this.#snapId as SnapId;
+  }
+
+  /**
+   * Snap client for keyring RPC calls.
+   *
+   * Throws if the keyring has not yet been initialized via
+   * {@link bindSnapId} (i.e. before `deserialize` is called).
+   *
+   * @throws If the keyring has not been initialized yet.
+   * @returns The internal snap client.
+   */
+  protected get client(): KeyringInternalSnapClient {
+    this.assertIsInitialized();
+    return this.#client as KeyringInternalSnapClient;
+  }
+
   constructor({
-    snapId,
     messenger,
     callbacks,
     isAnyAccountTypeAllowed = false,
   }: SnapKeyringV1Options) {
-    this.snapId = snapId;
     this.registry = new KeyringAccountRegistry();
     this.messenger = messenger;
     this.#callbacks = callbacks;
     this.#isAnyAccountTypeAllowed = isAnyAccountTypeAllowed;
-    this.client = new KeyringInternalSnapClient({ messenger, snapId });
     this.#requests = new Map();
     this.#options = new Map();
     this.#selectedAccounts = [];
+  }
+
+  /**
+   * Assert that this keyring has been initialized (i.e. `snapId` is set).
+   *
+   * @throws If the keyring has not been initialized yet.
+   */
+  protected assertIsInitialized(): void {
+    if (this.#snapId === undefined) {
+      throw new Error(
+        'SnapKeyring has not been initialized: call deserialize() first',
+      );
+    }
+  }
+
+  /**
+   * Bind this keyring to a snap ID and create the internal snap client.
+   *
+   * Idempotent for the same `snapId`; throws if called again with a different
+   * one to prevent accidentally swapping a keyring's identity.
+   *
+   * @param snapId - The snap ID to bind this keyring to.
+   * @throws If the keyring is already bound to a different snap ID.
+   */
+  protected bindSnapId(snapId: SnapId): void {
+    if (this.#snapId !== undefined && this.#snapId !== snapId) {
+      throw new Error(
+        `SnapKeyring bound to '${
+          this.#snapId
+        }' cannot be rebound to '${snapId}'`,
+      );
+    }
+    if (this.#snapId === undefined) {
+      this.#snapId = snapId;
+      this.#client = new KeyringInternalSnapClient({
+        messenger: this.messenger,
+        snapId,
+      });
+    }
   }
 
   // ──────────────────────────────────────────────

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -51,19 +51,23 @@ function makeMockCallbacks(): SnapKeyringCallbacks {
 /**
  * Create a `SnapKeyring` test instance with tracking arrays for callbacks.
  *
- * @param snapId - The Snap ID used to construct the keyring.
+ * The keyring is initialized (via `deserialize`) with the given snap ID and
+ * no accounts so that `snapId` and the internal snap client are available
+ * immediately after construction.
+ *
+ * @param snapId - The Snap ID to initialize the keyring with.
  * @param callbackOverrides - Optional callback overrides.
  * @returns The keyring, arrays of registered/unregistered IDs, and mock callbacks.
  */
-function makeKeyring(
+async function makeKeyring(
   snapId: SnapId = SNAP_ID,
   callbackOverrides?: Partial<SnapKeyringCallbacks>,
-): {
+): Promise<{
   keyring: SnapKeyring;
   registered: string[];
   unregistered: string[];
   callbacks: SnapKeyringCallbacks;
-} {
+}> {
   const registered: string[] = [];
   const unregistered: string[] = [];
   const callbacks: SnapKeyringCallbacks = {
@@ -80,28 +84,55 @@ function makeKeyring(
     call: jest.fn(),
     publish: jest.fn(),
   } as unknown as SnapKeyringMessenger;
-  const keyring = new SnapKeyring({ snapId, messenger, callbacks });
+  const keyring = new SnapKeyring({ messenger, callbacks });
+  await keyring.deserialize({ snapId, accounts: {} });
   return { keyring, registered, unregistered, callbacks };
 }
 
 describe('SnapKeyring', () => {
   describe('snapId', () => {
-    it('returns the snap ID passed at construction', () => {
-      const { keyring } = makeKeyring();
+    it('returns the snap ID set during deserialize', async () => {
+      const { keyring } = await makeKeyring();
       expect(keyring.snapId).toBe(SNAP_ID);
+    });
+
+    it('throws before deserialize is called', () => {
+      const messenger = {
+        call: jest.fn(),
+        publish: jest.fn(),
+      } as unknown as SnapKeyringMessenger;
+      const keyring = new SnapKeyring({
+        messenger,
+        callbacks: makeMockCallbacks(),
+      });
+      expect(() => keyring.snapId).toThrow(
+        'SnapKeyring has not been initialized',
+      );
+    });
+
+    it('throws when deserializing with a different snap ID', async () => {
+      const { keyring } = await makeKeyring(SNAP_ID);
+      await expect(
+        keyring.deserialize({
+          snapId: 'npm:@metamask/other-snap' as SnapId,
+          accounts: {},
+        }),
+      ).rejects.toThrow(
+        `SnapKeyring bound to '${SNAP_ID}' cannot be rebound to 'npm:@metamask/other-snap'`,
+      );
     });
   });
 
   describe('setAccount', () => {
-    it('adds a new account and fires onRegister', () => {
-      const { keyring, registered } = makeKeyring();
+    it('adds a new account and fires onRegister', async () => {
+      const { keyring, registered } = await makeKeyring();
       keyring.setAccount(account1);
       expect(keyring.hasAccount(account1.id)).toBe(true);
       expect(registered).toStrictEqual([account1.id]);
     });
 
-    it('updates an existing account without firing onRegister again', () => {
-      const { keyring, registered } = makeKeyring();
+    it('updates an existing account without firing onRegister again', async () => {
+      const { keyring, registered } = await makeKeyring();
       keyring.setAccount(account1);
       const updated = { ...account1, options: { updated: true } };
       keyring.setAccount(updated);
@@ -112,8 +143,8 @@ describe('SnapKeyring', () => {
   });
 
   describe('removeAccount', () => {
-    it('removes an existing account and fires onUnregister', () => {
-      const { keyring, unregistered } = makeKeyring();
+    it('removes an existing account and fires onUnregister', async () => {
+      const { keyring, unregistered } = await makeKeyring();
       keyring.setAccount(account1);
       const removed = keyring.removeAccount(account1.id);
       expect(removed).toBe(true);
@@ -121,8 +152,8 @@ describe('SnapKeyring', () => {
       expect(unregistered).toStrictEqual([account1.id]);
     });
 
-    it('returns false and does not fire onUnregister for unknown ID', () => {
-      const { keyring, unregistered } = makeKeyring();
+    it('returns false and does not fire onUnregister for unknown ID', async () => {
+      const { keyring, unregistered } = await makeKeyring();
       const removed = keyring.removeAccount('does-not-exist');
       expect(removed).toBe(false);
       expect(unregistered).toHaveLength(0);
@@ -130,55 +161,55 @@ describe('SnapKeyring', () => {
   });
 
   describe('hasAccount', () => {
-    it('returns true for an existing account', () => {
-      const { keyring } = makeKeyring();
+    it('returns true for an existing account', async () => {
+      const { keyring } = await makeKeyring();
       keyring.setAccount(account1);
       expect(keyring.hasAccount(account1.id)).toBe(true);
     });
 
-    it('returns false for an unknown account', () => {
-      const { keyring } = makeKeyring();
+    it('returns false for an unknown account', async () => {
+      const { keyring } = await makeKeyring();
       expect(keyring.hasAccount('does-not-exist')).toBe(false);
     });
   });
 
   describe('lookupAccount', () => {
-    it('returns the account for a known ID', () => {
-      const { keyring } = makeKeyring();
+    it('returns the account for a known ID', async () => {
+      const { keyring } = await makeKeyring();
       keyring.setAccount(account1);
       expect(keyring.lookupAccount(account1.id)).toStrictEqual(account1);
     });
 
-    it('returns undefined for an unknown ID', () => {
-      const { keyring } = makeKeyring();
+    it('returns undefined for an unknown ID', async () => {
+      const { keyring } = await makeKeyring();
       expect(keyring.lookupAccount('does-not-exist')).toBeUndefined();
     });
   });
 
   describe('lookupByAddress', () => {
-    it('returns the account for an exact address match', () => {
-      const { keyring } = makeKeyring();
+    it('returns the account for an exact address match', async () => {
+      const { keyring } = await makeKeyring();
       keyring.setAccount(account1);
       expect(keyring.lookupByAddress(account1.address)).toStrictEqual(account1);
     });
 
-    it('returns the account for a case-insensitive address match', () => {
-      const { keyring } = makeKeyring();
+    it('returns the account for a case-insensitive address match', async () => {
+      const { keyring } = await makeKeyring();
       keyring.setAccount(account1);
       expect(
         keyring.lookupByAddress(account1.address.toUpperCase()),
       ).toStrictEqual(account1);
     });
 
-    it('returns undefined for an unknown address', () => {
-      const { keyring } = makeKeyring();
+    it('returns undefined for an unknown address', async () => {
+      const { keyring } = await makeKeyring();
       expect(keyring.lookupByAddress('0xdeadbeef')).toBeUndefined();
     });
   });
 
   describe('accounts', () => {
-    it('returns all accounts', () => {
-      const { keyring } = makeKeyring();
+    it('returns all accounts', async () => {
+      const { keyring } = await makeKeyring();
       keyring.setAccount(account1);
       keyring.setAccount(account2);
       expect(keyring.accounts()).toStrictEqual(
@@ -186,15 +217,15 @@ describe('SnapKeyring', () => {
       );
     });
 
-    it('returns an empty array when no accounts are registered', () => {
-      const { keyring } = makeKeyring();
+    it('returns an empty array when no accounts are registered', async () => {
+      const { keyring } = await makeKeyring();
       expect(keyring.accounts()).toStrictEqual([]);
     });
   });
 
   describe('serialize', () => {
     it('returns the snap ID and all accounts', async () => {
-      const { keyring } = makeKeyring();
+      const { keyring } = await makeKeyring();
       keyring.setAccount(account1);
       keyring.setAccount(account2);
       const state = await keyring.serialize();
@@ -210,7 +241,7 @@ describe('SnapKeyring', () => {
 
   describe('deserialize', () => {
     it('restores accounts and fires onRegister for each', async () => {
-      const { keyring, registered } = makeKeyring();
+      const { keyring, registered } = await makeKeyring();
       await keyring.deserialize({
         snapId: SNAP_ID,
         accounts: { [account1.id]: account1, [account2.id]: account2 },
@@ -223,7 +254,7 @@ describe('SnapKeyring', () => {
     });
 
     it('clears existing accounts before restoring', async () => {
-      const { keyring } = makeKeyring();
+      const { keyring } = await makeKeyring();
       keyring.setAccount(account1);
       await keyring.deserialize({
         snapId: SNAP_ID,
@@ -234,7 +265,7 @@ describe('SnapKeyring', () => {
     });
 
     it('migrates v1 accounts during restore', async () => {
-      const { keyring } = makeKeyring();
+      const { keyring } = await makeKeyring();
       // A v1 account genuinely has no `scopes` field (not just undefined).
       const { scopes: _removed, ...v1Account } = account1;
       await keyring.deserialize({
@@ -249,15 +280,15 @@ describe('SnapKeyring', () => {
 
   describe('Keyring interface', () => {
     describe('type', () => {
-      it('returns "snap"', () => {
-        const { keyring } = makeKeyring();
+      it('returns "snap"', async () => {
+        const { keyring } = await makeKeyring();
         expect(keyring.type).toBe('snap');
       });
     });
 
     describe('getAccounts', () => {
       it('returns all accounts', async () => {
-        const { keyring } = makeKeyring();
+        const { keyring } = await makeKeyring();
         keyring.setAccount(account1);
         keyring.setAccount(account2);
         const result = await keyring.getAccounts();
@@ -269,14 +300,14 @@ describe('SnapKeyring', () => {
 
     describe('getAccount', () => {
       it('returns the account for a known ID', async () => {
-        const { keyring } = makeKeyring();
+        const { keyring } = await makeKeyring();
         keyring.setAccount(account1);
         const result = await keyring.getAccount(account1.id);
         expect(result).toStrictEqual(account1);
       });
 
       it('throws for an unknown ID', async () => {
-        const { keyring } = makeKeyring();
+        const { keyring } = await makeKeyring();
         await expect(keyring.getAccount('does-not-exist')).rejects.toThrow(
           "Account 'does-not-exist' not found",
         );
@@ -291,7 +322,7 @@ describe('SnapKeyring', () => {
       } as unknown as CreateAccountOptions;
 
       it('creates new accounts and saves state', async () => {
-        const { keyring, callbacks, registered } = makeKeyring();
+        const { keyring, callbacks, registered } = await makeKeyring();
         jest
           .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
           .mockResolvedValue([account1, account2]);
@@ -305,7 +336,7 @@ describe('SnapKeyring', () => {
       });
 
       it('skips existing accounts (idempotent)', async () => {
-        const { keyring, callbacks } = makeKeyring();
+        const { keyring, callbacks } = await makeKeyring();
         jest
           .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
           .mockResolvedValue([account1]);
@@ -322,7 +353,7 @@ describe('SnapKeyring', () => {
       });
 
       it('rolls back on error', async () => {
-        const { keyring } = makeKeyring(SNAP_ID, {
+        const { keyring } = await makeKeyring(SNAP_ID, {
           assertAccountCanBeUsed: jest
             .fn<Promise<void>, [KeyringAccount]>()
             .mockResolvedValueOnce(undefined)
@@ -343,7 +374,7 @@ describe('SnapKeyring', () => {
       });
 
       it('rejects duplicate accounts within a batch', async () => {
-        const { keyring } = makeKeyring();
+        const { keyring } = await makeKeyring();
         jest
           .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
           .mockResolvedValue([account1, account1]);
@@ -356,7 +387,7 @@ describe('SnapKeyring', () => {
 
     describe('deleteAccount', () => {
       it('removes the account and calls snap to delete', async () => {
-        const { keyring, unregistered } = makeKeyring();
+        const { keyring, unregistered } = await makeKeyring();
         keyring.setAccount(account1);
         const deleteSpy = jest
           .spyOn(KeyringInternalSnapClient.prototype, 'deleteAccount')
@@ -373,7 +404,7 @@ describe('SnapKeyring', () => {
         const consoleSpy = jest
           .spyOn(console, 'error')
           .mockImplementation(() => undefined);
-        const { keyring } = makeKeyring();
+        const { keyring } = await makeKeyring();
         jest
           .spyOn(KeyringInternalSnapClient.prototype, 'deleteAccount')
           .mockRejectedValue(new Error('snap error'));
@@ -391,7 +422,7 @@ describe('SnapKeyring', () => {
     describe('submitRequest', () => {
       it('delegates to inherited submitSnapRequest for a known account', async () => {
         const mockResult = { success: true };
-        const { keyring } = makeKeyring();
+        const { keyring } = await makeKeyring();
         keyring.setAccount(account1);
 
         // Spy on the inherited V1 method directly
@@ -422,7 +453,7 @@ describe('SnapKeyring', () => {
       });
 
       it('throws for an unknown account', async () => {
-        const { keyring } = makeKeyring();
+        const { keyring } = await makeKeyring();
 
         const request = {
           id: 'req-1',

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -7,6 +7,7 @@ import type {
 } from '@metamask/keyring-api/v2';
 import { KeyringType } from '@metamask/keyring-api/v2';
 import type { AccountId } from '@metamask/keyring-utils';
+import type { SnapId } from '@metamask/snaps-sdk';
 import type { Infer } from '@metamask/superstruct';
 import { assert, object, record, string, union } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
@@ -465,6 +466,10 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
   async deserialize(state: Json): Promise<void> {
     // Validate the raw payload — accepts both v1 and v2 account shapes.
     assert(state, SnapKeyringStateStruct);
+
+    // Bind the keyring to its snap ID (idempotent for the same ID, throws on
+    // mismatch to prevent swapping a keyring's identity via deserialize).
+    this.bindSnapId(state.snapId as SnapId);
 
     // Migrate v1 accounts to v2.
     const migratedAccounts: Record<string, KeyringAccount> = {};


### PR DESCRIPTION
Using the `snapId` in the constructor was working fine in the current setup, unfortunately this cannot be used with our keyring lifecycle.

The way the `KeyringController` creates keyring is:
- Creates the keyring with its builder `new Keyring(...)`
  * We cannot really pass dynamic options here
  * The Snap keyring v2 will be instantiated BY the `KeyringController` that have no knowledge about Snap IDs
- Call `deserialize` with some custom data
  * That's what we need to use to inject the Snap ID we need

Some thing like:
```ts
await controller.addNewKeyring(KeyringType.Snap /* v2 */, { snapId, accounts: { ... } });
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes keyring initialization semantics (snapId no longer provided at construction) and adds new async locking around per-snap keyring creation, which could affect runtime ordering and lifecycle edge-cases.
> 
> **Overview**
> **BREAKING:** `SnapKeyring`/`SnapKeyringV2` no longer accept `snapId` in the constructor; the snap identity is now *bound on first* `deserialize`, and re-deserializing with a different `snapId` throws.
> 
> The bridge’s per-snap keyring creation path (`#getOrCreateKeyring`) is now async and protected by a dedicated mutex, eagerly calling `deserialize({ snapId, accounts: {} })` before registering the new keyring to avoid races/duplicate keyrings under concurrent calls. Tests were updated to reflect the new initialization flow and to cover concurrent creation against a previously-unknown snap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dff76aaba17b4cae4653a89f2de270640e399ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->