### PR TITLE
feat(keyring-eth-hd): add keyring v2 getters

### DIFF
--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose same getters in `HdKeyring` (v2 keyring wrapper from `/v2`) ([#XXXX](https://github.com/MetaMask/accounts/pull/XXXX))
+- Expose same getters in `HdKeyring` (v2 keyring wrapper from `/v2`) ([#529](https://github.com/MetaMask/accounts/pull/529))
   - We need this as some consumers were already using those getters when using the v1 keyring.
 
 ## [14.0.1]

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose same getters in `HdKeyring` (v2 keyring wrapper from `/v2`) ([#XXXX](https://github.com/MetaMask/accounts/pull/XXXX))
+  - We need this as some consumers were already using those getters when using the v1 keyring.
+
 ## [14.0.1]
 
 ### Changed

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.test.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.test.ts
@@ -66,6 +66,46 @@ describe('HdKeyring (v2 wrapper)', () => {
     });
   });
 
+  describe('getters', () => {
+    it('exposes mnemonic from the inner keyring', () => {
+      expect(wrapper.mnemonic).toStrictEqual(inner.mnemonic);
+      expect(wrapper.mnemonic).toBeInstanceOf(Uint8Array);
+    });
+
+    it('exposes seed from the inner keyring', () => {
+      expect(wrapper.seed).toStrictEqual(inner.seed);
+      expect(wrapper.seed).toBeInstanceOf(Uint8Array);
+    });
+
+    it('exposes root from the inner keyring', () => {
+      expect(wrapper.root).toStrictEqual(inner.root);
+      expect(wrapper.root).not.toBeNull();
+    });
+
+    it('exposes hdWallet from the inner keyring', () => {
+      expect(wrapper.hdWallet).toStrictEqual(inner.hdWallet);
+      expect(wrapper.hdWallet).toBeDefined();
+    });
+
+    it('exposes hdPath from the inner keyring', () => {
+      expect(wrapper.hdPath).toBe(inner.hdPath);
+      expect(wrapper.hdPath).toBe("m/44'/60'/0'/0");
+    });
+
+    it('returns null for mnemonic/seed/root before deserialization', () => {
+      const emptyInner = new LegacyHdKeyring();
+      const emptyWrapper = new HdKeyring({
+        legacyKeyring: emptyInner,
+        entropySource: TEST_ENTROPY_SOURCE_ID,
+      });
+
+      expect(emptyWrapper.mnemonic).toBeUndefined();
+      expect(emptyWrapper.seed).toBeUndefined();
+      expect(emptyWrapper.root).toBeUndefined();
+      expect(emptyWrapper.hdWallet).toBeUndefined();
+    });
+  });
+
   describe('getAccounts', () => {
     beforeEach(async () => {
       await inner.addAccounts(2);

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.ts
@@ -74,6 +74,26 @@ export class HdKeyring
     this.entropySource = options.entropySource;
   }
 
+  get mnemonic(): LegacyHdKeyring['mnemonic'] {
+    return this.inner.mnemonic;
+  }
+
+  get seed(): LegacyHdKeyring['seed'] {
+    return this.inner.seed;
+  }
+
+  get root(): LegacyHdKeyring['root'] {
+    return this.inner.root;
+  }
+
+  get hdWallet(): LegacyHdKeyring['hdWallet'] {
+    return this.inner.hdWallet;
+  }
+
+  get hdPath(): LegacyHdKeyring['hdPath'] {
+    return this.inner.hdPath;
+  }
+
   /**
    * Checks if the given address is the last account in the inner keyring.
    * This compares against the actual inner keyring state, not the registry,

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.ts
@@ -74,22 +74,37 @@ export class HdKeyring
     this.entropySource = options.entropySource;
   }
 
+  /**
+   * @returns The mnemonic seed phrase as a `Uint8Array`, or `null`/`undefined` before initialization.
+   */
   get mnemonic(): LegacyHdKeyring['mnemonic'] {
     return this.inner.mnemonic;
   }
 
+  /**
+   * @returns The seed derived from the mnemonic, or `null`/`undefined` before initialization.
+   */
   get seed(): LegacyHdKeyring['seed'] {
     return this.inner.seed;
   }
 
+  /**
+   * @returns The root HD key derived from the seed at `hdPath`, or `null`/`undefined` before initialization.
+   */
   get root(): LegacyHdKeyring['root'] {
     return this.inner.root;
   }
 
+  /**
+   * @returns The master HD wallet key derived from the seed, or `undefined` before initialization.
+   */
   get hdWallet(): LegacyHdKeyring['hdWallet'] {
     return this.inner.hdWallet;
   }
 
+  /**
+   * @returns The BIP-44 derivation path used to derive accounts (default: `m/44'/60'/0'/0`).
+   */
   get hdPath(): LegacyHdKeyring['hdPath'] {
     return this.inner.hdPath;
   }


### PR DESCRIPTION
Re-expose the same getters than the v1 (inner) keyring, so we can use v2 keyrings to replace their current usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new public accessors that expose sensitive key material (mnemonic/seed/HD keys) through the v2 wrapper; while pass-through, it can broaden where secrets are accessed and relied upon.
> 
> **Overview**
> Re-exposes legacy HD keyring state on the v2 `HdKeyring` wrapper by adding passthrough getters for `mnemonic`, `seed`, `root`, `hdWallet`, and `hdPath` (returning `undefined` pre-deserialization) to maintain compatibility with v1 consumers.
> 
> Adds unit tests asserting the getters mirror the inner keyring values and updates the changelog to document the new API surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c56bb3b821b8f65db68e719574ae3c3e8f82f9a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->