### PR TITLE
fix: fix `scripts/tsd-test.sh`

### DIFF
--- a/scripts/tsd-test.sh
+++ b/scripts/tsd-test.sh
@@ -9,7 +9,7 @@ if [[ $# -eq 0 ]]; then
 fi
 
 package_test_dir="$1"
-package_test_files=("${package_test_dir}"/**/*.test-d.ts)
+package_test_files=($(find "${package_test_dir}" -name "*.test-d.ts"))
 
 # To avoid logging a tsd error message, we check if it exists any file for that
 # pattern:

--- a/scripts/tsd-test.sh
+++ b/scripts/tsd-test.sh
@@ -13,7 +13,7 @@ package_test_files=($(find "${package_test_dir}" -name "*.test-d.ts"))
 
 # To avoid logging a tsd error message, we check if it exists any file for that
 # pattern:
-if [ -e "${package_test_files[0]}" ]; then
+if [ "${#package_test_files[@]}" -gt 0 ]; then
   tsd --files "${package_test_dir}/**/*.test-d.ts"
 else
   echo "Nothing to test with tsd."


### PR DESCRIPTION
It seems the globbing does not always work with `bash`. Instead, we just rely on the usual `find` command that should work everytime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk shell-script change that only affects whether `tsd` runs; main potential issue is quoting/whitespace handling of paths returned by `find`.
> 
> **Overview**
> Improves `scripts/tsd-test.sh` portability by replacing bash globbing (`**/*.test-d.ts`) with a `find`-based file discovery step.
> 
> Updates the guard condition to check the resulting array length before invoking `tsd`, avoiding noisy failures when no `.test-d.ts` files exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b178546bb63c239f53db574b4d27ea1c494aaa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->