### PR TITLE
feat(keyring-api): add token approval type

### DIFF
--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `TransactionType.Approve` for token approval transactions ([#537](https://github.com/MetaMask/accounts/pull/537))
+- Add `TransactionType.TokenApprove` for token approval transactions ([#537](https://github.com/MetaMask/accounts/pull/537))
 
 ## [23.0.1]
 

--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `TransactionType.Approve` for token approval transactions ([#537](https://github.com/MetaMask/accounts/pull/537))
+
 ## [23.0.1]
 
 ### Fixed

--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -166,6 +166,11 @@ export enum TransactionType {
   StakeWithdraw = 'stake:withdraw',
 
   /**
+   * Represents a token approval transaction.
+   */
+  Approve = 'token:approve',
+
+  /**
    * The transaction type is unknown. It's not possible to determine the
    * transaction type based on the information available.
    */
@@ -355,6 +360,7 @@ export const TransactionStruct = object({
     `${TransactionType.BridgeReceive}`,
     `${TransactionType.StakeDeposit}`,
     `${TransactionType.StakeWithdraw}`,
+    `${TransactionType.Approve}`,
     `${TransactionType.Unknown}`,
   ]),
 

--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -168,7 +168,7 @@ export enum TransactionType {
   /**
    * Represents a token approval transaction.
    */
-  Approve = 'token:approve',
+  TokenApprove = 'token:approve',
 
   /**
    * The transaction type is unknown. It's not possible to determine the
@@ -360,7 +360,7 @@ export const TransactionStruct = object({
     `${TransactionType.BridgeReceive}`,
     `${TransactionType.StakeDeposit}`,
     `${TransactionType.StakeWithdraw}`,
-    `${TransactionType.Approve}`,
+    `${TransactionType.TokenApprove}`,
     `${TransactionType.Unknown}`,
   ]),
 


### PR DESCRIPTION
This adds a token approval type to `TransactionType` and subsequently `TransactionStruct`. The change was made as it is needed to make the distinction for transaction type in the UI, otherwise we see "Interaction"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small additive change to an enum and its struct validation; risk is limited to downstream consumers needing to handle the new transaction type string.
> 
> **Overview**
> Adds a new `TransactionType.TokenApprove` (`token:approve`) variant to represent ERC-20/asset approval transactions.
> 
> Updates `TransactionStruct` validation to accept the new type, and documents the addition in the `keyring-api` changelog under *Unreleased*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 785d6b5b4feecdf8d4a305f581320d7b6438cfc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->