### PR TITLE
fix(keyring-utils): fix invalid Keyring narrow type

### DIFF
--- a/packages/keyring-utils/CHANGELOG.md
+++ b/packages/keyring-utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Do not narrow `Keyring` with `BaseKeyring` ([#545](https://github.com/MetaMask/accounts/pull/545))
+  - We cannot use an intersection and narrow `getAccounts()` to use `Promise<Hex[]>` as a return type.
+  - We now instead verify with TSD that `Keyring` is compatible with `BaseKeyring` so we get the proper signature.
+
 ## [3.3.0]
 
 ### Added

--- a/packages/keyring-utils/src/keyring.test-d.ts
+++ b/packages/keyring-utils/src/keyring.test-d.ts
@@ -2,7 +2,7 @@ import type { TypedTransaction, TypedTxData } from '@ethereumjs/tx';
 import type { Eip1024EncryptedData, Hex, Json } from '@metamask/utils';
 import { expectAssignable, expectNotAssignable, expectType } from 'tsd';
 
-import type { EthKeyring, Keyring } from './keyring';
+import type { BaseKeyring, EthKeyring, Keyring } from './keyring';
 import type { Extends } from './typing';
 import { expectTrue } from './typing';
 
@@ -149,6 +149,9 @@ expectTrue<
   Extends<Required<Keyring>, { generateRandomMnemonic(): Promise<void> }>
 >();
 expectTrue<Extends<Required<Keyring>, { destroy(): Promise<void> }>>();
+
+// Keyring is assignable to BaseKeyring
+expectTrue<Extends<Keyring, BaseKeyring>>();
 
 // EthKeyring is an alias for Keyring
 expectType<EthKeyring>(minimalKeyring);

--- a/packages/keyring-utils/src/keyring.ts
+++ b/packages/keyring-utils/src/keyring.ts
@@ -109,7 +109,38 @@ export type BaseKeyring = {
  * should be treated with care though, just in case it does contain sensitive
  * material such as a private key.
  */
-export type Keyring = BaseKeyring & {
+export type Keyring = {
+  /**
+   * The name of this type of keyring. This must match the `type` property of
+   * the keyring class.
+   */
+  type: string;
+
+  /**
+   * Method to include asynchronous configuration.
+   */
+  init?(): Promise<void>;
+
+  /**
+   * Destroy the keyring.
+   */
+  destroy?(): Promise<void>;
+
+  /**
+   * Serialize the keyring state as a JSON-serializable object.
+   *
+   * @returns A JSON-serializable representation of the keyring state.
+   */
+  serialize(): Promise<Json>;
+
+  /**
+   * Deserialize the given keyring state, overwriting any existing state with
+   * the serialized state provided.
+   *
+   * @param state - A JSON-serializable representation of the keyring state.
+   */
+  deserialize(state: Json): Promise<void>;
+
   /**
    * Get the addresses for all accounts in this keyring.
    *


### PR DESCRIPTION
The `Keyring` type became invalid with the use of `BaseKeyring &` cause `getAccounts` signature was getting inferred with 2 overloads: `getAccounts(): Promise<Hex[]>` and `getAccounts(): Promise<string[]>` and the intersection of the 2 was `getAccounts(): Promise<string[]>` which breaks existing use of this type.

So instead of using an intersection. we verify that `Keyring` is compatible with `BaseKeyring` with TSD.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public TypeScript types are adjusted to avoid incorrect `getAccounts()` inference, which could affect downstream compilation and type-checking. Runtime behavior is unchanged, but any consumer relying on the prior (incorrect) intersection behavior may see new type errors.
> 
> **Overview**
> Fixes the `Keyring` type by **removing the `BaseKeyring &` intersection** and explicitly defining the shared members so `getAccounts()` retains the intended `Promise<Hex[]>` signature.
> 
> Adds a TSD check (`Extends<Keyring, BaseKeyring>`) to ensure `Keyring` remains compatible with `BaseKeyring` without forcing problematic signature narrowing, and documents the fix in the `keyring-utils` changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e8f11e18c6bca9a4e444b85acf29ae2d4c4796d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->