### PR TITLE
feat: add `isUnlocked` callback to `SnapKeyringCallbacks`

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `isUnlocked` callback as a safety mechanism for inflight account creation ([]())
+- Added `isUnlocked` callback as a safety mechanism for inflight account creation ([#531](https://github.com/MetaMask/accounts/pull/531))
 
 ## [22.0.0]
 

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `isUnlocked` callback as a safety mechanism for inflight account creation ([]())
+
 ## [22.0.0]
 
 ### Added

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -126,6 +126,7 @@ describe('SnapKeyring', () => {
       return Promise.resolve();
     }),
     redirectUser: jest.fn(async () => Promise.resolve()),
+    isUnlocked: jest.fn(),
   };
 
   const snapId = 'local:snap.mock' as SnapId;
@@ -379,6 +380,7 @@ describe('SnapKeyring', () => {
         await handleUserInput(true);
       },
     );
+    mockCallbacks.isUnlocked.mockReturnValue(true);
 
     mockMessenger.get.mockReset();
     mockMessenger.handleRequest.mockReset();
@@ -526,6 +528,26 @@ describe('SnapKeyring', () => {
             },
           }),
         ).rejects.toThrow(`Account '${ethEoaAccount1.id}' already exists`);
+      });
+
+      it('defers when the controller is locked', async () => {
+        mockCallbacks.addressExists.mockClear();
+        mockCallbacks.addAccount.mockClear();
+        mockCallbacks.isUnlocked.mockReturnValueOnce(false);
+
+        const result = await keyring.handleKeyringSnapMessage(snapId, {
+          method: KeyringEvent.AccountCreated,
+          params: {
+            account: {
+              ...(newEthEoaAccount as unknown as KeyringAccount),
+              id: '56189183-9b89-4ae6-90d9-99d167b28520',
+            },
+          },
+        });
+
+        expect(result).toBeNull();
+        expect(mockCallbacks.addressExists).not.toHaveBeenCalled();
+        expect(mockCallbacks.addAccount).not.toHaveBeenCalled();
       });
 
       describe('with options', () => {

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -66,6 +66,8 @@ export type SnapKeyringCallbacks = {
   ): Promise<void>;
 
   redirectUser(snapId: SnapId, url: string, message: string): Promise<void>;
+
+  isUnlocked: () => boolean;
 };
 
 /**
@@ -245,6 +247,7 @@ export class SnapKeyring {
           withLock: async <Result>(
             callback: () => Promise<Result>,
           ): Promise<Result> => this.#lock.runExclusive(callback),
+          isUnlocked: (): boolean => this.#callbacks.isUnlocked(),
         },
       });
 

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
@@ -149,6 +149,11 @@ export type SnapKeyringV1Callbacks = {
    * Optional — consumers that don't need cross-instance indexing can omit this.
    */
   onUnregister?: (accountId: AccountId) => void;
+
+  /**
+   * Check whether the KeyringController is currently unlocked.
+   */
+  isUnlocked: () => boolean;
 };
 
 /**
@@ -758,6 +763,12 @@ export class SnapKeyringV1 {
 
     if (this.getExistingAccount(account)) {
       // If the account already exists, we skip it.
+      return null;
+    }
+
+    // Defer gracefully if the controller is locked. Snap keeps its locally-
+    // persisted account; next align's idempotent re-fire registers it.
+    if (!this.#callbacks.isUnlocked()) {
       return null;
     }
 

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -45,6 +45,7 @@ function makeMockCallbacks(): SnapKeyringCallbacks {
     assertAccountCanBeUsed: jest
       .fn<Promise<void>, [KeyringAccount]>()
       .mockResolvedValue(undefined),
+    isUnlocked: jest.fn<boolean, []>().mockReturnValue(true),
   };
 }
 
@@ -382,6 +383,22 @@ describe('SnapKeyring', () => {
         await expect(keyring.createAccounts(options)).rejects.toThrow(
           'already part of this batch',
         );
+      });
+
+      it('defers when the controller is locked', async () => {
+        const { keyring, callbacks } = await makeKeyring(SNAP_ID, {
+          isUnlocked: jest.fn<boolean, []>().mockReturnValue(false),
+        });
+        const clientSpy = jest
+          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .mockResolvedValue([account1]);
+
+        const result = await keyring.createAccounts(options);
+
+        expect(result).toStrictEqual([]);
+        expect(clientSpy).not.toHaveBeenCalled();
+        expect(callbacks.assertAccountCanBeUsed).not.toHaveBeenCalled();
+        expect(callbacks.saveState).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -194,6 +194,12 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     options: CreateAccountOptions,
   ): Promise<KeyringAccount[]> {
     return this.#withLock(async () => {
+      // Defer gracefully if the controller is locked. Returns empty to signal
+      // no accounts were created this pass; next align will retry on unlock.
+      if (!this.#callbacks.isUnlocked()) {
+        return [];
+      }
+
       // Keep track of address/account ID part of this batch, to avoid having duplicates.
       const batchAddresses = new Set<string>();
       const batchIds = new Set<string>();


### PR DESCRIPTION
Added `isUnlocked` callback that checks if the `KeyringController` is unlocked as an extra safety mechanism for in flight account creation. 

Note: This does not eliminate entirely all lock errors as the controller might become locked after the `isUnlocked` check but this should eliminate most of the errors we've seen as they originated when we would make our `addressExists` which would fail because of the `KeyringController` being locked


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes account-creation behavior in both v1 event handling and v2 batch creation to early-return when the controller is locked, and introduces a new required callback that consumers must implement.
> 
> **Overview**
> Adds a new required `isUnlocked` callback to `SnapKeyringCallbacks`/`SnapKeyringV1Callbacks` and wires it through the per-snap keyring wrapper.
> 
> When `isUnlocked` is false, the bridge now **defers inflight account creation**: v1 `notify:accountCreated` handling returns `null` without running validation/callbacks, and v2 `createAccounts` returns an empty array without calling the Snap client. Tests and the changelog are updated to cover and document this locked-controller deferral behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c0f6ca585b6dc665bded1c984a552df42d429a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->