### PR TITLE
feat(keyring-eth-money)!: remove signTransaction pass-through

### DIFF
--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Remove `signTransaction` pass-through; Money accounts do not sign transactions ([#521](https://github.com/MetaMask/accounts/pull/521))
-- Unexport `EvmSigner` type (no longer needed externally)
+  - Unexport `EvmSigner` type and rename to `MoneySigner`; the type was incorrectly exported and no longer represents a full EVM signer
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
 
 ## [2.0.4]

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Remove `signTransaction` pass-through; Money accounts do not sign transactions ([#521](https://github.com/MetaMask/accounts/pull/521))
-  - Unexport `EvmSigner` type and rename to `MoneySigner`; the type was incorrectly exported and no longer represents a full EVM signer
+  - Unexport `EvmSigner` type and rename to `MoneySigner`; the type was incorrectly exported and didn't represent a full EVM signer
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
 
 ## [2.0.4]

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Remove `signTransaction` pass-through; Money accounts do not sign transactions ([#521](https://github.com/MetaMask/accounts/pull/521))
+- Unexport `EvmSigner` type (no longer needed externally)
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
 
 ## [2.0.4]

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **BREAKING:** Remove `signTransaction` pass-through; Money accounts do not sign transactions ([#521](https://github.com/MetaMask/accounts/pull/521))
-  - Unexport `EvmSigner` type and rename to `MoneySigner`; the type was incorrectly exported and didn't represent a full EVM signer
+  - Unexport `EvmSigner` type and rename to `MoneySigner`; the type was incorrectly exported and didn't represent a full EVM signer.
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
 
 ## [2.0.4]

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BREAKING:** Remove `signTransaction` pass-through; Money accounts do not sign transactions ([#521](https://github.com/MetaMask/accounts/pull/521))
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
 
 ## [2.0.4]

--- a/packages/keyring-eth-money/src/money-keyring.test.ts
+++ b/packages/keyring-eth-money/src/money-keyring.test.ts
@@ -397,23 +397,6 @@ describe('MoneyKeyring', () => {
       expect(signature).toMatch(/^0x[0-9a-f]+$/u);
     });
 
-    it('signTransaction delegates to the inner keyring', async () => {
-      const { HdKeyring } = await import('@metamask/eth-hd-keyring');
-      const mockSignature = '0xsignature';
-      const spy = jest
-        .spyOn(HdKeyring.prototype, 'signTransaction')
-        .mockResolvedValue(mockSignature as never);
-
-      const keyring = createKeyring();
-      await keyring.deserialize(mockState);
-
-      const mockTx = {} as never;
-      const result = await keyring.signTransaction(mockAccount, mockTx);
-
-      expect(spy).toHaveBeenCalledWith(mockAccount, mockTx);
-      expect(result).toBe(mockSignature);
-    });
-
     it('signTypedData delegates to the inner keyring', async () => {
       const { HdKeyring } = await import('@metamask/eth-hd-keyring');
       const mockSignature = '0xsignature';

--- a/packages/keyring-eth-money/src/money-keyring.ts
+++ b/packages/keyring-eth-money/src/money-keyring.ts
@@ -31,9 +31,9 @@ export const MONEY_KEYRING_TYPE = 'Money Keyring';
 export type GetMnemonicCallback = (entropySource: string) => Promise<number[]>;
 
 /**
- * EVM signer interface, a subset of {@link HdKeyring} methods.
+ * Message signing interface, a subset of {@link HdKeyring} methods.
  */
-type EvmSigner = {
+type MoneySigner = {
   signPersonalMessage: HdKeyring['signPersonalMessage'];
   signTypedData: HdKeyring['signTypedData'];
   signEip7702Authorization: HdKeyring['signEip7702Authorization'];
@@ -177,7 +177,7 @@ export class MoneyKeyring implements Keyring {
    *
    * @returns The EVM signer instance.
    */
-  async #getSigner(): Promise<EvmSigner> {
+  async #getSigner(): Promise<MoneySigner> {
     if (this.#inner) {
       return this.#inner;
     }

--- a/packages/keyring-eth-money/src/money-keyring.ts
+++ b/packages/keyring-eth-money/src/money-keyring.ts
@@ -31,7 +31,7 @@ export const MONEY_KEYRING_TYPE = 'Money Keyring';
 export type GetMnemonicCallback = (entropySource: string) => Promise<number[]>;
 
 /**
- * Message signing interface, a subset of {@link HdKeyring} methods.
+ * Signing interface for Money accounts, a subset of {@link HdKeyring} methods.
  */
 type MoneySigner = {
   signPersonalMessage: HdKeyring['signPersonalMessage'];

--- a/packages/keyring-eth-money/src/money-keyring.ts
+++ b/packages/keyring-eth-money/src/money-keyring.ts
@@ -33,7 +33,7 @@ export type GetMnemonicCallback = (entropySource: string) => Promise<number[]>;
 /**
  * EVM signer interface, a subset of {@link HdKeyring} methods.
  */
-export type EvmSigner = {
+type EvmSigner = {
   signPersonalMessage: HdKeyring['signPersonalMessage'];
   signTypedData: HdKeyring['signTypedData'];
   signEip7702Authorization: HdKeyring['signEip7702Authorization'];

--- a/packages/keyring-eth-money/src/money-keyring.ts
+++ b/packages/keyring-eth-money/src/money-keyring.ts
@@ -34,7 +34,6 @@ export type GetMnemonicCallback = (entropySource: string) => Promise<number[]>;
  * EVM signer interface, a subset of {@link HdKeyring} methods.
  */
 export type EvmSigner = {
-  signTransaction: HdKeyring['signTransaction'];
   signPersonalMessage: HdKeyring['signPersonalMessage'];
   signTypedData: HdKeyring['signTypedData'];
   signEip7702Authorization: HdKeyring['signEip7702Authorization'];
@@ -220,12 +219,6 @@ export class MoneyKeyring implements Keyring {
 
   async getAccounts(): Promise<Hex[]> {
     return this.#account ? [this.#account] : [];
-  }
-
-  async signTransaction(
-    ...args: Parameters<HdKeyring['signTransaction']>
-  ): ReturnType<HdKeyring['signTransaction']> {
-    return (await this.#getSigner()).signTransaction(...args);
   }
 
   async signPersonalMessage(


### PR DESCRIPTION
## Summary

- Remove `signTransaction` pass-through method from MoneyKeyring
- Unexport `EvmSigner` type and rename to `MoneySigner`; the type was incorrectly exported and no longer represents a full EVM signer
- Remove corresponding test
- Money accounts do not need to sign transactions

## Changes

- **BREAKING:** `MoneyKeyring.signTransaction` is no longer available
- **BREAKING:** `EvmSigner` renamed to `MoneySigner`, no longer exported

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it makes a breaking API change by removing `MoneyKeyring.signTransaction` and tightening the exposed signer surface, which can break downstream callers expecting transaction signing.
> 
> **Overview**
> **BREAKING:** `MoneyKeyring` no longer exposes `signTransaction`, reflecting that Money accounts should not sign EVM transactions.
> 
> The internal signer type is renamed from exported `EvmSigner` to unexported `MoneySigner` (and drops `signTransaction`), and the corresponding delegation test and changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d5b2d0ed2a081496a2ad8cc963491dde0cbcdc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->