### PR TITLE
fix: update `setSelectedAccounts` to filter dupes/non-existing accounts

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `SnapKeyringV1.setSelectedAccounts` only forwards account IDs that exist on this snap; unknown IDs are omitted and logged ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- `SnapKeyringV1.setSelectedAccounts` only forwards account IDs that exist on this snap; unknown IDs are omitted and logged ([#526](https://github.com/MetaMask/accounts/pull/526))
 
 ## [21.0.1]
 

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `SnapKeyringV1.setSelectedAccounts` only forwards account IDs that exist on this snap; unknown IDs are omitted and logged ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 ## [21.0.1]
 
 ### Changed

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
@@ -1,0 +1,166 @@
+import { EthAccountType, EthScope, KeyringRpcMethod } from '@metamask/keyring-api';
+import type { KeyringAccount } from '@metamask/keyring-api';
+import type { AccountId } from '@metamask/keyring-utils';
+import { SnapManageAccountsMethod } from '@metamask/keyring-snap-sdk';
+import type { JsonRpcRequest } from '@metamask/keyring-utils';
+import type { SnapId } from '@metamask/snaps-sdk';
+
+import type { SnapKeyringMessenger } from './SnapKeyringMessenger';
+import type { SnapKeyringV1Callbacks } from './SnapKeyringV1';
+import { SnapKeyringV1 } from './SnapKeyringV1';
+
+const SNAP_ID = 'npm:@metamask/test-snap' as SnapId;
+
+const account1: KeyringAccount = {
+  id: 'b05d918a-b37c-497a-bb28-3d15c0d56b7a' as AccountId,
+  address: '0xc728514df8a7f9271f4b7a4dd2aa6d2d723d3ee3',
+  options: {},
+  methods: [],
+  scopes: [EthScope.Eoa],
+  type: EthAccountType.Eoa,
+};
+
+/**
+ * Subclass that exposes {@link SnapKeyringV1.registry} seeding for tests.
+ */
+class TestSnapKeyringV1 extends SnapKeyringV1 {
+  seedAccount(account: KeyringAccount): void {
+    this.registry.set(account);
+  }
+}
+
+/**
+ * Build minimal {@link SnapKeyringV1Callbacks} for tests.
+ *
+ * @returns Callbacks object.
+ */
+function makeCallbacks(): SnapKeyringV1Callbacks {
+  return {
+    addAccount: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
+    removeAccount: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
+    saveState: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
+    redirectUser: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
+    assertAccountCanBeUsed: jest
+      .fn<Promise<void>, [KeyringAccount]>()
+      .mockResolvedValue(undefined),
+  };
+}
+
+describe('SnapKeyringV1', () => {
+  describe('setSelectedAccounts', () => {
+    it('forwards only account IDs that exist in this snap registry', async () => {
+      let lastSetSelectedAccounts: AccountId[] | undefined;
+      const messenger = {
+        call: jest.fn(
+          async (
+            action: string,
+            args: { request: JsonRpcRequest },
+          ): Promise<null> => {
+            if (action === 'SnapController:handleRequest') {
+              const { request } = args;
+              if (request.method === KeyringRpcMethod.SetSelectedAccounts) {
+                const params = request.params as { accounts: AccountId[] };
+                lastSetSelectedAccounts = params.accounts;
+                return null;
+              }
+            }
+            throw new Error(`Unexpected messenger.call: ${action}`);
+          },
+        ),
+        publish: jest.fn(),
+      } as unknown as SnapKeyringMessenger;
+
+      const keyring = new TestSnapKeyringV1({
+        snapId: SNAP_ID,
+        messenger,
+        callbacks: makeCallbacks(),
+      });
+      keyring.seedAccount(account1);
+
+      const unknownId = '00000000-0000-0000-0000-000000000000' as AccountId;
+      await keyring.setSelectedAccounts([unknownId, account1.id, unknownId]);
+
+      expect(lastSetSelectedAccounts).toStrictEqual([account1.id]);
+    });
+
+    it('deduplicates repeated known account IDs', async () => {
+      let lastSetSelectedAccounts: AccountId[] | undefined;
+      const messenger = {
+        call: jest.fn(
+          async (
+            action: string,
+            args: { request: JsonRpcRequest },
+          ): Promise<null> => {
+            if (action === 'SnapController:handleRequest') {
+              const { request } = args;
+              if (request.method === KeyringRpcMethod.SetSelectedAccounts) {
+                const params = request.params as { accounts: AccountId[] };
+                lastSetSelectedAccounts = params.accounts;
+                return null;
+              }
+            }
+            throw new Error(`Unexpected messenger.call: ${action}`);
+          },
+        ),
+        publish: jest.fn(),
+      } as unknown as SnapKeyringMessenger;
+
+      const keyring = new TestSnapKeyringV1({
+        snapId: SNAP_ID,
+        messenger,
+        callbacks: makeCallbacks(),
+      });
+      keyring.seedAccount(account1);
+
+      await keyring.setSelectedAccounts([account1.id, account1.id]);
+
+      expect(lastSetSelectedAccounts).toStrictEqual([account1.id]);
+    });
+
+    it('updates internal selection to the filtered list', async () => {
+      const messenger = {
+        call: jest.fn(async (): Promise<null> => null),
+        publish: jest.fn(),
+      } as unknown as SnapKeyringMessenger;
+
+      const keyring = new TestSnapKeyringV1({
+        snapId: SNAP_ID,
+        messenger,
+        callbacks: makeCallbacks(),
+      });
+      keyring.seedAccount(account1);
+
+      const unknownId = '00000000-0000-0000-0000-000000000000' as AccountId;
+      await keyring.setSelectedAccounts([unknownId, account1.id]);
+
+      const selected = await keyring.handleKeyringSnapMessage({
+        method: SnapManageAccountsMethod.GetSelectedAccounts,
+      });
+      expect(selected).toStrictEqual([account1.id]);
+    });
+
+    it('logs unknown account IDs', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation();
+      const messenger = {
+        call: jest.fn(async (): Promise<null> => null),
+        publish: jest.fn(),
+      } as unknown as SnapKeyringMessenger;
+
+      const keyring = new TestSnapKeyringV1({
+        snapId: SNAP_ID,
+        messenger,
+        callbacks: makeCallbacks(),
+      });
+      keyring.seedAccount(account1);
+
+      const unknownId = '00000000-0000-0000-0000-000000000000' as AccountId;
+      await keyring.setSelectedAccounts([unknownId, account1.id]);
+
+      expect(spy).toHaveBeenCalledWith(
+        `Snap '${SNAP_ID}' ignored unknown account IDs when setting selected accounts:`,
+        [unknownId],
+      );
+      spy.mockRestore();
+    });
+  });
+});

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
@@ -1,12 +1,11 @@
+import type { KeyringAccount } from '@metamask/keyring-api';
 import {
   EthAccountType,
   EthScope,
   KeyringRpcMethod,
 } from '@metamask/keyring-api';
-import type { KeyringAccount } from '@metamask/keyring-api';
-import type { AccountId } from '@metamask/keyring-utils';
 import { SnapManageAccountsMethod } from '@metamask/keyring-snap-sdk';
-import type { JsonRpcRequest } from '@metamask/keyring-utils';
+import type { AccountId, JsonRpcRequest } from '@metamask/keyring-utils';
 import type { SnapId } from '@metamask/snaps-sdk';
 
 import type { SnapKeyringMessenger } from './SnapKeyringMessenger';

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
@@ -1,4 +1,8 @@
-import { EthAccountType, EthScope, KeyringRpcMethod } from '@metamask/keyring-api';
+import {
+  EthAccountType,
+  EthScope,
+  KeyringRpcMethod,
+} from '@metamask/keyring-api';
 import type { KeyringAccount } from '@metamask/keyring-api';
 import type { AccountId } from '@metamask/keyring-utils';
 import { SnapManageAccountsMethod } from '@metamask/keyring-snap-sdk';
@@ -40,17 +44,11 @@ function makeCallbacks(): SnapKeyringV1Callbacks {
       .fn<Promise<void>, Parameters<SnapKeyringV1Callbacks['addAccount']>>()
       .mockResolvedValue(undefined),
     removeAccount: jest
-      .fn<
-        Promise<void>,
-        Parameters<SnapKeyringV1Callbacks['removeAccount']>
-      >()
+      .fn<Promise<void>, Parameters<SnapKeyringV1Callbacks['removeAccount']>>()
       .mockResolvedValue(undefined),
     saveState: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
     redirectUser: jest
-      .fn<
-        Promise<void>,
-        Parameters<SnapKeyringV1Callbacks['redirectUser']>
-      >()
+      .fn<Promise<void>, Parameters<SnapKeyringV1Callbacks['redirectUser']>>()
       .mockResolvedValue(undefined),
     assertAccountCanBeUsed: jest
       .fn<Promise<void>, [KeyringAccount]>()

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
@@ -36,10 +36,22 @@ class TestSnapKeyringV1 extends SnapKeyringV1 {
  */
 function makeCallbacks(): SnapKeyringV1Callbacks {
   return {
-    addAccount: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
-    removeAccount: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
+    addAccount: jest
+      .fn<Promise<void>, Parameters<SnapKeyringV1Callbacks['addAccount']>>()
+      .mockResolvedValue(undefined),
+    removeAccount: jest
+      .fn<
+        Promise<void>,
+        Parameters<SnapKeyringV1Callbacks['removeAccount']>
+      >()
+      .mockResolvedValue(undefined),
     saveState: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
-    redirectUser: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
+    redirectUser: jest
+      .fn<
+        Promise<void>,
+        Parameters<SnapKeyringV1Callbacks['redirectUser']>
+      >()
+      .mockResolvedValue(undefined),
     assertAccountCanBeUsed: jest
       .fn<Promise<void>, [KeyringAccount]>()
       .mockResolvedValue(undefined),

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
@@ -410,12 +410,39 @@ export class SnapKeyringV1 {
   /**
    * Update the selected accounts for this snap.
    *
+   * Only account IDs that exist in this instance's registry (accounts owned
+   * by this snap) are applied and forwarded to the Snap. Unknown IDs are
+   * omitted and logged.
+   *
    * @param accountIds - The account IDs to set as selected.
    */
   async setSelectedAccounts(accountIds: AccountId[]): Promise<void> {
-    this.#selectedAccounts = accountIds;
+    const ownedAccountIds: AccountId[] = [];
+    const seen = new Set<AccountId>();
+    for (const id of accountIds) {
+      if (!this.registry.has(id)) {
+        continue;
+      }
+      if (seen.has(id)) {
+        continue;
+      }
+      seen.add(id);
+      ownedAccountIds.push(id);
+    }
+
+    const unknownIds = [
+      ...new Set(accountIds.filter((id) => !this.registry.has(id))),
+    ];
+    if (unknownIds.length > 0) {
+      console.error(
+        `Snap '${this.snapId}' ignored unknown account IDs when setting selected accounts:`,
+        unknownIds,
+      );
+    }
+
+    this.#selectedAccounts = ownedAccountIds;
     try {
-      await this.client.setSelectedAccounts(accountIds);
+      await this.client.setSelectedAccounts(ownedAccountIds);
     } catch (error: any) {
       console.error(
         `Failed to set selected accounts for ${this.snapId} snap: '${error.message}'`,

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
@@ -418,21 +418,23 @@ export class SnapKeyringV1 {
    */
   async setSelectedAccounts(accountIds: AccountId[]): Promise<void> {
     const ownedAccountIds: AccountId[] = [];
-    const seen = new Set<AccountId>();
+    const seenOwned = new Set<AccountId>();
+    const unknownIds: AccountId[] = [];
+    const seenUnknown = new Set<AccountId>();
+
     for (const id of accountIds) {
-      if (!this.registry.has(id)) {
-        continue;
+      if (this.registry.has(id)) {
+        if (seenOwned.has(id)) {
+          continue;
+        }
+        seenOwned.add(id);
+        ownedAccountIds.push(id);
+      } else if (!seenUnknown.has(id)) {
+        seenUnknown.add(id);
+        unknownIds.push(id);
       }
-      if (seen.has(id)) {
-        continue;
-      }
-      seen.add(id);
-      ownedAccountIds.push(id);
     }
 
-    const unknownIds = [
-      ...new Set(accountIds.filter((id) => !this.registry.has(id))),
-    ];
     if (unknownIds.length > 0) {
       console.error(
         `Snap '${this.snapId}' ignored unknown account IDs when setting selected accounts:`,


### PR DESCRIPTION
Fixes: https://github.com/MetaMask/metamask-extension/issues/39068

Please see https://github.com/MetaMask/metamask-extension/pull/41845 for a description of the issue.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is localized to `SnapKeyringV1.setSelectedAccounts` and adds tests; behavior is stricter by dropping unknown/duplicate IDs, which could affect callers relying on previous passthrough.
> 
> **Overview**
> Tightens `SnapKeyringV1.setSelectedAccounts` to **only apply/forward selected account IDs that are owned by the snap**, deduplicating known IDs and **omitting (and logging) unknown IDs** before updating internal state and calling the snap client.
> 
> Adds a focused Jest test suite covering filtering, deduplication, internal `getSelectedAccounts` behavior, and logging, and documents the fix in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e111d99a539188ea67d89aa0fd2780df94f6b14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->