### PR TITLE
refactor(keyring-internal-api)!: remove `snap.{enabled,name}`

### DIFF
--- a/packages/keyring-internal-api/CHANGELOG.md
+++ b/packages/keyring-internal-api/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- **BREAKING:** Removed `InternalAccount.metadata.snap.{enabled,name}` ([#525](https://github.com/MetaMask/accounts/pull/525))
+  - Use `SnapController:getSnap` to get those information instead (in combination with `InternalAccount.metadata.snap.id`).
+
 ## [10.1.1]
 
 ### Changed

--- a/packages/keyring-internal-api/src/types.test.ts
+++ b/packages/keyring-internal-api/src/types.test.ts
@@ -143,8 +143,6 @@ describe('InternalAccount', () => {
         importTime: 1713153716,
         snap: {
           id: 'test-snap',
-          enabled: true,
-          name: 'Test Snap',
         },
       },
     };
@@ -152,10 +150,9 @@ describe('InternalAccount', () => {
     expect(() => assert(account, InternalAccountStruct)).not.toThrow();
   });
 
-  it.each([['name', 'enabled', 'id']])(
-    'should throw if snap.%s is not set',
-    (key: string) => {
-      const account: InternalAccount = {
+  it('should throw if snap.id is not set', () => {
+      // NOTE: We do not force `InternalAccount` here to make `snap.id` optional.
+      const account = {
         id: '606a7759-b0fb-48e4-9874-bab62ff8e7eb',
         address: '0x000',
         options: {},
@@ -170,18 +167,15 @@ describe('InternalAccount', () => {
           importTime: 1713153716,
           snap: {
             id: 'test-snap',
-            enabled: true,
-            name: 'Test Snap',
+          } as {
+            id?: string;
           },
         },
       };
 
-      // On `InternalAccount` the `metadata.snap` is optional, hence the `?.` here.
-      delete account.metadata.snap?.[key as keyof typeof account.metadata.snap];
+      delete account.metadata.snap.id;
 
-      const regex = new RegExp(`At path: metadata.snap.${key}`, 'u');
-
-      expect(() => assert(account, InternalAccountStruct)).toThrow(regex);
+      expect(() => assert(account, InternalAccountStruct)).toThrow('At path: metadata.snap.id -- Expected a string, but received: undefined');
     },
   );
 });

--- a/packages/keyring-internal-api/src/types.test.ts
+++ b/packages/keyring-internal-api/src/types.test.ts
@@ -151,31 +151,32 @@ describe('InternalAccount', () => {
   });
 
   it('should throw if snap.id is not set', () => {
-      // NOTE: We do not force `InternalAccount` here to make `snap.id` optional.
-      const account = {
-        id: '606a7759-b0fb-48e4-9874-bab62ff8e7eb',
-        address: '0x000',
-        options: {},
-        methods: [],
-        scopes: ['eip155:0'],
-        type: 'eip155:eoa',
-        metadata: {
-          keyring: {
-            type: 'Test Keyring',
-          },
-          name: 'Account 1',
-          importTime: 1713153716,
-          snap: {
-            id: 'test-snap',
-          } as {
-            id?: string;
-          },
+    // NOTE: We do not force `InternalAccount` here to make `snap.id` optional.
+    const account = {
+      id: '606a7759-b0fb-48e4-9874-bab62ff8e7eb',
+      address: '0x000',
+      options: {},
+      methods: [],
+      scopes: ['eip155:0'],
+      type: 'eip155:eoa',
+      metadata: {
+        keyring: {
+          type: 'Test Keyring',
         },
-      };
+        name: 'Account 1',
+        importTime: 1713153716,
+        snap: {
+          id: 'test-snap',
+        } as {
+          id?: string;
+        },
+      },
+    };
 
-      delete account.metadata.snap.id;
+    delete account.metadata.snap.id;
 
-      expect(() => assert(account, InternalAccountStruct)).toThrow('At path: metadata.snap.id -- Expected a string, but received: undefined');
-    },
-  );
+    expect(() => assert(account, InternalAccountStruct)).toThrow(
+      'At path: metadata.snap.id -- Expected a string, but received: undefined',
+    );
+  });
 });

--- a/packages/keyring-internal-api/src/types.ts
+++ b/packages/keyring-internal-api/src/types.ts
@@ -20,7 +20,7 @@ import {
 } from '@metamask/keyring-api';
 import { exactOptional, object } from '@metamask/keyring-utils';
 import type { Infer, Struct } from '@metamask/superstruct';
-import { boolean, string, number } from '@metamask/superstruct';
+import { string, number } from '@metamask/superstruct';
 
 export type InternalAccountType =
   | EthAccountType
@@ -36,8 +36,6 @@ export const InternalAccountMetadataStruct = object({
     snap: exactOptional(
       object({
         id: string(),
-        enabled: boolean(),
-        name: string(),
       }),
     ),
     lastSelected: exactOptional(number()),

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** No longer use `snapId` as constructor parameter for `SnapKeyring` (v2) ([#519](https://github.com/MetaMask/accounts/pull/519))
   - The `snapId` is now passed and bound to the keyring upon the first `deserialize` call, to better integrate with `KeyringController` keyrings lifecyle and keyring builders.
 
+### Removed
+
+- **BREAKING:** Removed `snap.{name,enabled}` from `InternalAccount` metadata produced by `SnapKeyring` ([#525](https://github.com/MetaMask/accounts/pull/525))
+  - Use `SnapController:getSnap` to get those information instead (in combination with `InternalAccount.metadata.snap.id`).
+
 ## [21.0.1]
 
 ### Changed

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -2380,8 +2380,6 @@ describe('SnapKeyring', () => {
     it('returns the list of accounts', async () => {
       const snapMetadata = {
         id: snapId,
-        name: 'Snap Name',
-        enabled: true,
       };
       const snapObject = {
         id: snapId,
@@ -2437,7 +2435,7 @@ describe('SnapKeyring', () => {
           metadata: {
             name: '',
             importTime: 0,
-            snap: { id: snapId, name: 'snap-name', enabled: true },
+            snap: { id: snapId },
             keyring: { type: 'Snap Keyring' },
           },
         },

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -780,7 +780,7 @@ export class SnapKeyring {
   ): InternalAccount['metadata']['snap'] | undefined {
     const snap = this.#getSnap(snapId);
     return snap
-      ? { id: snapId, name: snap.manifest.proposedName, enabled: snap.enabled }
+      ? { id: snapId }
       : undefined;
   }
 

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -779,9 +779,7 @@ export class SnapKeyring {
     snapId: SnapId,
   ): InternalAccount['metadata']['snap'] | undefined {
     const snap = this.#getSnap(snapId);
-    return snap
-      ? { id: snapId }
-      : undefined;
+    return snap ? { id: snapId } : undefined;
   }
 
   #transformToInternalAccount(


### PR DESCRIPTION
Those metadata are duplicated from the `SnapController` data. We should instead be using this controller to query those, thus, making the controller the only source of truth and avoid `:stateChange` handling on the `AccountsController` too!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change to `InternalAccount` metadata shape: code consuming `metadata.snap.name`/`metadata.snap.enabled` will fail until updated to query `SnapController:getSnap` instead. Runtime logic change is small but impacts multiple packages and downstream integrations expecting those fields.
> 
> **Overview**
> **BREAKING:** Removes `metadata.snap.name` and `metadata.snap.enabled` from `InternalAccount`, leaving only `metadata.snap.id` and updating validation accordingly.
> 
> `SnapKeyring` now only attaches `{ id }` as snap metadata when transforming accounts, and tests/changelogs are updated to reflect the new source-of-truth being `SnapController:getSnap` for snap name/enabled state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a0838b4d59c8fd84c66457db747a77bca391184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->