### PR TITLE
feat(keyring-sdk): add `EthKeyringV1Adapter`

### DIFF
--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add Stellar method `signAuthEntry` to `XlmMethod` ([#548](https://github.com/MetaMask/accounts/pull/548))
+- Add `EthBytesStrictStruct` ([#555](https://github.com/MetaMask/accounts/pull/555))
 
 ### Changed
 

--- a/packages/keyring-api/src/eth/types.ts
+++ b/packages/keyring-api/src/eth/types.ts
@@ -11,7 +11,13 @@ import {
   KeyringAccountStruct,
 } from '../api';
 
-export const EthBytesStruct = definePattern('EthBytes', /^0x[0-9a-f]*$/iu);
+const ETH_BYTES_REGEX = /^0x[0-9a-f]*$/iu;
+export const EthBytesStruct = definePattern('EthBytes', ETH_BYTES_REGEX);
+// Stricter struct that uses `Hex` as final type.
+export const EthBytesStrictStruct = definePattern<Hex>(
+  'EthBytesStrict',
+  ETH_BYTES_REGEX,
+);
 
 const ETH_ADDRESS_REGEX = /^0x[0-9a-f]{40}$/iu;
 export const EthAddressStruct = definePattern('EthAddress', ETH_ADDRESS_REGEX);

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `EthKeyringV1Adapter` and typed errors for adapting v2 ETH keyrings to legacy ETH keyring signing flows ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 ## [2.1.1]
 
 ### Changed

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `EthKeyringV1Adapter` and typed errors for adapting v2 ETH keyrings to legacy ETH keyring signing flows ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Add `EthKeyringV1Adapter` and typed errors for adapting v2 ETH keyrings to legacy ETH keyring signing flows ([#555](https://github.com/MetaMask/accounts/pull/555))
 
 ## [2.1.1]
 

--- a/packages/keyring-sdk/src/eth/eth-4337-keyring.ts
+++ b/packages/keyring-sdk/src/eth/eth-4337-keyring.ts
@@ -1,0 +1,55 @@
+import type {
+  EthBaseTransaction,
+  EthBaseUserOperation,
+  EthUserOperation,
+  EthUserOperationPatch,
+  KeyringExecutionContext,
+} from '@metamask/keyring-api';
+
+/**
+ * Legacy ETH keyring methods for ERC-4337 accounts.
+ */
+export type Eth4337Keyring = {
+  /**
+   * Convert base transactions to a base UserOperation.
+   *
+   * @param address - Address of the account to prepare the user operation for.
+   * @param transactions - Base transactions to include in the UserOperation.
+   * @param context - Keyring execution context.
+   * @returns A pseudo-UserOperation that can be used to construct a real one.
+   */
+  prepareUserOperation?(
+    address: string,
+    transactions: EthBaseTransaction[],
+    context: KeyringExecutionContext,
+  ): Promise<EthBaseUserOperation>;
+
+  /**
+   * Patches properties of a UserOperation. Currently, only the
+   * `paymasterAndData` can be patched.
+   *
+   * @param address - Address of the account to patch the user operation for.
+   * @param userOperation - UserOperation to patch.
+   * @param context - Keyring execution context.
+   * @returns A patch to apply to the UserOperation.
+   */
+  patchUserOperation?(
+    address: string,
+    userOperation: EthUserOperation,
+    context: KeyringExecutionContext,
+  ): Promise<EthUserOperationPatch>;
+
+  /**
+   * Signs a UserOperation.
+   *
+   * @param address - Address of the account to sign the user operation for.
+   * @param userOperation - UserOperation to sign.
+   * @param context - Keyring execution context.
+   * @returns A promise that resolves to the signature.
+   */
+  signUserOperation?(
+    address: string,
+    userOperation: EthUserOperation,
+    context: KeyringExecutionContext,
+  ): Promise<string>;
+};

--- a/packages/keyring-sdk/src/eth/index.ts
+++ b/packages/keyring-sdk/src/eth/index.ts
@@ -1,1 +1,2 @@
 export * from './account-id';
+export type * from './eth-4337-keyring';

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
@@ -47,22 +47,6 @@ const ALL_SUPPORTED_METHODS = [
   EthMethod.SignUserOperation,
 ];
 
-type BuildAdapterOptions = {
-  accounts?: KeyringAccount[];
-  exportedPrivateKey?: string;
-  includeExportAccount?: boolean;
-  origin?: string;
-  submitRequestResult?: Json;
-};
-
-type BuildAdapterResult = {
-  accounts: KeyringAccount[];
-  adapter: EthKeyringV1Adapter;
-  exportAccount: ExportAccountMock | undefined;
-  keyring: KeyringV2;
-  submitRequest: SubmitRequestMock;
-};
-
 type ExportAccount = NonNullable<KeyringV2['exportAccount']>;
 type ExportAccountMock = jest.Mock<
   ReturnType<ExportAccount>,
@@ -74,425 +58,27 @@ type SubmitRequestMock = jest.Mock<
   Parameters<SubmitRequest>
 >;
 
-describe('EthKeyringV1Adapter', () => {
-  it('exposes the base ETH keyring methods', () => {
-    const { adapter } = buildAdapter({ includeExportAccount: false });
-
-    expect(adapter.exportAccount).toStrictEqual(expect.any(Function));
-    expect(adapter.signTransaction).toStrictEqual(expect.any(Function));
-    expect(adapter.signMessage).toStrictEqual(expect.any(Function));
-    expect(adapter.signEip7702Authorization).toStrictEqual(
-      expect.any(Function),
-    );
-    expect(adapter.signPersonalMessage).toStrictEqual(expect.any(Function));
-    expect(adapter.signTypedData).toStrictEqual(expect.any(Function));
-    expect(adapter.prepareUserOperation).toStrictEqual(expect.any(Function));
-    expect(adapter.patchUserOperation).toStrictEqual(expect.any(Function));
-    expect(adapter.signUserOperation).toStrictEqual(expect.any(Function));
-    expect(
-      (adapter as unknown as { getEncryptionPublicKey?: unknown })
-        .getEncryptionPublicKey,
-    ).toBeUndefined();
-  });
-
-  it('exports a private key through the v2 keyring', async () => {
-    const account = buildAccount();
-    const { adapter, exportAccount } = buildAdapter({
-      accounts: [account],
-      exportedPrivateKey: '0xabc123',
-    });
-
-    expect(await adapter.exportAccount(ACCOUNT_ADDRESS as Hex)).toBe('abc123');
-
-    expect(exportAccount).toHaveBeenCalledWith(account.id, {
-      type: AccountExportType.PrivateKey,
-      encoding: PrivateKeyEncoding.Hexadecimal,
-    });
-  });
-
-  it('throws a non-typed unsupported export error if the v2 keyring does not support exporting', async () => {
-    const { adapter } = buildAdapter({ includeExportAccount: false });
-
-    const error = await getThrownError(async () =>
-      adapter.exportAccount(ACCOUNT_ADDRESS as Hex),
-    );
-
-    expect(error).toBeInstanceOf(Error);
-    expect(error).not.toBeInstanceOf(EthKeyringV1AccountNotFoundError);
-    expect(error).not.toBeInstanceOf(EthKeyringV1MethodNotSupportedError);
-    expect((error as Error).message).toBe(
-      'Keyring does not support exportAccount',
-    );
-  });
-
-  it('throws a typed error if no account matches the requested address', async () => {
-    const { adapter, submitRequest } = buildAdapter();
-
-    const error = await getThrownError(async () =>
-      adapter.signPersonalMessage(
-        UNKNOWN_ACCOUNT_ADDRESS as Hex,
-        '0xdeadbeef' as Hex,
-      ),
-    );
-
-    expect(error).toBeInstanceOf(EthKeyringV1AccountNotFoundError);
-    assertInstanceOf(error, EthKeyringV1AccountNotFoundError);
-    expect(error.address).toBe(UNKNOWN_ACCOUNT_ADDRESS);
-    expect(submitRequest).not.toHaveBeenCalled();
-  });
-
-  it('throws a typed error if the requested address cannot be normalized', async () => {
-    const invalidAddress = undefined as unknown as Hex;
-    const { adapter, submitRequest } = buildAdapter();
-
-    const error = await getThrownError(async () =>
-      adapter.signPersonalMessage(invalidAddress, '0xdeadbeef' as Hex),
-    );
-
-    expect(error).toBeInstanceOf(EthKeyringV1AccountNotFoundError);
-    assertInstanceOf(error, EthKeyringV1AccountNotFoundError);
-    expect(error.address).toBe(invalidAddress);
-    expect(submitRequest).not.toHaveBeenCalled();
-  });
-
-  it('throws a typed error if the account does not support the requested method', async () => {
-    const { adapter, submitRequest } = buildAdapter({
-      accounts: [buildAccount({ methods: [EthMethod.PersonalSign] })],
-    });
-
-    const error = await getThrownError(async () =>
-      adapter.signTransaction(
-        ACCOUNT_ADDRESS as Hex,
-        createTransaction({ to: ACCOUNT_ADDRESS }),
-      ),
-    );
-
-    expect(error).toBeInstanceOf(EthKeyringV1MethodNotSupportedError);
-    assertInstanceOf(error, EthKeyringV1MethodNotSupportedError);
-    expect(error.address).toBe(ACCOUNT_ADDRESS);
-    expect(error.method).toBe(EthMethod.SignTransaction);
-    expect(submitRequest).not.toHaveBeenCalled();
-  });
-
-  it('uses one adapter for multiple accounts with different supported methods', async () => {
-    const personalSignAccount = buildAccount({
-      methods: [EthMethod.PersonalSign],
-    });
-    const signAccount = buildAccount({
-      id: OTHER_ACCOUNT_ID,
-      address: OTHER_ACCOUNT_ADDRESS,
-      methods: [EthMethod.Sign],
-    });
-    const { adapter, submitRequest } = buildAdapter({
-      accounts: [personalSignAccount, signAccount],
-      submitRequestResult: '0xsigned',
-    });
-
-    expect(
-      await adapter.signPersonalMessage(
-        ACCOUNT_ADDRESS as Hex,
-        '0xdeadbeef' as Hex,
-      ),
-    ).toBe('0xsigned');
-    expectLastSubmitRequest(submitRequest, {
-      account: personalSignAccount,
-      method: EthMethod.PersonalSign,
-      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
-    });
-
-    expect(
-      await adapter.signMessage(OTHER_ACCOUNT_ADDRESS as Hex, '0xfeed'),
-    ).toBe('0xsigned');
-    expectLastSubmitRequest(submitRequest, {
-      account: signAccount,
-      method: EthMethod.Sign,
-      params: [OTHER_ACCOUNT_ADDRESS, '0xfeed'],
-    });
-  });
-
-  it('submits a transaction signing request', async () => {
-    const transactionData: TypedTxData = {
-      data: '0x',
-      gasLimit: '0x5208',
-      gasPrice: '0x1',
-      nonce: '0x0',
-      to: OTHER_ACCOUNT_ADDRESS,
-      value: '0x1',
-      chainId: '0x1',
-      type: '0x0',
-    };
-    const signature = {
-      r: '0x0' as Hex,
-      s: '0x0' as Hex,
-      v: '0x27' as Hex,
-    };
-    const keyringResponse = {
-      ...signature,
-      to: ACCOUNT_ADDRESS,
-      value: '0x2',
-    };
-    const transaction = createTransaction(transactionData);
-    const submittedTransaction = {
-      ...transaction.toJSON(),
-      from: ACCOUNT_ADDRESS as Hex,
-      type: '0x0' as Hex,
-      chainId: '0x1' as Hex,
-    };
-    const expectedSignedTransaction = TransactionFactory.fromTxData({
-      ...submittedTransaction,
-      ...signature,
-    });
-    const { accounts, adapter, submitRequest } = buildAdapter({
-      submitRequestResult: keyringResponse,
-    });
-
-    expect(
-      await adapter.signTransaction(ACCOUNT_ADDRESS as Hex, transaction),
-    ).toStrictEqual(expectedSignedTransaction);
-
-    expectLastSubmitRequest(submitRequest, {
-      account: accounts[0] as KeyringAccount,
-      method: EthMethod.SignTransaction,
-      params: [submittedTransaction],
-      scope: EthScope.Mainnet,
-    });
-  });
-
-  it('submits ETH signing requests', async () => {
-    const { accounts, adapter, submitRequest } = buildAdapter({
-      submitRequestResult: '0xsigned',
-    });
-    const authorization: [
-      chainId: number,
-      contractAddress: Hex,
-      nonce: number,
-    ] = [1, ACCOUNT_ADDRESS as Hex, 2];
-    const account = accounts[0] as KeyringAccount;
-
-    expect(
-      await adapter.signMessage(ACCOUNT_ADDRESS as Hex, '0xdeadbeef'),
-    ).toBe('0xsigned');
-    expectLastSubmitRequest(submitRequest, {
-      account,
-      method: EthMethod.Sign,
-      params: [ACCOUNT_ADDRESS, '0xdeadbeef'],
-    });
-
-    expect(
-      await adapter.signEip7702Authorization(
-        ACCOUNT_ADDRESS as Hex,
-        authorization,
-      ),
-    ).toBe('0xsigned');
-    expectLastSubmitRequest(submitRequest, {
-      account,
-      method: EthKeyringMethod.SignEip7702Authorization,
-      params: [authorization],
-    });
-
-    expect(
-      await adapter.signPersonalMessage(
-        ACCOUNT_ADDRESS as Hex,
-        '0xdeadbeef' as Hex,
-      ),
-    ).toBe('0xsigned');
-    expectLastSubmitRequest(submitRequest, {
-      account,
-      method: EthMethod.PersonalSign,
-      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
-    });
-  });
-
-  it('uses the default origin and EOA scope when submitting requests', async () => {
-    const account = buildAccount({
-      methods: [EthMethod.PersonalSign],
-      scopes: [],
-    });
-    const { adapter, submitRequest } = buildAdapter({
-      accounts: [account],
-      submitRequestResult: '0xsigned',
-    });
-
-    await adapter.signPersonalMessage(
-      ACCOUNT_ADDRESS as Hex,
-      '0xdeadbeef' as Hex,
-    );
-
-    expect(submitRequest).toHaveBeenCalledTimes(1);
-    expectLastSubmitRequest(submitRequest, {
-      account,
-      method: EthMethod.PersonalSign,
-      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
-    });
-  });
-
-  it('uses the configured origin when submitting requests', async () => {
-    const { accounts, adapter, submitRequest } = buildAdapter({
-      origin: APP_ORIGIN,
-      submitRequestResult: '0xsigned',
-    });
-
-    await adapter.signPersonalMessage(
-      ACCOUNT_ADDRESS as Hex,
-      '0xdeadbeef' as Hex,
-    );
-
-    expect(submitRequest).toHaveBeenCalledTimes(1);
-    expectLastSubmitRequest(submitRequest, {
-      account: accounts[0] as KeyringAccount,
-      method: EthMethod.PersonalSign,
-      origin: APP_ORIGIN,
-      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
-    });
-  });
-
-  it.each([
-    ['without options', undefined, EthMethod.SignTypedDataV1],
-    ['with V1', SignTypedDataVersion.V1, EthMethod.SignTypedDataV1],
-    ['with V3', SignTypedDataVersion.V3, EthMethod.SignTypedDataV3],
-    ['with V4', SignTypedDataVersion.V4, EthMethod.SignTypedDataV4],
-  ])(
-    'submits a typed data signing request %s',
-    async (_label, version, method) => {
-      const typedData = { message: 'hello' };
-      const { accounts, adapter, submitRequest } = buildAdapter({
-        submitRequestResult: '0xtyped',
-      });
-
-      expect(
-        await adapter.signTypedData(
-          ACCOUNT_ADDRESS as Hex,
-          typedData,
-          version === undefined ? undefined : { version },
-        ),
-      ).toBe('0xtyped');
-      expectLastSubmitRequest(submitRequest, {
-        account: accounts[0] as KeyringAccount,
-        method,
-        params: [ACCOUNT_ADDRESS, typedData],
-      });
-    },
-  );
-
-  it('throws a typed error if the requested typed data version is not supported by the account', async () => {
-    const { adapter, submitRequest } = buildAdapter({
-      accounts: [buildAccount({ methods: [EthMethod.SignTypedDataV1] })],
-    });
-
-    const error = await getThrownError(async () =>
-      adapter.signTypedData(
-        ACCOUNT_ADDRESS as Hex,
-        { message: 'hello' },
-        { version: SignTypedDataVersion.V4 },
-      ),
-    );
-
-    expect(error).toBeInstanceOf(EthKeyringV1MethodNotSupportedError);
-    assertInstanceOf(error, EthKeyringV1MethodNotSupportedError);
-    expect(error.address).toBe(ACCOUNT_ADDRESS);
-    expect(error.method).toBe(EthMethod.SignTypedDataV4);
-    expect(submitRequest).not.toHaveBeenCalled();
-  });
-
-  it('submits a user operation preparation request', async () => {
-    const { accounts, adapter, submitRequest } = buildAdapter();
-    const transactions: EthBaseTransaction[] = [
-      {
-        to: OTHER_ACCOUNT_ADDRESS,
-        value: '0x0',
-        data: '0x',
-      },
-      {
-        to: ACCOUNT_ADDRESS,
-        value: '0x1',
-        data: '0x1234',
-      },
-    ];
-    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
-    const baseUserOperation: EthBaseUserOperation = {
-      nonce: '0x1',
-      initCode: '0x',
-      callData: '0x1234',
-      gasLimits: {
-        callGasLimit: '0x1',
-        verificationGasLimit: '0x2',
-        preVerificationGas: '0x3',
-      },
-      dummyPaymasterAndData: '0x',
-      dummySignature: '0x',
-      bundlerUrl: 'https://bundler.example.com/rpc',
-    };
-
-    submitRequest.mockResolvedValueOnce(baseUserOperation as unknown as Json);
-    expect(
-      await adapter.prepareUserOperation(
-        ACCOUNT_ADDRESS,
-        transactions,
-        executionContext,
-      ),
-    ).toBe(baseUserOperation);
-    expectLastSubmitRequest(submitRequest, {
-      account: accounts[0] as KeyringAccount,
-      method: EthMethod.PrepareUserOperation,
-      params: transactions,
-      scope: 'eip155:0x1',
-    });
-  });
-
-  it('submits a user operation patch request', async () => {
-    const { accounts, adapter, submitRequest } = buildAdapter();
-    const userOperation = createUserOperation();
-    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
-    const patch: EthUserOperationPatch = {
-      paymasterAndData: '0x1234',
-      callGasLimit: '0x1',
-    };
-
-    submitRequest.mockResolvedValueOnce(patch as unknown as Json);
-    expect(
-      await adapter.patchUserOperation(
-        ACCOUNT_ADDRESS,
-        userOperation,
-        executionContext,
-      ),
-    ).toBe(patch);
-    expectLastSubmitRequest(submitRequest, {
-      account: accounts[0] as KeyringAccount,
-      method: EthMethod.PatchUserOperation,
-      params: [userOperation],
-      scope: 'eip155:0x1',
-    });
-  });
-
-  it('submits a user operation signing request', async () => {
-    const { accounts, adapter, submitRequest } = buildAdapter();
-    const userOperation = createUserOperation();
-    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
-
-    submitRequest.mockResolvedValueOnce('0xsignature');
-    expect(
-      await adapter.signUserOperation(
-        ACCOUNT_ADDRESS,
-        userOperation,
-        executionContext,
-      ),
-    ).toBe('0xsignature');
-    expectLastSubmitRequest(submitRequest, {
-      account: accounts[0] as KeyringAccount,
-      method: EthMethod.SignUserOperation,
-      params: [userOperation],
-      scope: 'eip155:0x1',
-    });
-  });
-});
-
-function buildAdapter({
+function setup({
   accounts = [buildAccount()],
   exportedPrivateKey = '0xabc123',
   includeExportAccount = true,
   origin,
   submitRequestResult = 'request-result',
-}: BuildAdapterOptions = {}): BuildAdapterResult {
+}: {
+  accounts?: KeyringAccount[];
+  exportedPrivateKey?: string;
+  includeExportAccount?: boolean;
+  origin?: string;
+  submitRequestResult?: Json;
+} = {}): {
+  accounts: KeyringAccount[];
+  adapter: EthKeyringV1Adapter;
+  keyring: KeyringV2;
+  mocks: {
+    exportAccount: ExportAccountMock | undefined;
+    submitRequest: SubmitRequestMock;
+  };
+} {
   const serialize = jest.fn(async () => ({ serialized: true }));
   const deserialize = jest.fn(async () => undefined);
   const getAccounts = jest.fn(async () => accounts);
@@ -537,9 +123,11 @@ function buildAdapter({
   return {
     accounts,
     adapter: new EthKeyringV1Adapter(adapterOptions),
-    exportAccount,
     keyring,
-    submitRequest,
+    mocks: {
+      exportAccount,
+      submitRequest,
+    },
   };
 }
 
@@ -597,7 +185,7 @@ function assertInstanceOf<ErrorType extends Error>(
 }
 
 function expectLastSubmitRequest(
-  submitRequest: SubmitRequestMock,
+  mocks: { submitRequest: SubmitRequestMock },
   {
     account,
     method,
@@ -612,7 +200,7 @@ function expectLastSubmitRequest(
     scope?: string;
   },
 ): void {
-  expect(submitRequest).toHaveBeenLastCalledWith(
+  expect(mocks.submitRequest).toHaveBeenLastCalledWith(
     expect.objectContaining({
       account: account.id,
       origin,
@@ -621,3 +209,416 @@ function expectLastSubmitRequest(
     }),
   );
 }
+describe('EthKeyringV1Adapter', () => {
+  it('exposes the base ETH keyring methods', () => {
+    const { adapter } = setup({ includeExportAccount: false });
+
+    expect(adapter.exportAccount).toStrictEqual(expect.any(Function));
+    expect(adapter.signTransaction).toStrictEqual(expect.any(Function));
+    expect(adapter.signMessage).toStrictEqual(expect.any(Function));
+    expect(adapter.signEip7702Authorization).toStrictEqual(
+      expect.any(Function),
+    );
+    expect(adapter.signPersonalMessage).toStrictEqual(expect.any(Function));
+    expect(adapter.signTypedData).toStrictEqual(expect.any(Function));
+    expect(adapter.prepareUserOperation).toStrictEqual(expect.any(Function));
+    expect(adapter.patchUserOperation).toStrictEqual(expect.any(Function));
+    expect(adapter.signUserOperation).toStrictEqual(expect.any(Function));
+    expect(
+      (adapter as unknown as { getEncryptionPublicKey?: unknown })
+        .getEncryptionPublicKey,
+    ).toBeUndefined();
+  });
+
+  it('exports a private key through the v2 keyring', async () => {
+    const account = buildAccount();
+    const { adapter, mocks } = setup({
+      accounts: [account],
+      exportedPrivateKey: '0xabc123',
+    });
+
+    expect(await adapter.exportAccount(ACCOUNT_ADDRESS as Hex)).toBe('abc123');
+
+    expect(mocks.exportAccount).toHaveBeenCalledWith(account.id, {
+      type: AccountExportType.PrivateKey,
+      encoding: PrivateKeyEncoding.Hexadecimal,
+    });
+  });
+
+  it('throws a non-typed unsupported export error if the v2 keyring does not support exporting', async () => {
+    const { adapter } = setup({ includeExportAccount: false });
+
+    const error = await getThrownError(async () =>
+      adapter.exportAccount(ACCOUNT_ADDRESS as Hex),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(EthKeyringV1AccountNotFoundError);
+    expect(error).not.toBeInstanceOf(EthKeyringV1MethodNotSupportedError);
+    expect((error as Error).message).toBe(
+      'Keyring does not support exportAccount',
+    );
+  });
+
+  it('throws a typed error if no account matches the requested address', async () => {
+    const { adapter, mocks } = setup();
+
+    const error = await getThrownError(async () =>
+      adapter.signPersonalMessage(
+        UNKNOWN_ACCOUNT_ADDRESS as Hex,
+        '0xdeadbeef' as Hex,
+      ),
+    );
+
+    expect(error).toBeInstanceOf(EthKeyringV1AccountNotFoundError);
+    assertInstanceOf(error, EthKeyringV1AccountNotFoundError);
+    expect(error.address).toBe(UNKNOWN_ACCOUNT_ADDRESS);
+    expect(mocks.submitRequest).not.toHaveBeenCalled();
+  });
+
+  it('throws a typed error if the requested address cannot be normalized', async () => {
+    const invalidAddress = undefined as unknown as Hex;
+    const { adapter, mocks } = setup();
+
+    const error = await getThrownError(async () =>
+      adapter.signPersonalMessage(invalidAddress, '0xdeadbeef' as Hex),
+    );
+
+    expect(error).toBeInstanceOf(EthKeyringV1AccountNotFoundError);
+    assertInstanceOf(error, EthKeyringV1AccountNotFoundError);
+    expect(error.address).toBe(invalidAddress);
+    expect(mocks.submitRequest).not.toHaveBeenCalled();
+  });
+
+  it('throws a typed error if the account does not support the requested method', async () => {
+    const { adapter, mocks } = setup({
+      accounts: [buildAccount({ methods: [EthMethod.PersonalSign] })],
+    });
+
+    const error = await getThrownError(async () =>
+      adapter.signTransaction(
+        ACCOUNT_ADDRESS as Hex,
+        createTransaction({ to: ACCOUNT_ADDRESS }),
+      ),
+    );
+
+    expect(error).toBeInstanceOf(EthKeyringV1MethodNotSupportedError);
+    assertInstanceOf(error, EthKeyringV1MethodNotSupportedError);
+    expect(error.address).toBe(ACCOUNT_ADDRESS);
+    expect(error.method).toBe(EthMethod.SignTransaction);
+    expect(mocks.submitRequest).not.toHaveBeenCalled();
+  });
+
+  it('uses one adapter for multiple accounts with different supported methods', async () => {
+    const personalSignAccount = buildAccount({
+      methods: [EthMethod.PersonalSign],
+    });
+    const signAccount = buildAccount({
+      id: OTHER_ACCOUNT_ID,
+      address: OTHER_ACCOUNT_ADDRESS,
+      methods: [EthMethod.Sign],
+    });
+    const { adapter, mocks } = setup({
+      accounts: [personalSignAccount, signAccount],
+      submitRequestResult: '0xsigned',
+    });
+
+    expect(
+      await adapter.signPersonalMessage(
+        ACCOUNT_ADDRESS as Hex,
+        '0xdeadbeef' as Hex,
+      ),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(mocks, {
+      account: personalSignAccount,
+      method: EthMethod.PersonalSign,
+      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+    });
+
+    expect(
+      await adapter.signMessage(OTHER_ACCOUNT_ADDRESS as Hex, '0xfeed'),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(mocks, {
+      account: signAccount,
+      method: EthMethod.Sign,
+      params: [OTHER_ACCOUNT_ADDRESS, '0xfeed'],
+    });
+  });
+
+  it('submits a transaction signing request', async () => {
+    const transactionData: TypedTxData = {
+      data: '0x',
+      gasLimit: '0x5208',
+      gasPrice: '0x1',
+      nonce: '0x0',
+      to: OTHER_ACCOUNT_ADDRESS,
+      value: '0x1',
+      chainId: '0x1',
+      type: '0x0',
+    };
+    const signature = {
+      r: '0x0' as Hex,
+      s: '0x0' as Hex,
+      v: '0x27' as Hex,
+    };
+    const keyringResponse = {
+      ...signature,
+      to: ACCOUNT_ADDRESS,
+      value: '0x2',
+    };
+    const transaction = createTransaction(transactionData);
+    const submittedTransaction = {
+      ...transaction.toJSON(),
+      from: ACCOUNT_ADDRESS as Hex,
+      type: '0x0' as Hex,
+      chainId: '0x1' as Hex,
+    };
+    const expectedSignedTransaction = TransactionFactory.fromTxData({
+      ...submittedTransaction,
+      ...signature,
+    });
+    const { accounts, adapter, mocks } = setup({
+      submitRequestResult: keyringResponse,
+    });
+
+    expect(
+      await adapter.signTransaction(ACCOUNT_ADDRESS as Hex, transaction),
+    ).toStrictEqual(expectedSignedTransaction);
+
+    expectLastSubmitRequest(mocks, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.SignTransaction,
+      params: [submittedTransaction],
+      scope: EthScope.Mainnet,
+    });
+  });
+
+  it('submits ETH signing requests', async () => {
+    const { accounts, adapter, mocks } = setup({
+      submitRequestResult: '0xsigned',
+    });
+    const authorization: [
+      chainId: number,
+      contractAddress: Hex,
+      nonce: number,
+    ] = [1, ACCOUNT_ADDRESS as Hex, 2];
+    const account = accounts[0] as KeyringAccount;
+
+    expect(
+      await adapter.signMessage(ACCOUNT_ADDRESS as Hex, '0xdeadbeef'),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(mocks, {
+      account,
+      method: EthMethod.Sign,
+      params: [ACCOUNT_ADDRESS, '0xdeadbeef'],
+    });
+
+    expect(
+      await adapter.signEip7702Authorization(
+        ACCOUNT_ADDRESS as Hex,
+        authorization,
+      ),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(mocks, {
+      account,
+      method: EthKeyringMethod.SignEip7702Authorization,
+      params: [authorization],
+    });
+
+    expect(
+      await adapter.signPersonalMessage(
+        ACCOUNT_ADDRESS as Hex,
+        '0xdeadbeef' as Hex,
+      ),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(mocks, {
+      account,
+      method: EthMethod.PersonalSign,
+      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+    });
+  });
+
+  it('uses the default origin and EOA scope when submitting requests', async () => {
+    const account = buildAccount({
+      methods: [EthMethod.PersonalSign],
+      scopes: [],
+    });
+    const { adapter, mocks } = setup({
+      accounts: [account],
+      submitRequestResult: '0xsigned',
+    });
+
+    await adapter.signPersonalMessage(
+      ACCOUNT_ADDRESS as Hex,
+      '0xdeadbeef' as Hex,
+    );
+
+    expect(mocks.submitRequest).toHaveBeenCalledTimes(1);
+    expectLastSubmitRequest(mocks, {
+      account,
+      method: EthMethod.PersonalSign,
+      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+    });
+  });
+
+  it('uses the configured origin when submitting requests', async () => {
+    const { accounts, adapter, mocks } = setup({
+      origin: APP_ORIGIN,
+      submitRequestResult: '0xsigned',
+    });
+
+    await adapter.signPersonalMessage(
+      ACCOUNT_ADDRESS as Hex,
+      '0xdeadbeef' as Hex,
+    );
+
+    expect(mocks.submitRequest).toHaveBeenCalledTimes(1);
+    expectLastSubmitRequest(mocks, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.PersonalSign,
+      origin: APP_ORIGIN,
+      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+    });
+  });
+
+  it.each([
+    ['without options', undefined, EthMethod.SignTypedDataV1],
+    ['with V1', SignTypedDataVersion.V1, EthMethod.SignTypedDataV1],
+    ['with V3', SignTypedDataVersion.V3, EthMethod.SignTypedDataV3],
+    ['with V4', SignTypedDataVersion.V4, EthMethod.SignTypedDataV4],
+  ])(
+    'submits a typed data signing request %s',
+    async (_label, version, method) => {
+      const typedData = { message: 'hello' };
+      const { accounts, adapter, mocks } = setup({
+        submitRequestResult: '0xtyped',
+      });
+
+      expect(
+        await adapter.signTypedData(
+          ACCOUNT_ADDRESS as Hex,
+          typedData,
+          version === undefined ? undefined : { version },
+        ),
+      ).toBe('0xtyped');
+      expectLastSubmitRequest(mocks, {
+        account: accounts[0] as KeyringAccount,
+        method,
+        params: [ACCOUNT_ADDRESS, typedData],
+      });
+    },
+  );
+
+  it('throws a typed error if the requested typed data version is not supported by the account', async () => {
+    const { adapter, mocks } = setup({
+      accounts: [buildAccount({ methods: [EthMethod.SignTypedDataV1] })],
+    });
+
+    const error = await getThrownError(async () =>
+      adapter.signTypedData(
+        ACCOUNT_ADDRESS as Hex,
+        { message: 'hello' },
+        { version: SignTypedDataVersion.V4 },
+      ),
+    );
+
+    expect(error).toBeInstanceOf(EthKeyringV1MethodNotSupportedError);
+    assertInstanceOf(error, EthKeyringV1MethodNotSupportedError);
+    expect(error.address).toBe(ACCOUNT_ADDRESS);
+    expect(error.method).toBe(EthMethod.SignTypedDataV4);
+    expect(mocks.submitRequest).not.toHaveBeenCalled();
+  });
+
+  it('submits a user operation preparation request', async () => {
+    const { accounts, adapter, mocks } = setup();
+    const transactions: EthBaseTransaction[] = [
+      {
+        to: OTHER_ACCOUNT_ADDRESS,
+        value: '0x0',
+        data: '0x',
+      },
+      {
+        to: ACCOUNT_ADDRESS,
+        value: '0x1',
+        data: '0x1234',
+      },
+    ];
+    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
+    const baseUserOperation: EthBaseUserOperation = {
+      nonce: '0x1',
+      initCode: '0x',
+      callData: '0x1234',
+      gasLimits: {
+        callGasLimit: '0x1',
+        verificationGasLimit: '0x2',
+        preVerificationGas: '0x3',
+      },
+      dummyPaymasterAndData: '0x',
+      dummySignature: '0x',
+      bundlerUrl: 'https://bundler.example.com/rpc',
+    };
+
+    mocks.submitRequest.mockResolvedValueOnce(
+      baseUserOperation as unknown as Json,
+    );
+    expect(
+      await adapter.prepareUserOperation(
+        ACCOUNT_ADDRESS,
+        transactions,
+        executionContext,
+      ),
+    ).toBe(baseUserOperation);
+    expectLastSubmitRequest(mocks, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.PrepareUserOperation,
+      params: transactions,
+      scope: 'eip155:0x1',
+    });
+  });
+
+  it('submits a user operation patch request', async () => {
+    const { accounts, adapter, mocks } = setup();
+    const userOperation = createUserOperation();
+    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
+    const patch: EthUserOperationPatch = {
+      paymasterAndData: '0x1234',
+      callGasLimit: '0x1',
+    };
+
+    mocks.submitRequest.mockResolvedValueOnce(patch as unknown as Json);
+    expect(
+      await adapter.patchUserOperation(
+        ACCOUNT_ADDRESS,
+        userOperation,
+        executionContext,
+      ),
+    ).toBe(patch);
+    expectLastSubmitRequest(mocks, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.PatchUserOperation,
+      params: [userOperation],
+      scope: 'eip155:0x1',
+    });
+  });
+
+  it('submits a user operation signing request', async () => {
+    const { accounts, adapter, mocks } = setup();
+    const userOperation = createUserOperation();
+    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
+
+    mocks.submitRequest.mockResolvedValueOnce('0xsignature');
+    expect(
+      await adapter.signUserOperation(
+        ACCOUNT_ADDRESS,
+        userOperation,
+        executionContext,
+      ),
+    ).toBe('0xsignature');
+    expectLastSubmitRequest(mocks, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.SignUserOperation,
+      params: [userOperation],
+      scope: 'eip155:0x1',
+    });
+  });
+});

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
@@ -1,0 +1,623 @@
+import type { TypedTransaction, TypedTxData } from '@ethereumjs/tx';
+import { TransactionFactory } from '@ethereumjs/tx';
+import { SignTypedDataVersion } from '@metamask/eth-sig-util';
+import { EthAccountType, EthMethod, EthScope } from '@metamask/keyring-api';
+import type {
+  EthBaseTransaction,
+  EthBaseUserOperation,
+  EthUserOperation,
+  EthUserOperationPatch,
+  KeyringAccount,
+  KeyringExecutionContext,
+  KeyringRequest,
+} from '@metamask/keyring-api';
+import {
+  AccountExportType,
+  KeyringType,
+  PrivateKeyEncoding,
+} from '@metamask/keyring-api/v2';
+import type { Keyring as KeyringV2 } from '@metamask/keyring-api/v2';
+import type { Hex, Json } from '@metamask/utils';
+
+import {
+  EthKeyringV1AccountNotFoundError,
+  EthKeyringV1Adapter,
+  EthKeyringV1MethodNotSupportedError,
+} from './eth-keyring-v1-adapter';
+import { EthKeyringMethod } from './eth-keyring-wrapper';
+
+const ACCOUNT_ADDRESS = '0x660265edc169bab511a40c0e049cc1e33774443d';
+const ACCOUNT_ID = 'mock-account-id';
+const OTHER_ACCOUNT_ADDRESS = '0x96a3a7898f0072d03cf76c91e8a11da5b03653c8';
+const OTHER_ACCOUNT_ID = 'mock-other-account-id';
+const UNKNOWN_ACCOUNT_ADDRESS = '0x9c6f1a77f5d6dbecc927bc9f1d5c1f4a10f23df9';
+const APP_ORIGIN = 'https://metamask.github.io';
+const DEFAULT_ORIGIN = 'metamask';
+
+const ALL_SUPPORTED_METHODS = [
+  EthMethod.SignTransaction,
+  EthMethod.Sign,
+  EthKeyringMethod.SignEip7702Authorization,
+  EthMethod.PersonalSign,
+  EthMethod.SignTypedDataV1,
+  EthMethod.SignTypedDataV3,
+  EthMethod.SignTypedDataV4,
+  EthMethod.PrepareUserOperation,
+  EthMethod.PatchUserOperation,
+  EthMethod.SignUserOperation,
+];
+
+type BuildAdapterOptions = {
+  accounts?: KeyringAccount[];
+  exportedPrivateKey?: string;
+  includeExportAccount?: boolean;
+  origin?: string;
+  submitRequestResult?: Json;
+};
+
+type BuildAdapterResult = {
+  accounts: KeyringAccount[];
+  adapter: EthKeyringV1Adapter;
+  exportAccount: ExportAccountMock | undefined;
+  keyring: KeyringV2;
+  submitRequest: SubmitRequestMock;
+};
+
+type ExportAccount = NonNullable<KeyringV2['exportAccount']>;
+type ExportAccountMock = jest.Mock<
+  ReturnType<ExportAccount>,
+  Parameters<ExportAccount>
+>;
+type SubmitRequest = KeyringV2['submitRequest'];
+type SubmitRequestMock = jest.Mock<
+  ReturnType<SubmitRequest>,
+  Parameters<SubmitRequest>
+>;
+
+describe('EthKeyringV1Adapter', () => {
+  it('exposes the base ETH keyring methods', () => {
+    const { adapter } = buildAdapter({ includeExportAccount: false });
+
+    expect(adapter.exportAccount).toStrictEqual(expect.any(Function));
+    expect(adapter.signTransaction).toStrictEqual(expect.any(Function));
+    expect(adapter.signMessage).toStrictEqual(expect.any(Function));
+    expect(adapter.signEip7702Authorization).toStrictEqual(
+      expect.any(Function),
+    );
+    expect(adapter.signPersonalMessage).toStrictEqual(expect.any(Function));
+    expect(adapter.signTypedData).toStrictEqual(expect.any(Function));
+    expect(adapter.prepareUserOperation).toStrictEqual(expect.any(Function));
+    expect(adapter.patchUserOperation).toStrictEqual(expect.any(Function));
+    expect(adapter.signUserOperation).toStrictEqual(expect.any(Function));
+    expect(
+      (adapter as unknown as { getEncryptionPublicKey?: unknown })
+        .getEncryptionPublicKey,
+    ).toBeUndefined();
+  });
+
+  it('exports a private key through the v2 keyring', async () => {
+    const account = buildAccount();
+    const { adapter, exportAccount } = buildAdapter({
+      accounts: [account],
+      exportedPrivateKey: '0xabc123',
+    });
+
+    expect(await adapter.exportAccount(ACCOUNT_ADDRESS as Hex)).toBe('abc123');
+
+    expect(exportAccount).toHaveBeenCalledWith(account.id, {
+      type: AccountExportType.PrivateKey,
+      encoding: PrivateKeyEncoding.Hexadecimal,
+    });
+  });
+
+  it('throws a non-typed unsupported export error if the v2 keyring does not support exporting', async () => {
+    const { adapter } = buildAdapter({ includeExportAccount: false });
+
+    const error = await getThrownError(async () =>
+      adapter.exportAccount(ACCOUNT_ADDRESS as Hex),
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(EthKeyringV1AccountNotFoundError);
+    expect(error).not.toBeInstanceOf(EthKeyringV1MethodNotSupportedError);
+    expect((error as Error).message).toBe(
+      'Keyring does not support exportAccount',
+    );
+  });
+
+  it('throws a typed error if no account matches the requested address', async () => {
+    const { adapter, submitRequest } = buildAdapter();
+
+    const error = await getThrownError(async () =>
+      adapter.signPersonalMessage(
+        UNKNOWN_ACCOUNT_ADDRESS as Hex,
+        '0xdeadbeef' as Hex,
+      ),
+    );
+
+    expect(error).toBeInstanceOf(EthKeyringV1AccountNotFoundError);
+    assertInstanceOf(error, EthKeyringV1AccountNotFoundError);
+    expect(error.address).toBe(UNKNOWN_ACCOUNT_ADDRESS);
+    expect(submitRequest).not.toHaveBeenCalled();
+  });
+
+  it('throws a typed error if the requested address cannot be normalized', async () => {
+    const invalidAddress = undefined as unknown as Hex;
+    const { adapter, submitRequest } = buildAdapter();
+
+    const error = await getThrownError(async () =>
+      adapter.signPersonalMessage(invalidAddress, '0xdeadbeef' as Hex),
+    );
+
+    expect(error).toBeInstanceOf(EthKeyringV1AccountNotFoundError);
+    assertInstanceOf(error, EthKeyringV1AccountNotFoundError);
+    expect(error.address).toBe(invalidAddress);
+    expect(submitRequest).not.toHaveBeenCalled();
+  });
+
+  it('throws a typed error if the account does not support the requested method', async () => {
+    const { adapter, submitRequest } = buildAdapter({
+      accounts: [buildAccount({ methods: [EthMethod.PersonalSign] })],
+    });
+
+    const error = await getThrownError(async () =>
+      adapter.signTransaction(
+        ACCOUNT_ADDRESS as Hex,
+        createTransaction({ to: ACCOUNT_ADDRESS }),
+      ),
+    );
+
+    expect(error).toBeInstanceOf(EthKeyringV1MethodNotSupportedError);
+    assertInstanceOf(error, EthKeyringV1MethodNotSupportedError);
+    expect(error.address).toBe(ACCOUNT_ADDRESS);
+    expect(error.method).toBe(EthMethod.SignTransaction);
+    expect(submitRequest).not.toHaveBeenCalled();
+  });
+
+  it('uses one adapter for multiple accounts with different supported methods', async () => {
+    const personalSignAccount = buildAccount({
+      methods: [EthMethod.PersonalSign],
+    });
+    const signAccount = buildAccount({
+      id: OTHER_ACCOUNT_ID,
+      address: OTHER_ACCOUNT_ADDRESS,
+      methods: [EthMethod.Sign],
+    });
+    const { adapter, submitRequest } = buildAdapter({
+      accounts: [personalSignAccount, signAccount],
+      submitRequestResult: '0xsigned',
+    });
+
+    expect(
+      await adapter.signPersonalMessage(
+        ACCOUNT_ADDRESS as Hex,
+        '0xdeadbeef' as Hex,
+      ),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(submitRequest, {
+      account: personalSignAccount,
+      method: EthMethod.PersonalSign,
+      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+    });
+
+    expect(
+      await adapter.signMessage(OTHER_ACCOUNT_ADDRESS as Hex, '0xfeed'),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(submitRequest, {
+      account: signAccount,
+      method: EthMethod.Sign,
+      params: [OTHER_ACCOUNT_ADDRESS, '0xfeed'],
+    });
+  });
+
+  it('submits a transaction signing request', async () => {
+    const transactionData: TypedTxData = {
+      data: '0x',
+      gasLimit: '0x5208',
+      gasPrice: '0x1',
+      nonce: '0x0',
+      to: OTHER_ACCOUNT_ADDRESS,
+      value: '0x1',
+      chainId: '0x1',
+      type: '0x0',
+    };
+    const signature = {
+      r: '0x0' as Hex,
+      s: '0x0' as Hex,
+      v: '0x27' as Hex,
+    };
+    const keyringResponse = {
+      ...signature,
+      to: ACCOUNT_ADDRESS,
+      value: '0x2',
+    };
+    const transaction = createTransaction(transactionData);
+    const submittedTransaction = {
+      ...transaction.toJSON(),
+      from: ACCOUNT_ADDRESS as Hex,
+      type: '0x0' as Hex,
+      chainId: '0x1' as Hex,
+    };
+    const expectedSignedTransaction = TransactionFactory.fromTxData({
+      ...submittedTransaction,
+      ...signature,
+    });
+    const { accounts, adapter, submitRequest } = buildAdapter({
+      submitRequestResult: keyringResponse,
+    });
+
+    expect(
+      await adapter.signTransaction(ACCOUNT_ADDRESS as Hex, transaction),
+    ).toStrictEqual(expectedSignedTransaction);
+
+    expectLastSubmitRequest(submitRequest, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.SignTransaction,
+      params: [submittedTransaction],
+      scope: EthScope.Mainnet,
+    });
+  });
+
+  it('submits ETH signing requests', async () => {
+    const { accounts, adapter, submitRequest } = buildAdapter({
+      submitRequestResult: '0xsigned',
+    });
+    const authorization: [
+      chainId: number,
+      contractAddress: Hex,
+      nonce: number,
+    ] = [1, ACCOUNT_ADDRESS as Hex, 2];
+    const account = accounts[0] as KeyringAccount;
+
+    expect(
+      await adapter.signMessage(ACCOUNT_ADDRESS as Hex, '0xdeadbeef'),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(submitRequest, {
+      account,
+      method: EthMethod.Sign,
+      params: [ACCOUNT_ADDRESS, '0xdeadbeef'],
+    });
+
+    expect(
+      await adapter.signEip7702Authorization(
+        ACCOUNT_ADDRESS as Hex,
+        authorization,
+      ),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(submitRequest, {
+      account,
+      method: EthKeyringMethod.SignEip7702Authorization,
+      params: [authorization],
+    });
+
+    expect(
+      await adapter.signPersonalMessage(
+        ACCOUNT_ADDRESS as Hex,
+        '0xdeadbeef' as Hex,
+      ),
+    ).toBe('0xsigned');
+    expectLastSubmitRequest(submitRequest, {
+      account,
+      method: EthMethod.PersonalSign,
+      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+    });
+  });
+
+  it('uses the default origin and EOA scope when submitting requests', async () => {
+    const account = buildAccount({
+      methods: [EthMethod.PersonalSign],
+      scopes: [],
+    });
+    const { adapter, submitRequest } = buildAdapter({
+      accounts: [account],
+      submitRequestResult: '0xsigned',
+    });
+
+    await adapter.signPersonalMessage(
+      ACCOUNT_ADDRESS as Hex,
+      '0xdeadbeef' as Hex,
+    );
+
+    expect(submitRequest).toHaveBeenCalledTimes(1);
+    expectLastSubmitRequest(submitRequest, {
+      account,
+      method: EthMethod.PersonalSign,
+      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+    });
+  });
+
+  it('uses the configured origin when submitting requests', async () => {
+    const { accounts, adapter, submitRequest } = buildAdapter({
+      origin: APP_ORIGIN,
+      submitRequestResult: '0xsigned',
+    });
+
+    await adapter.signPersonalMessage(
+      ACCOUNT_ADDRESS as Hex,
+      '0xdeadbeef' as Hex,
+    );
+
+    expect(submitRequest).toHaveBeenCalledTimes(1);
+    expectLastSubmitRequest(submitRequest, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.PersonalSign,
+      origin: APP_ORIGIN,
+      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+    });
+  });
+
+  it.each([
+    ['without options', undefined, EthMethod.SignTypedDataV1],
+    ['with V1', SignTypedDataVersion.V1, EthMethod.SignTypedDataV1],
+    ['with V3', SignTypedDataVersion.V3, EthMethod.SignTypedDataV3],
+    ['with V4', SignTypedDataVersion.V4, EthMethod.SignTypedDataV4],
+  ])(
+    'submits a typed data signing request %s',
+    async (_label, version, method) => {
+      const typedData = { message: 'hello' };
+      const { accounts, adapter, submitRequest } = buildAdapter({
+        submitRequestResult: '0xtyped',
+      });
+
+      expect(
+        await adapter.signTypedData(
+          ACCOUNT_ADDRESS as Hex,
+          typedData,
+          version === undefined ? undefined : { version },
+        ),
+      ).toBe('0xtyped');
+      expectLastSubmitRequest(submitRequest, {
+        account: accounts[0] as KeyringAccount,
+        method,
+        params: [ACCOUNT_ADDRESS, typedData],
+      });
+    },
+  );
+
+  it('throws a typed error if the requested typed data version is not supported by the account', async () => {
+    const { adapter, submitRequest } = buildAdapter({
+      accounts: [buildAccount({ methods: [EthMethod.SignTypedDataV1] })],
+    });
+
+    const error = await getThrownError(async () =>
+      adapter.signTypedData(
+        ACCOUNT_ADDRESS as Hex,
+        { message: 'hello' },
+        { version: SignTypedDataVersion.V4 },
+      ),
+    );
+
+    expect(error).toBeInstanceOf(EthKeyringV1MethodNotSupportedError);
+    assertInstanceOf(error, EthKeyringV1MethodNotSupportedError);
+    expect(error.address).toBe(ACCOUNT_ADDRESS);
+    expect(error.method).toBe(EthMethod.SignTypedDataV4);
+    expect(submitRequest).not.toHaveBeenCalled();
+  });
+
+  it('submits a user operation preparation request', async () => {
+    const { accounts, adapter, submitRequest } = buildAdapter();
+    const transactions: EthBaseTransaction[] = [
+      {
+        to: OTHER_ACCOUNT_ADDRESS,
+        value: '0x0',
+        data: '0x',
+      },
+      {
+        to: ACCOUNT_ADDRESS,
+        value: '0x1',
+        data: '0x1234',
+      },
+    ];
+    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
+    const baseUserOperation: EthBaseUserOperation = {
+      nonce: '0x1',
+      initCode: '0x',
+      callData: '0x1234',
+      gasLimits: {
+        callGasLimit: '0x1',
+        verificationGasLimit: '0x2',
+        preVerificationGas: '0x3',
+      },
+      dummyPaymasterAndData: '0x',
+      dummySignature: '0x',
+      bundlerUrl: 'https://bundler.example.com/rpc',
+    };
+
+    submitRequest.mockResolvedValueOnce(baseUserOperation as unknown as Json);
+    expect(
+      await adapter.prepareUserOperation(
+        ACCOUNT_ADDRESS,
+        transactions,
+        executionContext,
+      ),
+    ).toBe(baseUserOperation);
+    expectLastSubmitRequest(submitRequest, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.PrepareUserOperation,
+      params: transactions,
+      scope: 'eip155:0x1',
+    });
+  });
+
+  it('submits a user operation patch request', async () => {
+    const { accounts, adapter, submitRequest } = buildAdapter();
+    const userOperation = createUserOperation();
+    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
+    const patch: EthUserOperationPatch = {
+      paymasterAndData: '0x1234',
+      callGasLimit: '0x1',
+    };
+
+    submitRequest.mockResolvedValueOnce(patch as unknown as Json);
+    expect(
+      await adapter.patchUserOperation(
+        ACCOUNT_ADDRESS,
+        userOperation,
+        executionContext,
+      ),
+    ).toBe(patch);
+    expectLastSubmitRequest(submitRequest, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.PatchUserOperation,
+      params: [userOperation],
+      scope: 'eip155:0x1',
+    });
+  });
+
+  it('submits a user operation signing request', async () => {
+    const { accounts, adapter, submitRequest } = buildAdapter();
+    const userOperation = createUserOperation();
+    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
+
+    submitRequest.mockResolvedValueOnce('0xsignature');
+    expect(
+      await adapter.signUserOperation(
+        ACCOUNT_ADDRESS,
+        userOperation,
+        executionContext,
+      ),
+    ).toBe('0xsignature');
+    expectLastSubmitRequest(submitRequest, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.SignUserOperation,
+      params: [userOperation],
+      scope: 'eip155:0x1',
+    });
+  });
+});
+
+function buildAdapter({
+  accounts = [buildAccount()],
+  exportedPrivateKey = '0xabc123',
+  includeExportAccount = true,
+  origin,
+  submitRequestResult = 'request-result',
+}: BuildAdapterOptions = {}): BuildAdapterResult {
+  const serialize = jest.fn(async () => ({ serialized: true }));
+  const deserialize = jest.fn(async () => undefined);
+  const getAccounts = jest.fn(async () => accounts);
+  const getAccount = jest.fn(async (accountId: string) => {
+    const account = accounts.find(({ id }) => id === accountId);
+
+    if (!account) {
+      throw new Error(`Account not found: ${accountId}`);
+    }
+
+    return account;
+  });
+  const createAccounts = jest.fn(async () => []);
+  const deleteAccount = jest.fn(async () => undefined);
+  const submitRequest: SubmitRequestMock = jest.fn(
+    async (_request) => submitRequestResult,
+  );
+  const exportAccount: ExportAccountMock | undefined = includeExportAccount
+    ? jest.fn(async (_accountId, _options) => ({
+        type: AccountExportType.PrivateKey,
+        encoding: PrivateKeyEncoding.Hexadecimal,
+        privateKey: exportedPrivateKey,
+      }))
+    : undefined;
+  const keyring: KeyringV2 = {
+    type: KeyringType.Hd,
+    capabilities: {
+      scopes: [EthScope.Eoa],
+    },
+    serialize,
+    deserialize,
+    getAccounts,
+    getAccount,
+    createAccounts,
+    deleteAccount,
+    submitRequest,
+    ...(exportAccount === undefined ? {} : { exportAccount }),
+  };
+  const adapterOptions =
+    origin === undefined ? { keyring } : { keyring, origin };
+
+  return {
+    accounts,
+    adapter: new EthKeyringV1Adapter(adapterOptions),
+    exportAccount,
+    keyring,
+    submitRequest,
+  };
+}
+
+function buildAccount(overrides: Partial<KeyringAccount> = {}): KeyringAccount {
+  return {
+    id: ACCOUNT_ID,
+    type: EthAccountType.Eoa,
+    address: ACCOUNT_ADDRESS,
+    scopes: [EthScope.Eoa],
+    methods: [...ALL_SUPPORTED_METHODS],
+    options: {},
+    ...overrides,
+  };
+}
+
+function createTransaction(transactionData: TypedTxData): TypedTransaction {
+  return TransactionFactory.fromTxData(transactionData);
+}
+
+function createUserOperation(): EthUserOperation {
+  return {
+    sender: ACCOUNT_ADDRESS,
+    nonce: '0x1',
+    initCode: '0x',
+    callData: '0x1234',
+    callGasLimit: '0x1',
+    verificationGasLimit: '0x2',
+    preVerificationGas: '0x3',
+    maxFeePerGas: '0x4',
+    maxPriorityFeePerGas: '0x5',
+    paymasterAndData: '0x',
+    signature: '0x',
+  };
+}
+
+async function getThrownError(
+  action: () => Promise<unknown>,
+): Promise<unknown> {
+  try {
+    await action();
+  } catch (error) {
+    return error;
+  }
+
+  throw new Error('Expected action to throw');
+}
+
+function assertInstanceOf<ErrorType extends Error>(
+  error: unknown,
+  expectedError: new (...args: never[]) => ErrorType,
+): asserts error is ErrorType {
+  if (!(error instanceof expectedError)) {
+    throw new Error(`Expected error to be ${expectedError.name}`);
+  }
+}
+
+function expectLastSubmitRequest(
+  submitRequest: SubmitRequestMock,
+  {
+    account,
+    method,
+    origin = DEFAULT_ORIGIN,
+    params,
+    scope = EthScope.Eoa,
+  }: {
+    account: KeyringAccount;
+    method: string;
+    origin?: string;
+    params: KeyringRequest['request']['params'];
+    scope?: string;
+  },
+): void {
+  expect(submitRequest).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      account: account.id,
+      origin,
+      request: { method, params },
+      scope,
+    }),
+  );
+}

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
@@ -565,29 +565,35 @@ describe('EthKeyringV1Adapter', () => {
     },
   );
 
-  it('uses the typed data domain chain ID as the signing scope', async () => {
-    const typedData = {
-      domain: {
-        chainId: 1,
-      },
-      message: 'hello',
-    };
-    const { accounts, adapter, mocks } = setup({
-      submitRequestResult: '0x1234',
-    });
+  it.each([
+    ['number', 1],
+    ['hex string', '0x1'],
+  ])(
+    'uses the typed data domain chain ID as the signing scope when it is a %s',
+    async (_label, chainId) => {
+      const typedData = {
+        domain: {
+          chainId,
+        },
+        message: 'hello',
+      };
+      const { accounts, adapter, mocks } = setup({
+        submitRequestResult: '0x1234',
+      });
 
-    expect(
-      await adapter.signTypedData(ACCOUNT_ADDRESS as Hex, typedData, {
-        version: SignTypedDataVersion.V4,
-      }),
-    ).toBe('0x1234');
-    expectLastSubmitRequest(mocks, {
-      account: accounts[0] as KeyringAccount,
-      method: EthMethod.SignTypedDataV4,
-      params: [ACCOUNT_ADDRESS, typedData],
-      scope: EthScope.Mainnet,
-    });
-  });
+      expect(
+        await adapter.signTypedData(ACCOUNT_ADDRESS as Hex, typedData, {
+          version: SignTypedDataVersion.V4,
+        }),
+      ).toBe('0x1234');
+      expectLastSubmitRequest(mocks, {
+        account: accounts[0] as KeyringAccount,
+        method: EthMethod.SignTypedDataV4,
+        params: [ACCOUNT_ADDRESS, typedData],
+        scope: EthScope.Mainnet,
+      });
+    },
+  );
 
   it('throws a typed error if the requested typed data version is not supported by the account', async () => {
     const { adapter, mocks } = setup({
@@ -650,7 +656,7 @@ describe('EthKeyringV1Adapter', () => {
       account: accounts[0] as KeyringAccount,
       method: EthMethod.PrepareUserOperation,
       params: transactions,
-      scope: 'eip155:0x1',
+      scope: EthScope.Mainnet,
     });
   });
 
@@ -678,7 +684,7 @@ describe('EthKeyringV1Adapter', () => {
       account: accounts[0] as KeyringAccount,
       method: EthMethod.PatchUserOperation,
       params: [createUserOperation()],
-      scope: 'eip155:0x1',
+      scope: EthScope.Mainnet,
     });
   });
 
@@ -699,7 +705,7 @@ describe('EthKeyringV1Adapter', () => {
       account: accounts[0] as KeyringAccount,
       method: EthMethod.SignUserOperation,
       params: [userOperation],
-      scope: 'eip155:0x1',
+      scope: EthScope.Mainnet,
     });
   });
 

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
@@ -163,6 +163,22 @@ function createUserOperation(): EthUserOperation {
   };
 }
 
+function createBaseUserOperation(): EthBaseUserOperation {
+  return {
+    nonce: '0x1',
+    initCode: '0x',
+    callData: '0x1234',
+    gasLimits: {
+      callGasLimit: '0x1',
+      verificationGasLimit: '0x2',
+      preVerificationGas: '0x3',
+    },
+    dummyPaymasterAndData: '0x',
+    dummySignature: '0x',
+    bundlerUrl: 'https://bundler.example.com/rpc',
+  };
+}
+
 async function getThrownError(
   action: () => Promise<unknown>,
 ): Promise<unknown> {
@@ -320,7 +336,7 @@ describe('EthKeyringV1Adapter', () => {
     });
     const { adapter, mocks } = setup({
       accounts: [personalSignAccount, signAccount],
-      submitRequestResult: '0xsigned',
+      submitRequestResult: '0x1234',
     });
 
     expect(
@@ -328,20 +344,22 @@ describe('EthKeyringV1Adapter', () => {
         ACCOUNT_ADDRESS as Hex,
         '0xdeadbeef' as Hex,
       ),
-    ).toBe('0xsigned');
+    ).toBe('0x1234');
     expectLastSubmitRequest(mocks, {
       account: personalSignAccount,
       method: EthMethod.PersonalSign,
       params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+      scope: '',
     });
 
     expect(
       await adapter.signMessage(OTHER_ACCOUNT_ADDRESS as Hex, '0xfeed'),
-    ).toBe('0xsigned');
+    ).toBe('0x1234');
     expectLastSubmitRequest(mocks, {
       account: signAccount,
       method: EthMethod.Sign,
       params: [OTHER_ACCOUNT_ADDRESS, '0xfeed'],
+      scope: '',
     });
   });
 
@@ -395,7 +413,7 @@ describe('EthKeyringV1Adapter', () => {
 
   it('submits ETH signing requests', async () => {
     const { accounts, adapter, mocks } = setup({
-      submitRequestResult: '0xsigned',
+      submitRequestResult: '0x1234',
     });
     const authorization: [
       chainId: number,
@@ -406,11 +424,12 @@ describe('EthKeyringV1Adapter', () => {
 
     expect(
       await adapter.signMessage(ACCOUNT_ADDRESS as Hex, '0xdeadbeef'),
-    ).toBe('0xsigned');
+    ).toBe('0x1234');
     expectLastSubmitRequest(mocks, {
       account,
       method: EthMethod.Sign,
       params: [ACCOUNT_ADDRESS, '0xdeadbeef'],
+      scope: '',
     });
 
     expect(
@@ -418,7 +437,7 @@ describe('EthKeyringV1Adapter', () => {
         ACCOUNT_ADDRESS as Hex,
         authorization,
       ),
-    ).toBe('0xsigned');
+    ).toBe('0x1234');
     expectLastSubmitRequest(mocks, {
       account,
       method: EthKeyringMethod.SignEip7702Authorization,
@@ -430,22 +449,23 @@ describe('EthKeyringV1Adapter', () => {
         ACCOUNT_ADDRESS as Hex,
         '0xdeadbeef' as Hex,
       ),
-    ).toBe('0xsigned');
+    ).toBe('0x1234');
     expectLastSubmitRequest(mocks, {
       account,
       method: EthMethod.PersonalSign,
       params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+      scope: '',
     });
   });
 
-  it('uses the default origin and EOA scope when submitting requests', async () => {
+  it('uses the default origin and empty scope when submitting signing requests', async () => {
     const account = buildAccount({
       methods: [EthMethod.PersonalSign],
       scopes: [],
     });
     const { adapter, mocks } = setup({
       accounts: [account],
-      submitRequestResult: '0xsigned',
+      submitRequestResult: '0x1234',
     });
 
     await adapter.signPersonalMessage(
@@ -458,13 +478,14 @@ describe('EthKeyringV1Adapter', () => {
       account,
       method: EthMethod.PersonalSign,
       params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+      scope: '',
     });
   });
 
   it('uses the configured origin when submitting requests', async () => {
     const { accounts, adapter, mocks } = setup({
       origin: APP_ORIGIN,
-      submitRequestResult: '0xsigned',
+      submitRequestResult: '0x1234',
     });
 
     await adapter.signPersonalMessage(
@@ -478,6 +499,7 @@ describe('EthKeyringV1Adapter', () => {
       method: EthMethod.PersonalSign,
       origin: APP_ORIGIN,
       params: ['0xdeadbeef', ACCOUNT_ADDRESS],
+      scope: '',
     });
   });
 
@@ -489,9 +511,10 @@ describe('EthKeyringV1Adapter', () => {
   ])(
     'submits a typed data signing request %s',
     async (_label, version, method) => {
-      const typedData = { message: 'hello' };
+      const typedData = { message: 'hello', ignored: undefined };
+      const submittedTypedData = { message: 'hello' };
       const { accounts, adapter, mocks } = setup({
-        submitRequestResult: '0xtyped',
+        submitRequestResult: '0x1234',
       });
 
       expect(
@@ -500,14 +523,39 @@ describe('EthKeyringV1Adapter', () => {
           typedData,
           version === undefined ? undefined : { version },
         ),
-      ).toBe('0xtyped');
+      ).toBe('0x1234');
       expectLastSubmitRequest(mocks, {
         account: accounts[0] as KeyringAccount,
         method,
-        params: [ACCOUNT_ADDRESS, typedData],
+        params: [ACCOUNT_ADDRESS, submittedTypedData],
+        scope: '',
       });
     },
   );
+
+  it('uses the typed data domain chain ID as the signing scope', async () => {
+    const typedData = {
+      domain: {
+        chainId: 1,
+      },
+      message: 'hello',
+    };
+    const { accounts, adapter, mocks } = setup({
+      submitRequestResult: '0x1234',
+    });
+
+    expect(
+      await adapter.signTypedData(ACCOUNT_ADDRESS as Hex, typedData, {
+        version: SignTypedDataVersion.V4,
+      }),
+    ).toBe('0x1234');
+    expectLastSubmitRequest(mocks, {
+      account: accounts[0] as KeyringAccount,
+      method: EthMethod.SignTypedDataV4,
+      params: [ACCOUNT_ADDRESS, typedData],
+      scope: EthScope.Mainnet,
+    });
+  });
 
   it('throws a typed error if the requested typed data version is not supported by the account', async () => {
     const { adapter, mocks } = setup({
@@ -529,6 +577,16 @@ describe('EthKeyringV1Adapter', () => {
     expect(mocks.submitRequest).not.toHaveBeenCalled();
   });
 
+  it('throws if an ETH signing response is invalid', async () => {
+    const { adapter, mocks } = setup();
+
+    mocks.submitRequest.mockResolvedValueOnce('not-hex');
+
+    await expect(
+      adapter.signMessage(ACCOUNT_ADDRESS as Hex, '0xdeadbeef'),
+    ).rejects.toThrow('Expected a value of type');
+  });
+
   it('submits a user operation preparation request', async () => {
     const { accounts, adapter, mocks } = setup();
     const transactions: EthBaseTransaction[] = [
@@ -544,19 +602,7 @@ describe('EthKeyringV1Adapter', () => {
       },
     ];
     const executionContext: KeyringExecutionContext = { chainId: '0x1' };
-    const baseUserOperation: EthBaseUserOperation = {
-      nonce: '0x1',
-      initCode: '0x',
-      callData: '0x1234',
-      gasLimits: {
-        callGasLimit: '0x1',
-        verificationGasLimit: '0x2',
-        preVerificationGas: '0x3',
-      },
-      dummyPaymasterAndData: '0x',
-      dummySignature: '0x',
-      bundlerUrl: 'https://bundler.example.com/rpc',
-    };
+    const baseUserOperation = createBaseUserOperation();
 
     mocks.submitRequest.mockResolvedValueOnce(
       baseUserOperation as unknown as Json,
@@ -578,7 +624,10 @@ describe('EthKeyringV1Adapter', () => {
 
   it('submits a user operation patch request', async () => {
     const { accounts, adapter, mocks } = setup();
-    const userOperation = createUserOperation();
+    const userOperation = {
+      ...createUserOperation(),
+      ignored: undefined,
+    };
     const executionContext: KeyringExecutionContext = { chainId: '0x1' };
     const patch: EthUserOperationPatch = {
       paymasterAndData: '0x1234',
@@ -596,7 +645,7 @@ describe('EthKeyringV1Adapter', () => {
     expectLastSubmitRequest(mocks, {
       account: accounts[0] as KeyringAccount,
       method: EthMethod.PatchUserOperation,
-      params: [userOperation],
+      params: [createUserOperation()],
       scope: 'eip155:0x1',
     });
   });
@@ -606,19 +655,73 @@ describe('EthKeyringV1Adapter', () => {
     const userOperation = createUserOperation();
     const executionContext: KeyringExecutionContext = { chainId: '0x1' };
 
-    mocks.submitRequest.mockResolvedValueOnce('0xsignature');
+    mocks.submitRequest.mockResolvedValueOnce('0x1234');
     expect(
       await adapter.signUserOperation(
         ACCOUNT_ADDRESS,
         userOperation,
         executionContext,
       ),
-    ).toBe('0xsignature');
+    ).toBe('0x1234');
     expectLastSubmitRequest(mocks, {
       account: accounts[0] as KeyringAccount,
       method: EthMethod.SignUserOperation,
       params: [userOperation],
       scope: 'eip155:0x1',
     });
+  });
+
+  it('throws if a user operation preparation response is invalid', async () => {
+    const { adapter, mocks } = setup();
+    const transactions: EthBaseTransaction[] = [];
+    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
+
+    mocks.submitRequest.mockResolvedValueOnce({
+      ...createBaseUserOperation(),
+      extra: '0x',
+    } as unknown as Json);
+
+    await expect(
+      adapter.prepareUserOperation(
+        ACCOUNT_ADDRESS,
+        transactions,
+        executionContext,
+      ),
+    ).rejects.toThrow('Expected a value of type');
+  });
+
+  it('throws if a user operation patch response is invalid', async () => {
+    const { adapter, mocks } = setup();
+    const userOperation = createUserOperation();
+    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
+
+    mocks.submitRequest.mockResolvedValueOnce({
+      paymasterAndData: '0x1234',
+      extra: '0x',
+    } as unknown as Json);
+
+    await expect(
+      adapter.patchUserOperation(
+        ACCOUNT_ADDRESS,
+        userOperation,
+        executionContext,
+      ),
+    ).rejects.toThrow('Expected a value of type');
+  });
+
+  it('throws if a user operation signing response is invalid', async () => {
+    const { adapter, mocks } = setup();
+    const userOperation = createUserOperation();
+    const executionContext: KeyringExecutionContext = { chainId: '0x1' };
+
+    mocks.submitRequest.mockResolvedValueOnce('not-hex');
+
+    await expect(
+      adapter.signUserOperation(
+        ACCOUNT_ADDRESS,
+        userOperation,
+        executionContext,
+      ),
+    ).rejects.toThrow('Expected a value of type');
   });
 });

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
@@ -469,6 +469,7 @@ describe('EthKeyringV1Adapter', () => {
       account,
       method: EthKeyringMethod.SignEip7702Authorization,
       params: [authorization],
+      scope: EthScope.Mainnet,
     });
 
     expect(

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
@@ -33,8 +33,7 @@ const ACCOUNT_ID = 'mock-account-id';
 const OTHER_ACCOUNT_ADDRESS = '0x96a3a7898f0072d03cf76c91e8a11da5b03653c8';
 const OTHER_ACCOUNT_ID = 'mock-other-account-id';
 const UNKNOWN_ACCOUNT_ADDRESS = '0x9c6f1a77f5d6dbecc927bc9f1d5c1f4a10f23df9';
-const APP_ORIGIN = 'https://metamask.github.io';
-const DEFAULT_ORIGIN = 'metamask';
+const METAMASK_ORIGIN = 'metamask';
 
 const ALL_SUPPORTED_METHODS = [
   EthMethod.SignTransaction,
@@ -64,13 +63,11 @@ function setup({
   accounts = [buildAccount()],
   exportedPrivateKey = '0xabc123',
   includeExportAccount = true,
-  origin,
   submitRequestResult = 'request-result',
 }: {
   accounts?: KeyringAccount[];
   exportedPrivateKey?: string;
   includeExportAccount?: boolean;
-  origin?: string;
   submitRequestResult?: Json;
 } = {}): {
   accounts: KeyringAccount[];
@@ -119,12 +116,10 @@ function setup({
     submitRequest,
     ...(exportAccount === undefined ? {} : { exportAccount }),
   };
-  const adapterOptions =
-    origin === undefined ? { keyring } : { keyring, origin };
 
   return {
     accounts,
-    adapter: new EthKeyringV1Adapter(adapterOptions),
+    adapter: new EthKeyringV1Adapter(keyring),
     keyring,
     mocks: {
       exportAccount,
@@ -207,7 +202,7 @@ function expectLastSubmitRequest(
   {
     account,
     method,
-    origin = DEFAULT_ORIGIN,
+    origin = METAMASK_ORIGIN,
     params,
     scope = EthScope.Eoa,
   }: {
@@ -509,27 +504,6 @@ describe('EthKeyringV1Adapter', () => {
     expectLastSubmitRequest(mocks, {
       account,
       method: EthMethod.PersonalSign,
-      params: ['0xdeadbeef', ACCOUNT_ADDRESS],
-      scope: '',
-    });
-  });
-
-  it('uses the configured origin when submitting requests', async () => {
-    const { accounts, adapter, mocks } = setup({
-      origin: APP_ORIGIN,
-      submitRequestResult: '0x1234',
-    });
-
-    await adapter.signPersonalMessage(
-      ACCOUNT_ADDRESS as Hex,
-      '0xdeadbeef' as Hex,
-    );
-
-    expect(mocks.submitRequest).toHaveBeenCalledTimes(1);
-    expectLastSubmitRequest(mocks, {
-      account: accounts[0] as KeyringAccount,
-      method: EthMethod.PersonalSign,
-      origin: APP_ORIGIN,
       params: ['0xdeadbeef', ACCOUNT_ADDRESS],
       scope: '',
     });

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.test.ts
@@ -19,6 +19,8 @@ import {
 import type { Keyring as KeyringV2 } from '@metamask/keyring-api/v2';
 import type { Hex, Json } from '@metamask/utils';
 
+import { KeyringV1Adapter } from '../keyring-v1-adapter';
+import type { BaseEthKeyring } from './eth-keyring-v1-adapter';
 import {
   EthKeyringV1AccountNotFoundError,
   EthKeyringV1Adapter,
@@ -229,6 +231,10 @@ describe('EthKeyringV1Adapter', () => {
   it('exposes the base ETH keyring methods', () => {
     const { adapter } = setup({ includeExportAccount: false });
 
+    expect(adapter.getAccounts).toStrictEqual(expect.any(Function));
+    expect(adapter.serialize).toStrictEqual(expect.any(Function));
+    expect(adapter.deserialize).toStrictEqual(expect.any(Function));
+    expect(adapter.unwrap).toStrictEqual(expect.any(Function));
     expect(adapter.exportAccount).toStrictEqual(expect.any(Function));
     expect(adapter.signTransaction).toStrictEqual(expect.any(Function));
     expect(adapter.signMessage).toStrictEqual(expect.any(Function));
@@ -244,6 +250,32 @@ describe('EthKeyringV1Adapter', () => {
       (adapter as unknown as { getEncryptionPublicKey?: unknown })
         .getEncryptionPublicKey,
     ).toBeUndefined();
+  });
+
+  it('inherits generic v1 adapter behavior', async () => {
+    const account = buildAccount();
+    const otherAccount = buildAccount({
+      id: OTHER_ACCOUNT_ID,
+      address: OTHER_ACCOUNT_ADDRESS,
+    });
+    const { adapter, keyring } = setup({
+      accounts: [account, otherAccount],
+    });
+    const baseAdapter: BaseEthKeyring = adapter;
+    const state = { restored: true };
+
+    expect(adapter).toBeInstanceOf(KeyringV1Adapter);
+    expect(baseAdapter.type).toBe(KeyringType.Hd);
+    expect(adapter.unwrap()).toBe(keyring);
+    expect(await baseAdapter.getAccounts()).toStrictEqual([
+      ACCOUNT_ADDRESS,
+      OTHER_ACCOUNT_ADDRESS,
+    ]);
+    expect(await baseAdapter.serialize()).toStrictEqual({ serialized: true });
+
+    await baseAdapter.deserialize(state);
+
+    expect(keyring.deserialize).toHaveBeenCalledWith(state);
   });
 
   it('exports a private key through the v2 keyring', async () => {

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -1,0 +1,473 @@
+import type { TypedTransaction, TypedTxData } from '@ethereumjs/tx';
+import { TransactionFactory } from '@ethereumjs/tx';
+import type { SignTypedDataVersion } from '@metamask/eth-sig-util';
+import { normalize as ethNormalize } from '@metamask/eth-sig-util';
+import { EthMethod, EthScope } from '@metamask/keyring-api';
+import type {
+  EthBaseTransaction,
+  EthBaseUserOperation,
+  EthUserOperation,
+  EthUserOperationPatch,
+  KeyringAccount,
+  KeyringExecutionContext,
+  KeyringRequest,
+} from '@metamask/keyring-api';
+import type { Keyring as KeyringV2 } from '@metamask/keyring-api/v2';
+import {
+  AccountExportType,
+  PrivateKeyEncoding,
+} from '@metamask/keyring-api/v2';
+import type { EthKeyring } from '@metamask/keyring-utils';
+import { mask, object, string } from '@metamask/superstruct';
+import type { Hex, Json } from '@metamask/utils';
+import {
+  bigIntToHex,
+  KnownCaipNamespace,
+  remove0x,
+  toCaipChainId,
+} from '@metamask/utils';
+import { v4 as uuid } from 'uuid';
+
+import type { Eth4337Keyring } from '../../eth';
+import { EthKeyringMethod } from './eth-keyring-wrapper';
+
+const DEFAULT_ORIGIN = 'metamask';
+
+type RequestParams = NonNullable<KeyringRequest['request']['params']>;
+
+type ResolvedAccount = {
+  account: KeyringAccount;
+  normalizedAddress: Hex;
+};
+
+function toJson<Type extends Json = Json>(value: unknown): Type {
+  return JSON.parse(JSON.stringify(value)) as Type;
+}
+
+/**
+ * Legacy ETH keyring API surface exposed by {@link EthKeyringV1Adapter}.
+ */
+export type BaseEthKeyring = Pick<
+  EthKeyring,
+  | 'exportAccount'
+  | 'signMessage'
+  | 'signEip7702Authorization'
+  | 'signPersonalMessage'
+  | 'signTypedData'
+  | 'signTransaction'
+> & Eth4337Keyring;
+
+/**
+ * Error thrown when an account cannot be resolved from the requested address.
+ */
+export class EthKeyringV1AccountNotFoundError extends Error {
+  readonly address: string;
+
+  constructor(address: string) {
+    super(`Account not found for address: ${address}`);
+    this.name = 'EthKeyringV1AccountNotFoundError';
+    this.address = address;
+    Object.setPrototypeOf(this, EthKeyringV1AccountNotFoundError.prototype);
+  }
+}
+
+/**
+ * Error thrown when a resolved account does not support a requested method.
+ */
+export class EthKeyringV1MethodNotSupportedError extends Error {
+  readonly address: string;
+
+  readonly method: string;
+
+  constructor(method: string, address: string) {
+    super(`Account ${address} does not support method: ${method}`);
+    this.name = 'EthKeyringV1MethodNotSupportedError';
+    this.address = address;
+    this.method = method;
+    Object.setPrototypeOf(this, EthKeyringV1MethodNotSupportedError.prototype);
+  }
+}
+
+/**
+ * Adapts a `KeyringV2` instance to the subset of the legacy ETH keyring API
+ * used by existing ETH export and signing flows.
+ *
+ * The adapter is account-agnostic: each method resolves the requested address
+ * against the wrapped v2 keyring's accounts, verifies that the resolved account
+ * supports the requested method, then forwards the request through the v2
+ * `submitRequest` or `exportAccount` APIs.
+ */
+export class EthKeyringV1Adapter implements BaseEthKeyring {
+  readonly #keyring: KeyringV2;
+
+  readonly #origin: string;
+
+  /**
+   * Create a new ETH v1 adapter for a v2 keyring.
+   *
+   * @param options - Adapter options.
+   * @param options.keyring - The v2 keyring to adapt.
+   * @param options.origin - Origin to use for submitted requests.
+   */
+  constructor({
+    keyring,
+    origin = DEFAULT_ORIGIN,
+  }: {
+    keyring: KeyringV2;
+    origin?: string;
+  }) {
+    this.#keyring = keyring;
+    this.#origin = origin;
+  }
+
+  /**
+   * Gets the private data associated with the given address so
+   * that it may be exported.
+   *
+   * Used by the UI to export an account.
+   *
+   * @param address - Address of the account to export.
+   * @returns A promise that resolves to the exported private key.
+   * @throws {@link EthKeyringV1AccountNotFoundError} if no account matches the
+   * address.
+   */
+  async exportAccount(address: Hex): Promise<string> {
+    const { account } = await this.#getAccount(address);
+
+    if (!this.#keyring.exportAccount) {
+      throw new Error('Keyring does not support exportAccount');
+    }
+
+    const exportedAccount = await this.#keyring.exportAccount(account.id, {
+      type: AccountExportType.PrivateKey,
+      encoding: PrivateKeyEncoding.Hexadecimal,
+    });
+
+    return remove0x(exportedAccount.privateKey);
+  }
+
+  /**
+   * Sign a transaction.
+   *
+   * @param address - Sender's address.
+   * @param transaction - Transaction.
+   * @returns A promise that resolves to the signed transaction.
+   * @throws {@link EthKeyringV1AccountNotFoundError} if no account matches the
+   * address.
+   * @throws {@link EthKeyringV1MethodNotSupportedError} if the account does
+   * not support transaction signing.
+   */
+  async signTransaction(
+    address: Hex,
+    transaction: TypedTransaction,
+  ): Promise<TypedTransaction> {
+    const { account, normalizedAddress } = await this.#getAccountForMethod(
+      address,
+      EthMethod.SignTransaction,
+    );
+
+    const chainId = transaction.common.chainId();
+    const tx = toJson({
+      ...transaction.toJSON(),
+      from: normalizedAddress,
+      type: `0x${transaction.type.toString(16)}`,
+      chainId: bigIntToHex(chainId),
+    });
+
+    const signedTx = await this.#submitRequest(
+      account,
+      EthMethod.SignTransaction,
+      [tx],
+      toCaipChainId(KnownCaipNamespace.Eip155, `${chainId}`),
+    );
+
+    // Only take the signature fields from the keyring response. This prevents
+    // the keyring from overwriting the transaction payload we submitted.
+    const signature = mask(
+      signedTx,
+      object({
+        r: string(),
+        s: string(),
+        v: string(),
+      }),
+    );
+
+    return TransactionFactory.fromTxData({
+      ...(tx as Record<string, Json>),
+      r: signature.r as Hex,
+      s: signature.s as Hex,
+      v: signature.v as Hex,
+    });
+  }
+
+  /**
+   * Sign a message.
+   *
+   * @param address - Signer's address.
+   * @param data - Data to sign.
+   * @returns A promise that resolves to the signature.
+   * @throws {@link EthKeyringV1AccountNotFoundError} if no account matches the
+   * address.
+   * @throws {@link EthKeyringV1MethodNotSupportedError} if the account does
+   * not support message signing.
+   */
+  async signMessage(address: Hex, data: string): Promise<string> {
+    const { account, normalizedAddress } = await this.#getAccountForMethod(
+      address,
+      EthMethod.Sign,
+    );
+
+    return await this.#submitRequest<string>(account, EthMethod.Sign, [
+      normalizedAddress,
+      data,
+    ]);
+  }
+
+  /**
+   * Sign an EIP-7702 authorization.
+   *
+   * @param address - Signer's address.
+   * @param authorization - Authorization tuple to sign.
+   * @returns A promise that resolves to the signature.
+   * @throws {@link EthKeyringV1AccountNotFoundError} if no account matches the
+   * address.
+   * @throws {@link EthKeyringV1MethodNotSupportedError} if the account does
+   * not support EIP-7702 authorization signing.
+   */
+  async signEip7702Authorization(
+    address: Hex,
+    authorization: [chainId: number, contractAddress: Hex, nonce: number],
+  ): Promise<string> {
+    const { account } = await this.#getAccountForMethod(
+      address,
+      EthKeyringMethod.SignEip7702Authorization,
+    );
+
+    return await this.#submitRequest<string>(
+      account,
+      EthKeyringMethod.SignEip7702Authorization,
+      [authorization],
+    );
+  }
+
+  /**
+   * Sign a personal message.
+   *
+   * Note: KeyringController says this should return a Buffer but it actually
+   * expects a string.
+   *
+   * @param address - Signer's address.
+   * @param message - Data to sign.
+   * @returns A promise that resolves to the signature.
+   * @throws {@link EthKeyringV1AccountNotFoundError} if no account matches the
+   * address.
+   * @throws {@link EthKeyringV1MethodNotSupportedError} if the account does
+   * not support personal message signing.
+   */
+  async signPersonalMessage(address: Hex, message: Hex): Promise<string> {
+    const { account, normalizedAddress } = await this.#getAccountForMethod(
+      address,
+      EthMethod.PersonalSign,
+    );
+
+    return await this.#submitRequest<string>(account, EthMethod.PersonalSign, [
+      message,
+      normalizedAddress,
+    ]);
+  }
+
+  /**
+   * Sign a typed data message.
+   *
+   * @param address - Signer's address.
+   * @param typedData - Typed data to sign.
+   * @param options - Signing options.
+   * @param options.version - The typed data version to use.
+   * @returns A promise that resolves to the signature.
+   * @throws {@link EthKeyringV1AccountNotFoundError} if no account matches the
+   * address.
+   * @throws {@link EthKeyringV1MethodNotSupportedError} if the account does
+   * not support the requested typed data signing method.
+   */
+  async signTypedData(
+    address: Hex,
+    typedData: unknown[] | Record<string, unknown>,
+    options?: Record<string, unknown>,
+  ): Promise<string> {
+    const version = options?.version as SignTypedDataVersion | undefined;
+    const method = this.#getSignTypedDataMethod(version);
+    const { account, normalizedAddress } = await this.#getAccountForMethod(
+      address,
+      method,
+    );
+
+    return await this.#submitRequest<string>(account, method, [
+      normalizedAddress,
+      typedData as Json,
+    ]);
+  }
+
+  /**
+   * Convert base transactions to a base UserOperation.
+   *
+   * @param address - Address of the sender.
+   * @param transactions - Base transactions to include in the UserOperation.
+   * @param context - Keyring execution context.
+   * @returns A pseudo-UserOperation that can be used to construct a real one.
+   * @throws {@link EthKeyringV1AccountNotFoundError} if no account matches the
+   * address.
+   * @throws {@link EthKeyringV1MethodNotSupportedError} if the account does
+   * not support UserOperation preparation.
+   */
+  async prepareUserOperation(
+    address: string,
+    transactions: EthBaseTransaction[],
+    context: KeyringExecutionContext,
+  ): Promise<EthBaseUserOperation> {
+    const { account } = await this.#getAccountForMethod(
+      address,
+      EthMethod.PrepareUserOperation,
+    );
+
+    return await this.#submitRequest<EthBaseUserOperation>(
+      account,
+      EthMethod.PrepareUserOperation,
+      transactions as Json[],
+      this.#getUserOperationScope(context),
+    );
+  }
+
+  /**
+   * Patches properties of a UserOperation. Currently, only the
+   * `paymasterAndData` can be patched.
+   *
+   * @param address - Address of the sender.
+   * @param userOperation - UserOperation to patch.
+   * @param context - Keyring execution context.
+   * @returns A patch to apply to the UserOperation.
+   * @throws {@link EthKeyringV1AccountNotFoundError} if no account matches the
+   * address.
+   * @throws {@link EthKeyringV1MethodNotSupportedError} if the account does
+   * not support UserOperation patching.
+   */
+  async patchUserOperation(
+    address: string,
+    userOperation: EthUserOperation,
+    context: KeyringExecutionContext,
+  ): Promise<EthUserOperationPatch> {
+    const { account } = await this.#getAccountForMethod(
+      address,
+      EthMethod.PatchUserOperation,
+    );
+
+    return await this.#submitRequest<EthUserOperationPatch>(
+      account,
+      EthMethod.PatchUserOperation,
+      [userOperation as Json],
+      this.#getUserOperationScope(context),
+    );
+  }
+
+  /**
+   * Signs a UserOperation.
+   *
+   * @param address - Address of the sender.
+   * @param userOperation - UserOperation to sign.
+   * @param context - Keyring execution context.
+   * @returns The signature of the UserOperation.
+   * @throws {@link EthKeyringV1AccountNotFoundError} if no account matches the
+   * address.
+   * @throws {@link EthKeyringV1MethodNotSupportedError} if the account does
+   * not support UserOperation signing.
+   */
+  async signUserOperation(
+    address: string,
+    userOperation: EthUserOperation,
+    context: KeyringExecutionContext,
+  ): Promise<string> {
+    const { account } = await this.#getAccountForMethod(
+      address,
+      EthMethod.SignUserOperation,
+    );
+
+    return await this.#submitRequest<string>(
+      account,
+      EthMethod.SignUserOperation,
+      [userOperation as Json],
+      this.#getUserOperationScope(context),
+    );
+  }
+
+  async #getAccount(address: string): Promise<ResolvedAccount> {
+    const normalizedAddress = ethNormalize(address);
+    const normalizedAddressLowerCase = normalizedAddress?.toLowerCase();
+
+    if (!normalizedAddress || !normalizedAddressLowerCase) {
+      throw new EthKeyringV1AccountNotFoundError(address);
+    }
+
+    const accounts = await this.#keyring.getAccounts();
+    const account = accounts.find((keyringAccount) => {
+      const accountAddress = ethNormalize(keyringAccount.address);
+      return accountAddress?.toLowerCase() === normalizedAddressLowerCase;
+    });
+
+    if (!account) {
+      throw new EthKeyringV1AccountNotFoundError(address);
+    }
+
+    return {
+      account,
+      normalizedAddress: normalizedAddress as Hex,
+    };
+  }
+
+  async #getAccountForMethod(
+    address: string,
+    method: string,
+  ): Promise<ResolvedAccount> {
+    const resolvedAccount = await this.#getAccount(address);
+
+    if (!resolvedAccount.account.methods.includes(method)) {
+      throw new EthKeyringV1MethodNotSupportedError(method, address);
+    }
+
+    return resolvedAccount;
+  }
+
+  #getSignTypedDataMethod(
+    version: SignTypedDataVersion | undefined,
+  ): EthMethod {
+    switch (version) {
+      case 'V3':
+        return EthMethod.SignTypedDataV3;
+      case 'V4':
+        return EthMethod.SignTypedDataV4;
+      case 'V1':
+      default:
+        return EthMethod.SignTypedDataV1;
+    }
+  }
+
+  #getUserOperationScope(context: KeyringExecutionContext): string {
+    return toCaipChainId(KnownCaipNamespace.Eip155, context.chainId);
+  }
+
+  async #submitRequest<Result extends Json = Json>(
+    account: KeyringAccount,
+    method: string,
+    params: RequestParams,
+    scope: string = EthScope.Eoa,
+  ): Promise<Result> {
+    return (await this.#keyring.submitRequest({
+      id: uuid(),
+      origin: this.#origin,
+      scope,
+      account: account.id,
+      request: {
+        method,
+        params,
+      },
+    })) as Result;
+  }
+}

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -57,10 +57,14 @@ type TypedDataWithDomain = {
  * Convert a value to a valid JSON object.
  *
  * The function chains JSON.stringify and JSON.parse to ensure that the result
- * is a valid JSON object. In objects, undefined values are removed, and in
- * arrays, they are replaced with null.
+ * is a valid JSON object.
  *
- * @param value - Value to convert to JSON.
+ * We assume that the input value is JSON-serializable.
+ *
+ * However, some transformations can occur like: in objects, undefined values
+ * are removed, and in arrays, they are replaced with null.
+ *
+ * @param value - Value to convert to JSON - Assumed to be JSON-serializable.
  * @returns JSON representation of the value.
  */
 function toJson<Type extends Json = Json>(value: unknown): Type {

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -267,10 +267,13 @@ export class EthKeyringV1Adapter<
       EthKeyringMethod.SignEip7702Authorization,
     );
 
-    return await this.#submitRequest<string>(
-      account,
-      EthKeyringMethod.SignEip7702Authorization,
-      [authorization],
+    return strictMask(
+      await this.#submitRequest(
+        account,
+        EthKeyringMethod.SignEip7702Authorization,
+        [authorization],
+      ),
+      EthBytesStruct,
     );
   }
 

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -114,9 +114,8 @@ export class EthKeyringV1MethodNotSupportedError extends Error {
  * supports the requested method, then forwards the request through the v2
  * `submitRequest` or `exportAccount` APIs.
  */
-export class EthKeyringV1Adapter<
-  InnerKeyring extends KeyringV2 = KeyringV2,
-> extends KeyringV1Adapter<InnerKeyring>
+export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
+  extends KeyringV1Adapter<InnerKeyring>
   implements BaseEthKeyring
 {
   readonly #origin: string;

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -1,4 +1,4 @@
-import type { TypedTransaction, TypedTxData } from '@ethereumjs/tx';
+import type { TypedTransaction } from '@ethereumjs/tx';
 import { TransactionFactory } from '@ethereumjs/tx';
 import type { SignTypedDataVersion } from '@metamask/eth-sig-util';
 import { normalize as ethNormalize } from '@metamask/eth-sig-util';
@@ -55,7 +55,8 @@ export type BaseEthKeyring = Pick<
   | 'signPersonalMessage'
   | 'signTypedData'
   | 'signTransaction'
-> & Eth4337Keyring;
+> &
+  Eth4337Keyring;
 
 /**
  * Error thrown when an account cannot be resolved from the requested address.

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -23,7 +23,7 @@ import {
   AccountExportType,
   PrivateKeyEncoding,
 } from '@metamask/keyring-api/v2';
-import type { EthKeyring } from '@metamask/keyring-utils';
+import type { BaseKeyring, EthKeyring } from '@metamask/keyring-utils';
 import { strictMask } from '@metamask/keyring-utils';
 import { mask, object, string } from '@metamask/superstruct';
 import type { Hex, Json } from '@metamask/utils';
@@ -36,6 +36,7 @@ import {
 import { v4 as uuid } from 'uuid';
 
 import type { Eth4337Keyring } from '../../eth';
+import { KeyringV1Adapter } from '../keyring-v1-adapter';
 import { EthKeyringMethod } from './eth-keyring-wrapper';
 
 const DEFAULT_ORIGIN = 'metamask';
@@ -60,15 +61,17 @@ function toJson<Type extends Json = Json>(value: unknown): Type {
 /**
  * Legacy ETH keyring API surface exposed by {@link EthKeyringV1Adapter}.
  */
-export type BaseEthKeyring = Pick<
-  EthKeyring,
-  | 'exportAccount'
-  | 'signMessage'
-  | 'signEip7702Authorization'
-  | 'signPersonalMessage'
-  | 'signTypedData'
-  | 'signTransaction'
-> &
+export type BaseEthKeyring = BaseKeyring &
+  // Only pick account-related methods (signing and exporting).
+  Pick<
+    EthKeyring,
+    | 'exportAccount'
+    | 'signMessage'
+    | 'signEip7702Authorization'
+    | 'signPersonalMessage'
+    | 'signTypedData'
+    | 'signTransaction'
+  > &
   Eth4337Keyring;
 
 /**
@@ -111,9 +114,10 @@ export class EthKeyringV1MethodNotSupportedError extends Error {
  * supports the requested method, then forwards the request through the v2
  * `submitRequest` or `exportAccount` APIs.
  */
-export class EthKeyringV1Adapter implements BaseEthKeyring {
-  readonly #keyring: KeyringV2;
-
+export class EthKeyringV1Adapter
+  extends KeyringV1Adapter<KeyringV2>
+  implements BaseEthKeyring
+{
   readonly #origin: string;
 
   /**
@@ -130,7 +134,7 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
     keyring: KeyringV2;
     origin?: string;
   }) {
-    this.#keyring = keyring;
+    super(keyring);
     this.#origin = origin;
   }
 
@@ -147,12 +151,13 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
    */
   async exportAccount(address: Hex): Promise<string> {
     const { account } = await this.#getAccount(address);
+    const keyring = this.unwrap();
 
-    if (!this.#keyring.exportAccount) {
+    if (!keyring.exportAccount) {
       throw new Error('Keyring does not support exportAccount');
     }
 
-    const exportedAccount = await this.#keyring.exportAccount(account.id, {
+    const exportedAccount = await keyring.exportAccount(account.id, {
       type: AccountExportType.PrivateKey,
       encoding: PrivateKeyEncoding.Hexadecimal,
     });
@@ -447,7 +452,7 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
       throw new EthKeyringV1AccountNotFoundError(address);
     }
 
-    const accounts = await this.#keyring.getAccounts();
+    const accounts = await this.unwrap().getAccounts();
     const account = accounts.find((keyringAccount) => {
       const accountAddress = ethNormalize(keyringAccount.address);
       return accountAddress?.toLowerCase() === normalizedAddressLowerCase;
@@ -500,7 +505,7 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
     params: RequestParams,
     scope: string = EthScope.Eoa,
   ): Promise<Result> {
-    return (await this.#keyring.submitRequest({
+    return (await this.unwrap().submitRequest({
       id: uuid(),
       origin: this.#origin,
       scope,

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -6,7 +6,6 @@ import {
   EthBaseUserOperationStruct,
   EthBytesStruct,
   EthMethod,
-  EthScope,
   EthUserOperationPatchStruct,
 } from '@metamask/keyring-api';
 import type {
@@ -266,11 +265,14 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
       EthKeyringMethod.SignEip7702Authorization,
     );
 
+    const [chainId] = authorization;
+
     return strictMask(
       await this.#submitRequest(
         account,
         EthKeyringMethod.SignEip7702Authorization,
         [authorization],
+        toEip155Scope(chainId),
       ),
       EthBytesStruct,
     );
@@ -510,7 +512,7 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
     account: KeyringAccount,
     method: string,
     params: RequestParams,
-    scope: string = EthScope.Eoa,
+    scope: string,
   ): Promise<Result> {
     return (await this.inner.submitRequest({
       id: uuid(),

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -39,7 +39,7 @@ import type { Eth4337Keyring } from '../../eth';
 import { KeyringV1Adapter } from '../keyring-v1-adapter';
 import { EthKeyringMethod } from './eth-keyring-wrapper';
 
-const DEFAULT_ORIGIN = 'metamask';
+const METAMASK_ORIGIN = 'metamask';
 
 type RequestParams = NonNullable<KeyringRequest['request']['params']>;
 
@@ -138,26 +138,6 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
   extends KeyringV1Adapter<InnerKeyring>
   implements BaseEthKeyring
 {
-  readonly #origin: string;
-
-  /**
-   * Create a new ETH v1 adapter for a v2 keyring.
-   *
-   * @param options - Adapter options.
-   * @param options.keyring - The v2 keyring to adapt.
-   * @param options.origin - Origin to use for submitted requests.
-   */
-  constructor({
-    keyring,
-    origin = DEFAULT_ORIGIN,
-  }: {
-    keyring: InnerKeyring;
-    origin?: string;
-  }) {
-    super(keyring);
-    this.#origin = origin;
-  }
-
   /**
    * Gets the private data associated with the given address so
    * that it may be exported.
@@ -534,7 +514,7 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
   ): Promise<Result> {
     return (await this.inner.submitRequest({
       id: uuid(),
-      origin: this.#origin,
+      origin: METAMASK_ORIGIN,
       scope,
       account: account.id,
       request: {

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -151,13 +151,12 @@ export class EthKeyringV1Adapter
    */
   async exportAccount(address: Hex): Promise<string> {
     const { account } = await this.#getAccount(address);
-    const keyring = this.unwrap();
 
-    if (!keyring.exportAccount) {
+    if (!this.inner.exportAccount) {
       throw new Error('Keyring does not support exportAccount');
     }
 
-    const exportedAccount = await keyring.exportAccount(account.id, {
+    const exportedAccount = await this.inner.exportAccount(account.id, {
       type: AccountExportType.PrivateKey,
       encoding: PrivateKeyEncoding.Hexadecimal,
     });
@@ -452,7 +451,7 @@ export class EthKeyringV1Adapter
       throw new EthKeyringV1AccountNotFoundError(address);
     }
 
-    const accounts = await this.unwrap().getAccounts();
+    const accounts = await this.inner.getAccounts();
     const account = accounts.find((keyringAccount) => {
       const accountAddress = ethNormalize(keyringAccount.address);
       return accountAddress?.toLowerCase() === normalizedAddressLowerCase;
@@ -505,7 +504,7 @@ export class EthKeyringV1Adapter
     params: RequestParams,
     scope: string = EthScope.Eoa,
   ): Promise<Result> {
-    return (await this.unwrap().submitRequest({
+    return (await this.inner.submitRequest({
       id: uuid(),
       origin: this.#origin,
       scope,

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -114,8 +114,9 @@ export class EthKeyringV1MethodNotSupportedError extends Error {
  * supports the requested method, then forwards the request through the v2
  * `submitRequest` or `exportAccount` APIs.
  */
-export class EthKeyringV1Adapter
-  extends KeyringV1Adapter<KeyringV2>
+export class EthKeyringV1Adapter<
+  InnerKeyring extends KeyringV2 = KeyringV2,
+> extends KeyringV1Adapter<InnerKeyring>
   implements BaseEthKeyring
 {
   readonly #origin: string;
@@ -131,7 +132,7 @@ export class EthKeyringV1Adapter
     keyring,
     origin = DEFAULT_ORIGIN,
   }: {
-    keyring: KeyringV2;
+    keyring: InnerKeyring;
     origin?: string;
   }) {
     super(keyring);

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -54,8 +54,28 @@ type TypedDataWithDomain = {
   };
 };
 
+/**
+ * Convert a value to a valid JSON object.
+ *
+ * The function chains JSON.stringify and JSON.parse to ensure that the result
+ * is a valid JSON object. In objects, undefined values are removed, and in
+ * arrays, they are replaced with null.
+ *
+ * @param value - Value to convert to JSON.
+ * @returns JSON representation of the value.
+ */
 function toJson<Type extends Json = Json>(value: unknown): Type {
   return JSON.parse(JSON.stringify(value)) as Type;
+}
+
+/**
+ * Convert a chain ID (number or hex) to an EIP-155 CAIP chain ID string for keyring request scoping.
+ *
+ * @param chainId - The chain ID to convert.
+ * @returns The EIP-155 CAIP chain ID string.
+ */
+function toEip155Scope(chainId: string | number | bigint): string {
+  return toCaipChainId(KnownCaipNamespace.Eip155, BigInt(chainId).toString());
 }
 
 /**
@@ -196,7 +216,7 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
       account,
       EthMethod.SignTransaction,
       toJson<Json[]>([tx]),
-      toCaipChainId(KnownCaipNamespace.Eip155, `${chainId}`),
+      toEip155Scope(chainId),
     );
 
     // Only take the signature fields from the keyring response. This prevents
@@ -331,6 +351,9 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
       address,
       method,
     );
+
+    // Extract chain ID as if it was a typed message (as defined by EIP-712), if
+    // input is not a typed message, then chain ID will be undefined!
     const chainId = (typedData as TypedDataWithDomain).domain?.chainId;
 
     return strictMask(
@@ -338,9 +361,7 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
         account,
         method,
         toJson<Json[]>([normalizedAddress, typedData]),
-        chainId === undefined
-          ? ''
-          : toCaipChainId(KnownCaipNamespace.Eip155, `${chainId}`),
+        chainId === undefined ? '' : toEip155Scope(chainId),
       ),
       EthBytesStruct,
     );
@@ -373,7 +394,7 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
         account,
         EthMethod.PrepareUserOperation,
         toJson<Json[]>(transactions),
-        this.#getUserOperationScope(context),
+        toEip155Scope(context.chainId),
       ),
       EthBaseUserOperationStruct,
     );
@@ -407,7 +428,7 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
         account,
         EthMethod.PatchUserOperation,
         toJson<Json[]>([userOperation]),
-        this.#getUserOperationScope(context),
+        toEip155Scope(context.chainId),
       ),
       EthUserOperationPatchStruct,
     );
@@ -440,7 +461,7 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
         account,
         EthMethod.SignUserOperation,
         toJson<Json[]>([userOperation]),
-        this.#getUserOperationScope(context),
+        toEip155Scope(context.chainId),
       ),
       EthBytesStruct,
     );
@@ -493,12 +514,10 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
         return EthMethod.SignTypedDataV4;
       case 'V1':
       default:
+        // Use 'V1' by default to match other keyring implementations. V1 will be
+        // used if the version is not specified or not supported.
         return EthMethod.SignTypedDataV1;
     }
-  }
-
-  #getUserOperationScope(context: KeyringExecutionContext): string {
-    return toCaipChainId(KnownCaipNamespace.Eip155, context.chainId);
   }
 
   async #submitRequest<Result extends Json = Json>(

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -2,7 +2,13 @@ import type { TypedTransaction } from '@ethereumjs/tx';
 import { TransactionFactory } from '@ethereumjs/tx';
 import type { SignTypedDataVersion } from '@metamask/eth-sig-util';
 import { normalize as ethNormalize } from '@metamask/eth-sig-util';
-import { EthMethod, EthScope } from '@metamask/keyring-api';
+import {
+  EthBaseUserOperationStruct,
+  EthBytesStruct,
+  EthMethod,
+  EthScope,
+  EthUserOperationPatchStruct,
+} from '@metamask/keyring-api';
 import type {
   EthBaseTransaction,
   EthBaseUserOperation,
@@ -18,6 +24,7 @@ import {
   PrivateKeyEncoding,
 } from '@metamask/keyring-api/v2';
 import type { EthKeyring } from '@metamask/keyring-utils';
+import { strictMask } from '@metamask/keyring-utils';
 import { mask, object, string } from '@metamask/superstruct';
 import type { Hex, Json } from '@metamask/utils';
 import {
@@ -38,6 +45,12 @@ type RequestParams = NonNullable<KeyringRequest['request']['params']>;
 type ResolvedAccount = {
   account: KeyringAccount;
   normalizedAddress: Hex;
+};
+
+type TypedDataWithDomain = {
+  domain?: {
+    chainId?: string | number;
+  };
 };
 
 function toJson<Type extends Json = Json>(value: unknown): Type {
@@ -178,7 +191,7 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
     const signedTx = await this.#submitRequest(
       account,
       EthMethod.SignTransaction,
-      [tx],
+      toJson<Json[]>([tx]),
       toCaipChainId(KnownCaipNamespace.Eip155, `${chainId}`),
     );
 
@@ -218,10 +231,15 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
       EthMethod.Sign,
     );
 
-    return await this.#submitRequest<string>(account, EthMethod.Sign, [
-      normalizedAddress,
-      data,
-    ]);
+    return strictMask(
+      await this.#submitRequest(
+        account,
+        EthMethod.Sign,
+        toJson<Json[]>([normalizedAddress, data]),
+        '',
+      ),
+      EthBytesStruct,
+    );
   }
 
   /**
@@ -271,10 +289,15 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
       EthMethod.PersonalSign,
     );
 
-    return await this.#submitRequest<string>(account, EthMethod.PersonalSign, [
-      message,
-      normalizedAddress,
-    ]);
+    return strictMask(
+      await this.#submitRequest(
+        account,
+        EthMethod.PersonalSign,
+        toJson<Json[]>([message, normalizedAddress]),
+        '',
+      ),
+      EthBytesStruct,
+    );
   }
 
   /**
@@ -301,11 +324,19 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
       address,
       method,
     );
+    const chainId = (typedData as TypedDataWithDomain).domain?.chainId;
 
-    return await this.#submitRequest<string>(account, method, [
-      normalizedAddress,
-      typedData as Json,
-    ]);
+    return strictMask(
+      await this.#submitRequest(
+        account,
+        method,
+        toJson<Json[]>([normalizedAddress, typedData]),
+        chainId === undefined
+          ? ''
+          : toCaipChainId(KnownCaipNamespace.Eip155, `${chainId}`),
+      ),
+      EthBytesStruct,
+    );
   }
 
   /**
@@ -330,11 +361,14 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
       EthMethod.PrepareUserOperation,
     );
 
-    return await this.#submitRequest<EthBaseUserOperation>(
-      account,
-      EthMethod.PrepareUserOperation,
-      transactions as Json[],
-      this.#getUserOperationScope(context),
+    return strictMask(
+      await this.#submitRequest(
+        account,
+        EthMethod.PrepareUserOperation,
+        toJson<Json[]>(transactions),
+        this.#getUserOperationScope(context),
+      ),
+      EthBaseUserOperationStruct,
     );
   }
 
@@ -361,11 +395,14 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
       EthMethod.PatchUserOperation,
     );
 
-    return await this.#submitRequest<EthUserOperationPatch>(
-      account,
-      EthMethod.PatchUserOperation,
-      [userOperation as Json],
-      this.#getUserOperationScope(context),
+    return strictMask(
+      await this.#submitRequest(
+        account,
+        EthMethod.PatchUserOperation,
+        toJson<Json[]>([userOperation]),
+        this.#getUserOperationScope(context),
+      ),
+      EthUserOperationPatchStruct,
     );
   }
 
@@ -391,11 +428,14 @@ export class EthKeyringV1Adapter implements BaseEthKeyring {
       EthMethod.SignUserOperation,
     );
 
-    return await this.#submitRequest<string>(
-      account,
-      EthMethod.SignUserOperation,
-      [userOperation as Json],
-      this.#getUserOperationScope(context),
+    return strictMask(
+      await this.#submitRequest(
+        account,
+        EthMethod.SignUserOperation,
+        toJson<Json[]>([userOperation]),
+        this.#getUserOperationScope(context),
+      ),
+      EthBytesStruct,
     );
   }
 

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -393,6 +393,12 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
       await this.#submitRequest(
         account,
         EthMethod.PrepareUserOperation,
+        // NOTE: This is inconsistent with the other methods. We are not wrapping `transactions` in an array.
+        // Which means the receiver of the `submitRequest` call would see individual transactions spread as
+        // separate params rather than a single transactions array as the first param, which doesn't match
+        // the method signature of `prepareUserOperation(address, transactions, context)`.
+        // This was already implemented like this in the legacy Snap keyring, so we keep the same logic here
+        // too!
         toJson<Json[]>(transactions),
         toEip155Scope(context.chainId),
       ),

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -4,6 +4,7 @@ import type { SignTypedDataVersion } from '@metamask/eth-sig-util';
 import { normalize as ethNormalize } from '@metamask/eth-sig-util';
 import {
   EthBaseUserOperationStruct,
+  EthBytesStrictStruct,
   EthBytesStruct,
   EthMethod,
   EthUserOperationPatchStruct,
@@ -24,7 +25,7 @@ import {
 } from '@metamask/keyring-api/v2';
 import type { BaseKeyring, EthKeyring } from '@metamask/keyring-utils';
 import { strictMask } from '@metamask/keyring-utils';
-import { mask, object, string } from '@metamask/superstruct';
+import { mask, object } from '@metamask/superstruct';
 import type { Hex, Json } from '@metamask/utils';
 import {
   bigIntToHex,
@@ -207,17 +208,17 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
     const signature = mask(
       signedTx,
       object({
-        r: string(),
-        s: string(),
-        v: string(),
+        r: EthBytesStrictStruct,
+        s: EthBytesStrictStruct,
+        v: EthBytesStrictStruct,
       }),
     );
 
     return TransactionFactory.fromTxData({
       ...(tx as Record<string, Json>),
-      r: signature.r as Hex,
-      s: signature.s as Hex,
-      v: signature.v as Hex,
+      r: signature.r,
+      s: signature.s,
+      v: signature.v,
     });
   }
 

--- a/packages/keyring-sdk/src/v2/eth/index.ts
+++ b/packages/keyring-sdk/src/v2/eth/index.ts
@@ -1,1 +1,2 @@
+export * from './eth-keyring-v1-adapter';
 export * from './eth-keyring-wrapper';

--- a/packages/keyring-sdk/src/v2/keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/keyring-v1-adapter.ts
@@ -40,10 +40,10 @@ export class KeyringV1Adapter<
    */
   readonly type: string;
 
-  readonly #inner: InnerKeyring;
+  protected readonly inner: InnerKeyring;
 
   constructor(inner: InnerKeyring) {
-    this.#inner = inner;
+    this.inner = inner;
     this.type = inner.type;
   }
 
@@ -56,7 +56,7 @@ export class KeyringV1Adapter<
    * @returns The inner v2 keyring instance.
    */
   unwrap(): InnerKeyring {
-    return this.#inner;
+    return this.inner;
   }
 
   /**
@@ -68,7 +68,7 @@ export class KeyringV1Adapter<
    * @returns A promise resolving to the list of account addresses.
    */
   async getAccounts(): Promise<string[]> {
-    const accounts = await this.#inner.getAccounts();
+    const accounts = await this.inner.getAccounts();
     return accounts.map((account: KeyringAccount) => account.address);
   }
 
@@ -80,7 +80,7 @@ export class KeyringV1Adapter<
    * @returns A promise resolving to the serialized state.
    */
   async serialize(): Promise<Json> {
-    return this.#inner.serialize();
+    return this.inner.serialize();
   }
 
   /**
@@ -92,6 +92,6 @@ export class KeyringV1Adapter<
    * @returns A promise that resolves when deserialization is complete.
    */
   async deserialize(state: Json): Promise<void> {
-    return this.#inner.deserialize(state);
+    return this.inner.deserialize(state);
   }
 }


### PR DESCRIPTION
Adding a new `EthKeyringV1Adapter` that adapts a v2 keyring to expose v1 ETH methods (`signTransaction`, `signPersonalMessage`, etc.) so a consumer can use `":withKeyringV2` + adapt it so it can use proper function calls rather than "raw" `submitRequest` dispatching.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches private key export and all major ETH signing paths (transactions, typed data, EIP-7702, user operations) with validation and request shaping that must stay compatible with existing controllers and snaps.
> 
> **Overview**
> Adds **`EthKeyringV1Adapter`**, which wraps a v2 keyring and exposes legacy ETH **export**, **transaction/message signing**, **EIP-7702 authorization**, **typed data**, and **ERC-4337 user operation** APIs by resolving addresses, checking per-account `methods`, and forwarding through v2 `submitRequest` / `exportAccount` with scoped CAIP-2 requests and response validation.
> 
> Introduces **`EthKeyringV1AccountNotFoundError`** and **`EthKeyringV1MethodNotSupportedError`**, an **`Eth4337Keyring`** type surface, and **`EthBytesStrictStruct`** in `@metamask/keyring-api` (used when merging `r`/`s`/`v` into signed txs). **`KeyringV1Adapter`** now exposes a **`protected inner`** field so ETH-specific adapters can delegate to the wrapped v2 instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f04dd22cdff834c6fa11cd31cbe526a47f177d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->