### PR TITLE
feat(keyring-snap-bridge): add isSnapKeyring

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isSnapKeyring` (v2) helper ([#549](https://github.com/MetaMask/accounts/pull/549))
+
 ### Changed
 
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.1.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -7,8 +7,11 @@ import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-clien
 import type { SnapId } from '@metamask/snaps-sdk';
 
 import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
+import type { Keyring } from '@metamask/keyring-api/v2';
+import { KeyringType } from '@metamask/keyring-api/v2';
+
 import type { SnapKeyringCallbacks } from './SnapKeyring';
-import { SnapKeyring } from './SnapKeyring';
+import { isSnapKeyring, SnapKeyring } from './SnapKeyring';
 
 const SNAP_ID = 'npm:@metamask/test-snap' as SnapId;
 
@@ -467,6 +470,33 @@ describe('SnapKeyring', () => {
           "Account 'unknown-id' not found",
         );
       });
+    });
+  });
+
+  describe('isSnapKeyring', () => {
+    it('returns true for a SnapKeyring instance', async () => {
+      const { keyring } = await makeKeyring();
+      expect(isSnapKeyring(keyring)).toBe(true);
+    });
+
+    it('narrows the keyring type', async () => {
+      const { keyring } = await makeKeyring();
+      const asKeyring: Keyring = keyring;
+      if (isSnapKeyring(asKeyring)) {
+        expect(asKeyring.snapId).toBe(SNAP_ID);
+      } else {
+        throw new Error('Expected isSnapKeyring to narrow to SnapKeyring');
+      }
+    });
+
+    it('returns false for a keyring with a different type', () => {
+      const other = { type: 'HD Key Tree' } as unknown as Keyring;
+      expect(isSnapKeyring(other)).toBe(false);
+    });
+
+    it('checks the type field exactly', () => {
+      const fake = { type: KeyringType.Snap } as unknown as Keyring;
+      expect(isSnapKeyring(fake)).toBe(true);
     });
   });
 });

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -482,11 +482,7 @@ describe('SnapKeyring', () => {
     it('narrows the keyring type', async () => {
       const { keyring } = await makeKeyring();
       const asKeyring: Keyring = keyring;
-      if (isSnapKeyring(asKeyring)) {
-        expect(asKeyring.snapId).toBe(SNAP_ID);
-      } else {
-        throw new Error('Expected isSnapKeyring to narrow to SnapKeyring');
-      }
+      expect(isSnapKeyring(asKeyring) && asKeyring.snapId).toBe(SNAP_ID);
     });
 
     it('returns false for a keyring with a different type', () => {

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -3,13 +3,12 @@ import type {
   KeyringAccount,
   CreateAccountOptions,
 } from '@metamask/keyring-api';
+import type { Keyring } from '@metamask/keyring-api/v2';
+import { KeyringType } from '@metamask/keyring-api/v2';
 import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client';
 import type { SnapId } from '@metamask/snaps-sdk';
 
 import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
-import type { Keyring } from '@metamask/keyring-api/v2';
-import { KeyringType } from '@metamask/keyring-api/v2';
-
 import type { SnapKeyringCallbacks } from './SnapKeyring';
 import { isSnapKeyring, SnapKeyring } from './SnapKeyring';
 

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -70,6 +70,16 @@ type SnapKeyringOptions = Omit<SnapKeyringV1Options, 'callbacks'> & {
 };
 
 /**
+ * Checks if a given keyring is a Snap keyring (v2).
+ *
+ * @param keyring - The keyring to check.
+ * @returns `true` if the keyring is a Snap keyring (v2), `false` otherwise.
+ */
+export function isSnapKeyring(keyring: Keyring): keyring is SnapKeyring {
+  return keyring.type === KeyringType.Snap;
+}
+
+/**
  * Per-snap keyring wrapper that implements `Keyring`.
  *
  * Extends `SnapKeyringV1` — the v1 event-driven flow (account lifecycle,


### PR DESCRIPTION
A small helper to check and narrow a `Keyring` (v2) type to `SnapKeyring` (v2).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: introduces a pure type-guard helper (`keyring.type === KeyringType.Snap`) plus unit tests and a changelog entry, without altering keyring behavior.
> 
> **Overview**
> Adds `isSnapKeyring` to the v2 `SnapKeyring` module as a type-guard helper to detect Snap keyrings by `type` and narrow `Keyring` to `SnapKeyring`.
> 
> Extends `SnapKeyring.test.ts` with coverage for true/false cases and type narrowing, and documents the addition in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a43b590bcda9a863a88310f94b21b2f8922b2935. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->