### PR TITLE
chore: update docs to mention oxfmt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,22 +124,27 @@ yarn lint:fix
 
 # Individual linters
 yarn lint:eslint          # ESLint only
-yarn lint:misc --check    # oxfmt (formatting check; CI "Checking formatting")
+yarn lint:misc --check    # oxfmt: same check as CI "Checking formatting"
 yarn lint:dependencies    # Check dependency issues
 yarn lint:readme          # Verify README is up to date
 
 # Fix specific issues
 yarn lint:dependencies:fix  # Fix dependency issues
-yarn lint:misc --write      # Auto-fix oxfmt formatting
+yarn lint:misc --write      # Auto-fix oxfmt (same as oxfmt --write)
 ```
 
 **Linting Notes:**
 
-- ESLint uses flat config in [`eslint.config.mjs`](./eslint.config.mjs) (extends `@metamask/eslint-config`).
-- **`yarn lint:misc`** runs **[oxfmt](https://oxc.rs/docs/guide/usage/formatter)** via `oxfmt --ignore-path .gitignore`. Options live in [`.oxfmtrc.json`](./.oxfmtrc.json) (for example `printWidth`, `singleQuote`, **`sortImports`**, and `ignorePatterns`). **CI treats `oxfmt --check` as the formatting gate** for files oxfmt covers (including `.ts` / `.tsx`).
-- The **`prettier/prettier` ESLint rule is off** in `eslint.config.mjs`, so **editor Prettier alone will not match** what CI enforces on TypeScript; use **`yarn lint:misc --write`** or **`yarn lint:fix`** before pushing.
-- **Prettier** is still a devDependency for **other scripts** (for example `yarn auto-changelog validate --prettier` in `scripts/validate-changelog.sh` and `scripts/update-changelog.sh`). That is **separate** from **`yarn lint:misc`**.
-- No `any` types allowed (enforced by linter)
+- ESLint (flat): [`eslint.config.mjs`](./eslint.config.mjs) — @metamask preset.
+- Oxfmt: [`.oxfmtrc.json`](./.oxfmtrc.json) (`printWidth`, `sortImports`, etc.).
+- The `lint:misc` script is `oxfmt` with `oxfmt --ignore-path .gitignore`.
+- In CI, `oxfmt --check` is the “Checking formatting” step.
+- The same as `yarn lint:misc --check` locally.
+- [Oxc (oxfmt)](https://oxc.rs/docs/guide/usage/formatter).
+- `prettier/prettier` is off. Use `yarn lint:fix` to match TypeScript in CI.
+- Editor Prettier is not a substitute for `lint:misc` and oxfmt.
+- `auto-changelog` uses Prettier. That path is not `oxfmt` or `lint:misc`.
+- No `any` types (enforced by the linter)
 
 ### Dependency Management
 
@@ -962,7 +967,7 @@ IF you added/modified types:
 | Problem                     | Solution                                    |
 | --------------------------- | ------------------------------------------- |
 | ESLint errors               | Run `yarn lint:fix` to auto-fix             |
-| `lint:misc` / formatting CI   | Run `yarn lint:misc --write` or `yarn lint:fix` (**oxfmt**; not Prettier for this script) |
+| oxfmt check (CI)            | `yarn lint:fix` / `yarn lint:misc --write`  |
 | Type errors                 | Check imported types are exported correctly |
 | Dependency version mismatch | Run `yarn lint:dependencies:fix`            |
 | Yarn lockfile conflicts     | Run `yarn dedupe`                           |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,22 +124,22 @@ yarn lint:fix
 
 # Individual linters
 yarn lint:eslint          # ESLint only
-yarn lint:misc --check    # Prettier for JSON/MD/YAML
+yarn lint:misc --check    # oxfmt (formatting check; CI "Checking formatting")
 yarn lint:dependencies    # Check dependency issues
 yarn lint:readme          # Verify README is up to date
 
 # Fix specific issues
 yarn lint:dependencies:fix  # Fix dependency issues
-yarn lint:misc --write      # Auto-fix formatting
+yarn lint:misc --write      # Auto-fix oxfmt formatting
 ```
 
 **Linting Notes:**
 
-- ESLint config extends `@metamask/eslint-config`
-- TypeScript-specific rules in `.eslintrc.js`
+- ESLint uses flat config in [`eslint.config.mjs`](./eslint.config.mjs) (extends `@metamask/eslint-config`).
+- **`yarn lint:misc`** runs **[oxfmt](https://oxc.rs/docs/guide/usage/formatter)** via `oxfmt --ignore-path .gitignore`. Options live in [`.oxfmtrc.json`](./.oxfmtrc.json) (for example `printWidth`, `singleQuote`, **`sortImports`**, and `ignorePatterns`). **CI treats `oxfmt --check` as the formatting gate** for files oxfmt covers (including `.ts` / `.tsx`).
+- The **`prettier/prettier` ESLint rule is off** in `eslint.config.mjs`, so **editor Prettier alone will not match** what CI enforces on TypeScript; use **`yarn lint:misc --write`** or **`yarn lint:fix`** before pushing.
+- **Prettier** is still a devDependency for **other scripts** (for example `yarn auto-changelog validate --prettier` in `scripts/validate-changelog.sh` and `scripts/update-changelog.sh`). That is **separate** from **`yarn lint:misc`**.
 - No `any` types allowed (enforced by linter)
-- Prettier for consistent formatting
-- All JSON, Markdown (.md), and YAML (.yml) files must be linted using Prettier (`yarn lint:misc -w`)
 
 ### Dependency Management
 
@@ -316,7 +316,8 @@ accounts/
 ├── jest.config.packages.js  # Shared Jest config
 ├── tsconfig.json         # Root TypeScript config
 ├── tsconfig.packages.json    # Packages TypeScript config
-├── .eslintrc.js         # ESLint configuration
+├── eslint.config.mjs   # ESLint flat configuration
+├── .oxfmtrc.json       # oxfmt formatter configuration
 └── package.json         # Root package.json (workspace config)
 ```
 
@@ -961,6 +962,7 @@ IF you added/modified types:
 | Problem                     | Solution                                    |
 | --------------------------- | ------------------------------------------- |
 | ESLint errors               | Run `yarn lint:fix` to auto-fix             |
+| `lint:misc` / formatting CI   | Run `yarn lint:misc --write` or `yarn lint:fix` (**oxfmt**; not Prettier for this script) |
 | Type errors                 | Check imported types are exported correctly |
 | Dependency version mismatch | Run `yarn lint:dependencies:fix`            |
 | Yarn lockfile conflicts     | Run `yarn dedupe`                           |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This monorepo is a collection of accounts-related packages used across multiple 
 
 - [How to release](./docs/how-to-release.md)
 
+## Contributing
+
+Use **`yarn lint:fix`** before opening a PR so ESLint and **oxfmt** (via `yarn lint:misc`) match CI. Formatting in CI is **`oxfmt --check`**, not the Prettier editor extension on TypeScript. See **[AGENTS.md](./AGENTS.md)** (Linting & Formatting) for details.
+
 ## Modules
 
 This repository contains the following packages [^fn1]:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ This monorepo is a collection of accounts-related packages used across multiple 
 
 ## Contributing
 
-Use **`yarn lint:fix`** before opening a PR so ESLint and **oxfmt** (via `yarn lint:misc`) match CI. Formatting in CI is **`oxfmt --check`**, not the Prettier editor extension on TypeScript. See **[AGENTS.md](./AGENTS.md)** (Linting & Formatting) for details.
+- Run **`yarn lint:fix`** before a PR (ESLint + oxfmt / `yarn lint:misc`).
+- TS in CI: **`oxfmt --check`**, not the Prettier extension alone.
+- See **[AGENTS.md](./AGENTS.md)** (Linting & Formatting) for more.
 
 ## Modules
 


### PR DESCRIPTION
`AGENTS.md` pointed to prettier as the linter, updated to mention oxfmt and also mentioned in the `README.md` file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates contributor guidance around formatting checks (oxfmt) and related lint scripts.
> 
> **Overview**
> Updates contributor docs to explicitly describe **`oxfmt` as the formatter behind `yarn lint:misc`** and the CI “Checking formatting” step, including how to run `--check`/`--write` locally.
> 
> Adds a **Contributing** section to `README.md` and refreshes `AGENTS.md` references to point at `eslint.config.mjs`/`.oxfmtrc.json` and clarify that Prettier editor formatting is not equivalent to the repo’s `oxfmt` checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c807ecbe14492c39053f4b63031e9bc5be00712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->