### PR TITLE
fix: expose missing methods in hardware keyrings wrappers

### DIFF
--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose device-management pass-throughs on the V2 `LedgerKeyring` wrapper: `hdPath` (getter), `bridge` (getter), `getDeviceId`, `setDeviceId`, `setHdPath`, `getFirstPage`, `getNextPage`, `getPreviousPage`, `forgetDevice`. `forgetDevice` additionally clears the V2 account registry to keep it in sync with the inner keyring.
+- Expose device-management pass-throughs on the V2 `LedgerKeyring` wrapper: `hdPath` (getter), `bridge` (getter), `getDeviceId`, `setDeviceId`, `setHdPath`, `getFirstPage`, `getNextPage`, `getPreviousPage`, `forgetDevice`. `forgetDevice` additionally clears the V2 account registry to keep it in sync with the inner keyring. ([#551](https://github.com/MetaMask/accounts/pull/551))
 
 ## [12.0.3]
 

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose device-management pass-throughs on the V2 `LedgerKeyring` wrapper: `hdPath` (getter), `bridge` (getter), `getDeviceId`, `setDeviceId`, `setHdPath`, `getFirstPage`, `getNextPage`, `getPreviousPage`, `forgetDevice`. `forgetDevice` additionally clears the V2 account registry to keep it in sync with the inner keyring.
+
 ## [12.0.3]
 
 ### Changed

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose device-management pass-throughs on the V2 `LedgerKeyring` wrapper: `hdPath` (getter), `bridge` (getter), `getDeviceId`, `setDeviceId`, `setHdPath`, `getFirstPage`, `getNextPage`, `getPreviousPage`, `forgetDevice`. `forgetDevice` additionally clears the V2 account registry to keep it in sync with the inner keyring. ([#551](https://github.com/MetaMask/accounts/pull/551))
+- Expose device-management pass-throughs on the V2 `LedgerKeyring` wrapper: `hdPath` (getter), `bridge` (getter), `getDeviceId`, `setDeviceId`, `setHdPath`, `getFirstPage`, `getNextPage`, `getPreviousPage`, `forgetDevice`, `isUnlocked`, `attemptMakeApp`, `getAppNameAndVersion`. `forgetDevice` additionally clears the V2 account registry to keep it in sync with the inner keyring. ([#551](https://github.com/MetaMask/accounts/pull/551))
 
 ## [12.0.3]
 

--- a/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.test.ts
@@ -852,4 +852,81 @@ describe('LedgerKeyring', () => {
       expect(accounts[1]?.options.entropy.groupIndex).toBe(2);
     });
   });
+
+  describe('device management pass-throughs', () => {
+    it('exposes the inner keyring hdPath', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+
+      expect(wrapper.hdPath).toBe(inner.hdPath);
+    });
+
+    it('exposes the inner keyring bridge', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+
+      expect(wrapper.bridge).toBe(inner.bridge);
+    });
+
+    it('getDeviceId delegates to the inner keyring', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      inner.setDeviceId('device-abc');
+
+      expect(wrapper.getDeviceId()).toBe('device-abc');
+    });
+
+    it('setDeviceId delegates to the inner keyring', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+
+      wrapper.setDeviceId('device-xyz');
+
+      expect(inner.getDeviceId()).toBe('device-xyz');
+    });
+
+    it('setHdPath delegates to the inner keyring', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const setHdPathSpy = jest.spyOn(inner, 'setHdPath');
+
+      wrapper.setHdPath(`m/44'/60'/0'/0`);
+
+      expect(setHdPathSpy).toHaveBeenCalledWith(`m/44'/60'/0'/0`);
+      expect(inner.hdPath).toBe(`m/44'/60'/0'/0`);
+    });
+
+    it('getFirstPage delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const page = [{ address: EXPECTED_ACCOUNTS[0], balance: 0, index: 0 }];
+      jest.spyOn(inner, 'getFirstPage').mockResolvedValue(page);
+
+      expect(await wrapper.getFirstPage()).toStrictEqual(page);
+    });
+
+    it('getNextPage delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const page = [{ address: EXPECTED_ACCOUNTS[1], balance: 0, index: 1 }];
+      jest.spyOn(inner, 'getNextPage').mockResolvedValue(page);
+
+      expect(await wrapper.getNextPage()).toStrictEqual(page);
+    });
+
+    it('getPreviousPage delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const page = [{ address: EXPECTED_ACCOUNTS[0], balance: 0, index: 0 }];
+      jest.spyOn(inner, 'getPreviousPage').mockResolvedValue(page);
+
+      expect(await wrapper.getPreviousPage()).toStrictEqual(page);
+    });
+
+    it('forgetDevice clears inner state and the V2 registry', async () => {
+      const { wrapper, inner } = await createWrapperWithAccounts(2);
+
+      // Populate the wrapper's registry by reading accounts.
+      const accounts = await wrapper.getAccounts();
+      expect(accounts).toHaveLength(2);
+
+      wrapper.forgetDevice();
+
+      expect(inner.accounts).toStrictEqual([]);
+      expect(inner.accountDetails).toStrictEqual({});
+      expect(await wrapper.getAccounts()).toStrictEqual([]);
+    });
+  });
 });

--- a/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.test.ts
@@ -928,5 +928,27 @@ describe('LedgerKeyring', () => {
       expect(inner.accountDetails).toStrictEqual({});
       expect(await wrapper.getAccounts()).toStrictEqual([]);
     });
+
+    it('isUnlocked delegates to the inner keyring', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      jest.spyOn(inner, 'isUnlocked').mockReturnValue(true);
+
+      expect(wrapper.isUnlocked()).toBe(true);
+    });
+
+    it('attemptMakeApp delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      jest.spyOn(inner, 'attemptMakeApp').mockResolvedValue(true);
+
+      expect(await wrapper.attemptMakeApp()).toBe(true);
+    });
+
+    it('getAppNameAndVersion delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const response = { appName: 'Ethereum', version: '1.10.0' };
+      jest.spyOn(inner, 'getAppNameAndVersion').mockResolvedValue(response);
+
+      expect(await wrapper.getAppNameAndVersion()).toStrictEqual(response);
+    });
   });
 });

--- a/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.test.ts
@@ -922,7 +922,7 @@ describe('LedgerKeyring', () => {
       const accounts = await wrapper.getAccounts();
       expect(accounts).toHaveLength(2);
 
-      wrapper.forgetDevice();
+      await wrapper.forgetDevice();
 
       expect(inner.accounts).toStrictEqual([]);
       expect(inner.accountDetails).toStrictEqual({});

--- a/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.ts
@@ -17,7 +17,11 @@ import type { AccountId, EthKeyring } from '@metamask/keyring-utils';
 import { add0x, getChecksumAddress } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import type { LedgerKeyring as LegacyLedgerKeyring } from '../ledger-keyring';
+import type { LedgerBridge, LedgerBridgeOptions } from '../ledger-bridge';
+import type {
+  AccountPage,
+  LedgerKeyring as LegacyLedgerKeyring,
+} from '../ledger-keyring';
 
 /**
  * Methods supported by Ledger keyring EOA accounts.
@@ -349,5 +353,81 @@ export class LedgerKeyring
       // Remove from the registry
       this.registry.delete(accountId);
     });
+  }
+
+  /**
+   * @returns The current derivation path used by the inner keyring.
+   */
+  get hdPath(): string {
+    return this.inner.hdPath;
+  }
+
+  /**
+   * @returns The bridge instance used by the inner keyring to communicate
+   * with the device.
+   */
+  get bridge(): LedgerBridge<LedgerBridgeOptions> {
+    return this.inner.bridge;
+  }
+
+  /**
+   * @returns The device ID for the paired Ledger device.
+   */
+  getDeviceId(): string {
+    return this.inner.getDeviceId();
+  }
+
+  /**
+   * Set the device ID for the paired Ledger device.
+   *
+   * @param deviceId - The device ID to set.
+   */
+  setDeviceId(deviceId: string): void {
+    this.inner.setDeviceId(deviceId);
+  }
+
+  /**
+   * Set the derivation path on the inner keyring.
+   *
+   * @param hdPath - The derivation path to set.
+   */
+  setHdPath(hdPath: string): void {
+    this.inner.setHdPath(hdPath);
+  }
+
+  /**
+   * Fetch the first page of candidate addresses from the device.
+   *
+   * @returns The first page of accounts.
+   */
+  async getFirstPage(): Promise<AccountPage> {
+    return this.inner.getFirstPage();
+  }
+
+  /**
+   * Fetch the next page of candidate addresses from the device.
+   *
+   * @returns The next page of accounts.
+   */
+  async getNextPage(): Promise<AccountPage> {
+    return this.inner.getNextPage();
+  }
+
+  /**
+   * Fetch the previous page of candidate addresses from the device.
+   *
+   * @returns The previous page of accounts.
+   */
+  async getPreviousPage(): Promise<AccountPage> {
+    return this.inner.getPreviousPage();
+  }
+
+  /**
+   * Clear the inner keyring's device-pairing state and accounts, and reset
+   * the V2 account registry to keep them in sync.
+   */
+  forgetDevice(): void {
+    this.inner.forgetDevice();
+    this.registry.clear();
   }
 }

--- a/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.ts
@@ -17,7 +17,11 @@ import type { AccountId, EthKeyring } from '@metamask/keyring-utils';
 import { add0x, getChecksumAddress } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
-import type { LedgerBridge, LedgerBridgeOptions } from '../ledger-bridge';
+import type {
+  GetAppNameAndVersionResponse,
+  LedgerBridge,
+  LedgerBridgeOptions,
+} from '../ledger-bridge';
 import type {
   AccountPage,
   LedgerKeyring as LegacyLedgerKeyring,
@@ -429,5 +433,29 @@ export class LedgerKeyring
   forgetDevice(): void {
     this.inner.forgetDevice();
     this.registry.clear();
+  }
+
+  /**
+   * @returns Whether the inner keyring has an unlocked HD key.
+   */
+  isUnlocked(): boolean {
+    return this.inner.isUnlocked();
+  }
+
+  /**
+   * Attempt to open the Ethereum app on the connected Ledger device.
+   *
+   * @returns Whether the app was opened.
+   */
+  async attemptMakeApp(): Promise<boolean> {
+    return this.inner.attemptMakeApp();
+  }
+
+  /**
+   * @returns The app name and version currently running on the connected
+   * Ledger device.
+   */
+  async getAppNameAndVersion(): Promise<GetAppNameAndVersionResponse> {
+    return this.inner.getAppNameAndVersion();
   }
 }

--- a/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.ts
@@ -430,9 +430,11 @@ export class LedgerKeyring
    * Clear the inner keyring's device-pairing state and accounts, and reset
    * the V2 account registry to keep them in sync.
    */
-  forgetDevice(): void {
-    this.inner.forgetDevice();
-    this.registry.clear();
+  async forgetDevice(): Promise<void> {
+    await this.withLock(async () => {
+      this.inner.forgetDevice();
+      this.registry.clear();
+    });
   }
 
   /**

--- a/packages/keyring-eth-qr/CHANGELOG.md
+++ b/packages/keyring-eth-qr/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Expose device-management pass-throughs on the V2 `QrKeyring` wrapper: `getName`, `getMode`, `getFirstPage`, `getNextPage`, `getPreviousPage`, `forgetDevice`. `forgetDevice` additionally clears the V2 account registry to keep it in sync with the inner keyring.
+- Expose device-management pass-throughs on the V2 `QrKeyring` wrapper: `getName`, `getMode`, `getFirstPage`, `getNextPage`, `getPreviousPage`, `forgetDevice`. `forgetDevice` additionally clears the V2 account registry to keep it in sync with the inner keyring. ([#551](https://github.com/MetaMask/accounts/pull/551))
 
 ### Changed
 

--- a/packages/keyring-eth-qr/CHANGELOG.md
+++ b/packages/keyring-eth-qr/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose device-management pass-throughs on the V2 `QrKeyring` wrapper: `getName`, `getMode`, `getFirstPage`, `getNextPage`, `getPreviousPage`, `forgetDevice`. `forgetDevice` additionally clears the V2 account registry to keep it in sync with the inner keyring.
+
 ### Changed
 
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.1.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/keyring-eth-qr/src/v2/qr-keyring.test.ts
+++ b/packages/keyring-eth-qr/src/v2/qr-keyring.test.ts
@@ -766,4 +766,61 @@ describe('QrKeyring', () => {
       });
     });
   });
+
+  describe('device management pass-throughs', () => {
+    it('getName delegates to the inner keyring', async () => {
+      const { wrapper, inner } = await createWrapperWithAccounts(1);
+
+      expect(wrapper.getName()).toBe(inner.getName());
+    });
+
+    it('getMode delegates to the inner keyring', async () => {
+      const { wrapper, inner } = await createWrapperWithAccounts(1);
+
+      expect(wrapper.getMode()).toBe(inner.getMode());
+    });
+
+    it('getFirstPage delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const page = [{ address: EXPECTED_ACCOUNTS[0], index: 0 }] as Awaited<
+        ReturnType<LegacyQrKeyring['getFirstPage']>
+      >;
+      jest.spyOn(inner, 'getFirstPage').mockResolvedValue(page);
+
+      expect(await wrapper.getFirstPage()).toStrictEqual(page);
+    });
+
+    it('getNextPage delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const page = [{ address: EXPECTED_ACCOUNTS[1], index: 1 }] as Awaited<
+        ReturnType<LegacyQrKeyring['getNextPage']>
+      >;
+      jest.spyOn(inner, 'getNextPage').mockResolvedValue(page);
+
+      expect(await wrapper.getNextPage()).toStrictEqual(page);
+    });
+
+    it('getPreviousPage delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const page = [{ address: EXPECTED_ACCOUNTS[0], index: 0 }] as Awaited<
+        ReturnType<LegacyQrKeyring['getPreviousPage']>
+      >;
+      jest.spyOn(inner, 'getPreviousPage').mockResolvedValue(page);
+
+      expect(await wrapper.getPreviousPage()).toStrictEqual(page);
+    });
+
+    it('forgetDevice clears inner state and the V2 registry', async () => {
+      const { wrapper, inner } = await createWrapperWithAccounts(2);
+
+      // Populate the wrapper's registry by reading accounts.
+      const accounts = await wrapper.getAccounts();
+      expect(accounts).toHaveLength(2);
+
+      await wrapper.forgetDevice();
+
+      expect(await inner.getAccounts()).toStrictEqual([]);
+      expect(await wrapper.getAccounts()).toStrictEqual([]);
+    });
+  });
 });

--- a/packages/keyring-eth-qr/src/v2/qr-keyring.ts
+++ b/packages/keyring-eth-qr/src/v2/qr-keyring.ts
@@ -18,6 +18,7 @@ import type { AccountId } from '@metamask/keyring-utils';
 import type { Hex } from '@metamask/utils';
 
 import { DeviceMode } from '../device';
+import type { IndexedAddress } from '../device';
 import type { QrKeyring as LegacyQrKeyring } from '../qr-keyring';
 
 /**
@@ -434,5 +435,57 @@ export class QrKeyring
       // Remove from the registry
       this.registry.delete(accountId);
     });
+  }
+
+  /**
+   * @returns The name of the paired device, or the keyring type if no device
+   * is paired.
+   */
+  getName(): string {
+    return this.inner.getName();
+  }
+
+  /**
+   * @returns The current device mode (HD or Account), or `undefined` if no
+   * device is paired.
+   */
+  getMode(): DeviceMode | undefined {
+    return this.inner.getMode();
+  }
+
+  /**
+   * Fetch the first page of candidate addresses from the device.
+   *
+   * @returns The first page of addresses.
+   */
+  async getFirstPage(): Promise<IndexedAddress[]> {
+    return this.inner.getFirstPage();
+  }
+
+  /**
+   * Fetch the next page of candidate addresses from the device.
+   *
+   * @returns The next page of addresses.
+   */
+  async getNextPage(): Promise<IndexedAddress[]> {
+    return this.inner.getNextPage();
+  }
+
+  /**
+   * Fetch the previous page of candidate addresses from the device.
+   *
+   * @returns The previous page of addresses.
+   */
+  async getPreviousPage(): Promise<IndexedAddress[]> {
+    return this.inner.getPreviousPage();
+  }
+
+  /**
+   * Clear the inner keyring's device-pairing state and accounts, and reset
+   * the V2 account registry to keep them in sync.
+   */
+  async forgetDevice(): Promise<void> {
+    await this.inner.forgetDevice();
+    this.registry.clear();
   }
 }

--- a/packages/keyring-eth-qr/src/v2/qr-keyring.ts
+++ b/packages/keyring-eth-qr/src/v2/qr-keyring.ts
@@ -485,7 +485,9 @@ export class QrKeyring
    * the V2 account registry to keep them in sync.
    */
   async forgetDevice(): Promise<void> {
-    await this.inner.forgetDevice();
-    this.registry.clear();
+    await this.withLock(async () => {
+      await this.inner.forgetDevice();
+      this.registry.clear();
+    });
   }
 }

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose device-management pass-throughs on the V2 `TrezorKeyring` wrapper (inherited by the V2 `OneKeyKeyring`): `getModel`, `hdPath` (getter), `bridge` (getter), `setHdPath`, `getFirstPage`, `getNextPage`, `getPreviousPage`, `forgetDevice`, `isUnlocked`. `forgetDevice` additionally clears the V2 account registry to keep it in sync with the inner keyring. ([#551](https://github.com/MetaMask/accounts/pull/551))
+
 ### Changed
 
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.1.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/keyring-eth-trezor/src/v2/trezor-keyring.test.ts
+++ b/packages/keyring-eth-trezor/src/v2/trezor-keyring.test.ts
@@ -905,7 +905,7 @@ describe('TrezorKeyring', () => {
       const accounts = await wrapper.getAccounts();
       expect(accounts).toHaveLength(2);
 
-      wrapper.forgetDevice();
+      await wrapper.forgetDevice();
 
       expect(inner.accounts).toStrictEqual([]);
       expect(await wrapper.getAccounts()).toStrictEqual([]);

--- a/packages/keyring-eth-trezor/src/v2/trezor-keyring.test.ts
+++ b/packages/keyring-eth-trezor/src/v2/trezor-keyring.test.ts
@@ -844,4 +844,78 @@ describe('TrezorKeyring', () => {
       );
     });
   });
+
+  describe('device management pass-throughs', () => {
+    it('getModel delegates to the inner keyring', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      jest.spyOn(inner, 'getModel').mockReturnValue('T');
+
+      expect(wrapper.getModel()).toBe('T');
+    });
+
+    it('exposes the inner keyring hdPath', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+
+      expect(wrapper.hdPath).toBe(inner.hdPath);
+    });
+
+    it('exposes the inner keyring bridge', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+
+      expect(wrapper.bridge).toBe(inner.bridge);
+    });
+
+    it('setHdPath delegates to the inner keyring', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const setHdPathSpy = jest.spyOn(inner, 'setHdPath');
+
+      wrapper.setHdPath(`m/44'/60'/0'/0`);
+
+      expect(setHdPathSpy).toHaveBeenCalledWith(`m/44'/60'/0'/0`);
+      expect(inner.hdPath).toBe(`m/44'/60'/0'/0`);
+    });
+
+    it('getFirstPage delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const page = [{ address: EXPECTED_ACCOUNTS[0], balance: 0, index: 0 }];
+      jest.spyOn(inner, 'getFirstPage').mockResolvedValue(page);
+
+      expect(await wrapper.getFirstPage()).toStrictEqual(page);
+    });
+
+    it('getNextPage delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const page = [{ address: EXPECTED_ACCOUNTS[1], balance: 0, index: 1 }];
+      jest.spyOn(inner, 'getNextPage').mockResolvedValue(page);
+
+      expect(await wrapper.getNextPage()).toStrictEqual(page);
+    });
+
+    it('getPreviousPage delegates to the inner keyring', async () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      const page = [{ address: EXPECTED_ACCOUNTS[0], balance: 0, index: 0 }];
+      jest.spyOn(inner, 'getPreviousPage').mockResolvedValue(page);
+
+      expect(await wrapper.getPreviousPage()).toStrictEqual(page);
+    });
+
+    it('forgetDevice clears inner state and the V2 registry', async () => {
+      const { wrapper, inner } = await createWrapperWithAccounts(2);
+
+      const accounts = await wrapper.getAccounts();
+      expect(accounts).toHaveLength(2);
+
+      wrapper.forgetDevice();
+
+      expect(inner.accounts).toStrictEqual([]);
+      expect(await wrapper.getAccounts()).toStrictEqual([]);
+    });
+
+    it('isUnlocked delegates to the inner keyring', () => {
+      const { wrapper, inner } = createEmptyWrapper();
+      jest.spyOn(inner, 'isUnlocked').mockReturnValue(true);
+
+      expect(wrapper.isUnlocked()).toBe(true);
+    });
+  });
 });

--- a/packages/keyring-eth-trezor/src/v2/trezor-keyring.ts
+++ b/packages/keyring-eth-trezor/src/v2/trezor-keyring.ts
@@ -16,7 +16,11 @@ import { EthKeyringWrapper } from '@metamask/keyring-sdk/v2';
 import type { AccountId, EthKeyring } from '@metamask/keyring-utils';
 import type { Hex, Json } from '@metamask/utils';
 
-import type { TrezorKeyring as LegacyTrezorKeyring } from '../trezor-keyring';
+import type { TrezorBridge } from '../trezor-bridge';
+import type {
+  AccountPage,
+  TrezorKeyring as LegacyTrezorKeyring,
+} from '../trezor-keyring';
 
 /**
  * Methods supported by Trezor keyring EOA accounts.
@@ -365,5 +369,81 @@ export class TrezorKeyring
       // Remove from the registry
       this.registry.delete(accountId);
     });
+  }
+
+  /**
+   * @returns The device model reported by the bridge, or `undefined` if no
+   * device is paired.
+   */
+  getModel(): string | undefined {
+    return this.inner.getModel();
+  }
+
+  /**
+   * @returns The current derivation path used by the inner keyring.
+   */
+  get hdPath(): string {
+    return this.inner.hdPath;
+  }
+
+  /**
+   * @returns The bridge instance used by the inner keyring to communicate
+   * with the device.
+   */
+  get bridge(): TrezorBridge {
+    return this.inner.bridge;
+  }
+
+  /**
+   * Set the derivation path on the inner keyring. Must be one of the allowed
+   * HD paths supported by the legacy Trezor keyring.
+   *
+   * @param hdPath - The derivation path to set.
+   */
+  setHdPath(hdPath: Parameters<LegacyTrezorKeyring['setHdPath']>[0]): void {
+    this.inner.setHdPath(hdPath);
+  }
+
+  /**
+   * Fetch the first page of candidate addresses from the device.
+   *
+   * @returns The first page of accounts.
+   */
+  async getFirstPage(): Promise<AccountPage> {
+    return this.inner.getFirstPage();
+  }
+
+  /**
+   * Fetch the next page of candidate addresses from the device.
+   *
+   * @returns The next page of accounts.
+   */
+  async getNextPage(): Promise<AccountPage> {
+    return this.inner.getNextPage();
+  }
+
+  /**
+   * Fetch the previous page of candidate addresses from the device.
+   *
+   * @returns The previous page of accounts.
+   */
+  async getPreviousPage(): Promise<AccountPage> {
+    return this.inner.getPreviousPage();
+  }
+
+  /**
+   * Clear the inner keyring's device-pairing state and accounts, and reset
+   * the V2 account registry to keep them in sync.
+   */
+  forgetDevice(): void {
+    this.inner.forgetDevice();
+    this.registry.clear();
+  }
+
+  /**
+   * @returns Whether the inner keyring has an unlocked HD key.
+   */
+  isUnlocked(): boolean {
+    return this.inner.isUnlocked();
   }
 }

--- a/packages/keyring-eth-trezor/src/v2/trezor-keyring.ts
+++ b/packages/keyring-eth-trezor/src/v2/trezor-keyring.ts
@@ -435,9 +435,11 @@ export class TrezorKeyring
    * Clear the inner keyring's device-pairing state and accounts, and reset
    * the V2 account registry to keep them in sync.
    */
-  forgetDevice(): void {
-    this.inner.forgetDevice();
-    this.registry.clear();
+  async forgetDevice(): Promise<void> {
+    await this.withLock(async () => {
+      this.inner.forgetDevice();
+      this.registry.clear();
+    });
   }
 
   /**


### PR DESCRIPTION
There's some missing methods that are needed by the clients.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds new public surface area and changes `forgetDevice` behavior to also clear the V2 account registry, which could affect client state/caching around device resets.
> 
> **Overview**
> Exposes missing *device-management* APIs on the V2 wrapper keyrings so clients can manage paired hardware devices directly via the wrapper.
> 
> `LedgerKeyring`, `QrKeyring`, and `TrezorKeyring` (and thus `OneKeyKeyring`) now pass through getters/methods like `hdPath`, `bridge`, paging (`getFirstPage`/`getNextPage`/`getPreviousPage`), and device reset (`forgetDevice`), plus device-specific calls (e.g. Ledger `get/setDeviceId`, `attemptMakeApp`, `getAppNameAndVersion`, Trezor `getModel`, `isUnlocked`). `forgetDevice` also clears the V2 registry to keep wrapper accounts in sync with the inner keyring, and new unit tests/changelog entries cover these additions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e782cea8bd95d3e35cc40d7a77e7a42cd49ac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->