### PR TITLE
feat: add SignAuthEntry to XlmMethod

### DIFF
--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Stellar method `signAuthEntry` to `XlmMethod` ([#548](https://github.com/MetaMask/accounts/pull/548))
+
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/keyring-api/src/xlm/types.ts
+++ b/packages/keyring-api/src/xlm/types.ts
@@ -23,6 +23,7 @@ export const XlmAddressStruct = definePattern('XlmAddress', /^G[A-Z2-7]{55}$/u);
 export enum XlmMethod {
   SignMessage = 'signMessage',
   SignTransaction = 'signTransaction',
+  SignAuthEntry = 'signAuthEntry',
 }
 
 export const XlmAccountStruct = object({

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Stellar method `signAuthEntry` to `XlmMethod` ([#548](https://github.com/MetaMask/accounts/pull/548))
+
 ## [2.1.1]
 
 ### Changed

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Add Stellar method `signAuthEntry` to `XlmMethod` ([#548](https://github.com/MetaMask/accounts/pull/548))
-
 ## [2.1.1]
 
 ### Changed


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->

Adds `signAuthEntry` to the Stellar XlmMethod enum in `@metamask/keyring-api`, alongside `signMessage` and `signTransaction`, so Stellar accounts can declare support for auth-entry signing in their methods list

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive API change that only extends the Stellar `XlmMethod` enum and updates the changelog; existing consumers may need to handle the new method value if they enumerate supported methods strictly.
> 
> **Overview**
> Adds a new Stellar signing capability by extending `XlmMethod` with `SignAuthEntry` (`"signAuthEntry"`), allowing XLM accounts to advertise support for auth-entry signing via their `methods` list.
> 
> Updates the `@metamask/keyring-api` changelog to document the new method under **Unreleased**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1fe4bb5d58073bdd62e9244a46772db60a12191. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->