### PR TITLE
test(keyring-utils): add `Keyring` test types

### DIFF
--- a/packages/keyring-utils/src/keyring.test-d.ts
+++ b/packages/keyring-utils/src/keyring.test-d.ts
@@ -1,0 +1,156 @@
+import type { TypedTransaction, TypedTxData } from '@ethereumjs/tx';
+import type { Eip1024EncryptedData, Hex, Json } from '@metamask/utils';
+import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
+
+import type { EthKeyring, Keyring } from './keyring';
+import type { Extends } from './typing';
+import { expectTrue } from './typing';
+
+// Required members are all present on Keyring
+expectTrue<
+  Extends<
+    Keyring,
+    {
+      type: string;
+      getAccounts(): Promise<Hex[]>;
+      addAccounts(number: number): Promise<Hex[]>;
+      serialize(): Promise<Json>;
+      deserialize(state: Json): Promise<void>;
+    }
+  >
+>();
+
+// A minimal valid implementation is assignable to Keyring
+const minimalKeyring: Keyring = {
+  type: 'Test',
+  getAccounts: async () => [],
+  addAccounts: async (_n: number) => [],
+  serialize: async () => ({}),
+  deserialize: async (_state: Json) => undefined,
+};
+expectAssignable<Keyring>(minimalKeyring);
+
+// Objects missing required members are NOT assignable to Keyring
+expectNotAssignable<Keyring>({ type: 'Test' });
+expectNotAssignable<Keyring>({
+  getAccounts: async () => [],
+  addAccounts: async (_n: number) => [],
+  serialize: async () => ({}),
+  deserialize: async () => undefined,
+});
+
+// Optional members have the correct signatures (checked individually so a
+// single removed method fails exactly one assertion).
+// We use Required<Keyring> so that removal of a method causes a compile error.
+// NOTE: Extends<Keyring, { method?() }> s alawys be true for any type because
+// TypeScript satisfies optional-only targets structurally.
+expectTrue<Extends<Required<Keyring>, { init(): Promise<void> }>>();
+expectTrue<Extends<Required<Keyring>, { removeAccount(address: Hex): void }>>();
+expectTrue<
+  Extends<
+    Required<Keyring>,
+    {
+      exportAccount(
+        address: Hex,
+        options?: Record<string, unknown>,
+      ): Promise<string>;
+    }
+  >
+>();
+expectTrue<
+  Extends<
+    Required<Keyring>,
+    { getAppKeyAddress(address: Hex, origin: string): Promise<Hex> }
+  >
+>();
+expectTrue<
+  Extends<
+    Required<Keyring>,
+    {
+      signTransaction(
+        address: Hex,
+        transaction: TypedTransaction,
+        options?: Record<string, unknown>,
+      ): Promise<TypedTxData>;
+    }
+  >
+>();
+expectTrue<
+  Extends<
+    Required<Keyring>,
+    {
+      signMessage(
+        address: Hex,
+        message: string,
+        options?: Record<string, unknown>,
+      ): Promise<string>;
+    }
+  >
+>();
+expectTrue<
+  Extends<
+    Required<Keyring>,
+    {
+      signEip7702Authorization(
+        address: Hex,
+        authorization: [chainId: number, contractAddress: Hex, nonce: number],
+        options?: Record<string, unknown>,
+      ): Promise<string>;
+    }
+  >
+>();
+expectTrue<
+  Extends<
+    Required<Keyring>,
+    {
+      signPersonalMessage(
+        address: Hex,
+        message: Hex,
+        options?: { version?: string } & Record<string, unknown>,
+      ): Promise<string>;
+    }
+  >
+>();
+expectTrue<
+  Extends<
+    Required<Keyring>,
+    {
+      signTypedData(
+        address: Hex,
+        typedData: unknown[] | Record<string, unknown>,
+        options?: Record<string, unknown>,
+      ): Promise<string>;
+    }
+  >
+>();
+expectTrue<
+  Extends<
+    Required<Keyring>,
+    {
+      getEncryptionPublicKey(
+        account: Hex,
+        options?: Record<string, unknown>,
+      ): Promise<string>;
+    }
+  >
+>();
+expectTrue<
+  Extends<
+    Required<Keyring>,
+    {
+      decryptMessage(
+        account: Hex,
+        encryptedData: Eip1024EncryptedData,
+      ): Promise<string>;
+    }
+  >
+>();
+expectTrue<
+  Extends<Required<Keyring>, { generateRandomMnemonic(): Promise<void> }>
+>();
+expectTrue<Extends<Required<Keyring>, { destroy(): Promise<void> }>>();
+
+// EthKeyring is an alias for Keyring
+expectType<EthKeyring>(minimalKeyring);
+expectTrue<Extends<EthKeyring, Keyring>>();
+expectTrue<Extends<Keyring, EthKeyring>>();


### PR DESCRIPTION
Some basic type tests for the `Keyring` interface as I plan to split it in 2 with a `BaseKeyring` (coming soon) and the other methods.

The idea being to cover this with type tests to easily spot breaking change during that split.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds compile-time `tsd` assertions only, with no runtime or production code changes.
> 
> **Overview**
> Adds a new `tsd` test file (`keyring.test-d.ts`) that *type-checks* the `Keyring` interface by asserting required fields exist, invalid shapes are rejected, and each optional method’s signature matches expectations (using `Required<Keyring>` so removals break the test).
> 
> Also asserts `EthKeyring` remains a strict alias of `Keyring`, helping catch breaking type changes ahead of an upcoming interface split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0cc55477626165c9320ab88306201d675f7b0cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->