### PR TITLE
feat(keyring-snap-bridge): normalize account address

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Normalize `KeyringAccount`'s address with `:accountCreated` and `setAccounts` ([#556](https://github.com/MetaMask/accounts/pull/556))
+
 ## [22.1.0]
 
 ### Added

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -20,12 +20,13 @@ import type { Snap } from '@metamask/snaps-utils';
 import type { Json } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 
+import { normalizeAccountAddress } from './account';
 import type { SnapKeyringInternalOptions } from './options';
 import type { SnapKeyringMessenger } from './SnapKeyringMessenger';
 import { SNAP_KEYRING_NAME } from './SnapKeyringMessenger';
 import type { AccountMethod } from './SnapKeyringV1';
 import type { SnapMessage } from './types';
-import { normalizeAccountAddress, throwError, unique } from './util';
+import { throwError, unique } from './util';
 import { SnapKeyring as SnapKeyringV2 } from './v2/SnapKeyring';
 
 export const SNAP_KEYRING_TYPE = 'Snap Keyring';

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
@@ -47,7 +47,8 @@ import {
 } from '@metamask/utils';
 import { v4 as uuid } from 'uuid';
 
-import { transformAccount } from './account';
+import { normalizeAccount, transformAccount } from './account';
+import { normalizeAccountAddress } from './account';
 import {
   AccountCreatedEventStruct,
   AccountUpdatedEventStruct,
@@ -65,13 +66,7 @@ import type {
 } from './SnapKeyringMessenger';
 import type { SnapMessage } from './types';
 import { SnapMessageStruct } from './types';
-import {
-  equalsIgnoreCase,
-  normalizeAccountAddress,
-  sanitizeUrl,
-  throwError,
-  toJson,
-} from './util';
+import { equalsIgnoreCase, sanitizeUrl, throwError, toJson } from './util';
 
 // TODO: to be removed when this is added to the keyring-api
 export type AccountMethod = EthMethod | BtcMethod;
@@ -753,8 +748,8 @@ export class SnapKeyringV1 {
     // first create the account data and then fire the "AccountCreated" event.
 
     // Potentially migrate the account.
-    const account = transformAccount(newAccountFromEvent);
-    const address = normalizeAccountAddress(account);
+    const account = normalizeAccount(transformAccount(newAccountFromEvent));
+    const { address } = account;
 
     if (this.getExistingAccount(account)) {
       // If the account already exists, we skip it.

--- a/packages/keyring-snap-bridge/src/account.test.ts
+++ b/packages/keyring-snap-bridge/src/account.test.ts
@@ -1,8 +1,61 @@
 import type { KeyringAccount } from '@metamask/keyring-api';
+import {
+  EthAccountType,
+  EthScope,
+  SolAccountType,
+  SolScope,
+} from '@metamask/keyring-api';
 
-import { transformAccount } from './account';
+import {
+  normalizeAccount,
+  normalizeAccountAddress,
+  transformAccount,
+} from './account';
+
+const ethAccount: KeyringAccount = {
+  id: 'b05d918a-b37c-497a-bb28-3d15c0d56b7a',
+  address: '0xC728514Df8A7F9271f4B7a4dd2Aa6d2D723d3eE3',
+  options: {},
+  methods: [],
+  scopes: [EthScope.Eoa],
+  type: EthAccountType.Eoa,
+};
+
+const solAccount: KeyringAccount = {
+  id: '780ee179-5ab5-449d-9c25-34e12c1ada66',
+  address: '3d4v35MRK57xM2Nte3E3rTQU1zyXGVrkXJ6FuEjVoKzM',
+  options: {},
+  methods: [],
+  scopes: [SolScope.Mainnet],
+  type: SolAccountType.DataAccount,
+};
 
 describe('account', () => {
+  describe('normalizeAccountAddress', () => {
+    it('lowercases EVM account addresses', () => {
+      expect(normalizeAccountAddress(ethAccount)).toBe(
+        '0xc728514df8a7f9271f4b7a4dd2aa6d2d723d3ee3',
+      );
+    });
+
+    it('preserves non-EVM account addresses', () => {
+      expect(normalizeAccountAddress(solAccount)).toBe(solAccount.address);
+    });
+  });
+
+  describe('normalizeAccount', () => {
+    it('normalizes EVM account addresses', () => {
+      expect(normalizeAccount(ethAccount)).toStrictEqual({
+        ...ethAccount,
+        address: '0xc728514df8a7f9271f4b7a4dd2aa6d2d723d3ee3',
+      });
+    });
+
+    it('preserves non-EVM account addresses', () => {
+      expect(normalizeAccount(solAccount)).toStrictEqual(solAccount);
+    });
+  });
+
   it('throws for unknown account type', () => {
     const unknownAccount = {
       // This should not be really possible to create such account, but since we potentially

--- a/packages/keyring-snap-bridge/src/account.ts
+++ b/packages/keyring-snap-bridge/src/account.ts
@@ -134,6 +134,8 @@ export function normalizeAccountAddress(account: KeyringAccount): string {
 export function normalizeAccount(account: KeyringAccount): KeyringAccount {
   return {
     ...account,
+    // Normalization is only meaningful for EVM addresses. Since Snaps might be using checksum addresses, we should normalize
+    // them in the "MetaMask world" to keep compatibility with the rest of the codebase (e.g. when comparing addresses, etc.).
     address: normalizeAccountAddress(account),
   };
 }

--- a/packages/keyring-snap-bridge/src/account.ts
+++ b/packages/keyring-snap-bridge/src/account.ts
@@ -16,12 +16,12 @@ import {
   TrxEoaAccountStruct,
   XlmAccountType,
   XlmAccountStruct,
+  isEvmAccountType,
 } from '@metamask/keyring-api';
 import { assert, omit } from '@metamask/superstruct';
 import type { Infer } from '@metamask/superstruct';
 
 import { isAccountV1, transformAccountV1 } from './migrations';
-
 /**
  * A `KeyringAccount` with some optional fields which can be used to keep
  * the retro-compatility with older version of keyring accounts/events.
@@ -108,4 +108,32 @@ export function transformAccount(
 
   // We still assert that the converted account is valid according to their account's type.
   return assertKeyringAccount(account);
+}
+
+/**
+ * Normalize account's address.
+ *
+ * EVM addresses are lowercased; non-EVM addresses (e.g. Solana) are
+ * left as-is because they are case-sensitive.
+ *
+ * @param account - The account.
+ * @returns The normalized account address.
+ */
+export function normalizeAccountAddress(account: KeyringAccount): string {
+  return isEvmAccountType(account.type)
+    ? account.address.toLowerCase()
+    : account.address;
+}
+
+/**
+ * Normalize a `KeyringAccount` (e.g., its address).
+ *
+ * @param account - The account to normalize.
+ * @returns The normalized `KeyringAccount`.
+ */
+export function normalizeAccount(account: KeyringAccount): KeyringAccount {
+  return {
+    ...account,
+    address: normalizeAccountAddress(account),
+  };
 }

--- a/packages/keyring-snap-bridge/src/util.ts
+++ b/packages/keyring-snap-bridge/src/util.ts
@@ -1,5 +1,3 @@
-import type { KeyringAccount } from '@metamask/keyring-api';
-import { isEvmAccountType } from '@metamask/keyring-api';
 import type { Json } from '@metamask/utils';
 
 /**
@@ -57,21 +55,6 @@ export function throwError(message: string): never {
  */
 export function equalsIgnoreCase(a: string, b: string): boolean {
   return a.toLowerCase() === b.toLowerCase();
-}
-
-/**
- * Normalize account's address.
- *
- * EVM addresses are lowercased; non-EVM addresses (e.g. Solana) are
- * left as-is because they are case-sensitive.
- *
- * @param account - The account.
- * @returns The normalized account address.
- */
-export function normalizeAccountAddress(account: KeyringAccount): string {
-  return isEvmAccountType(account.type)
-    ? account.address.toLowerCase()
-    : account.address;
 }
 
 /**

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -13,7 +13,11 @@ import { assert, object, record, string, union } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 
-import { KeyringAccountV1Struct, transformAccount } from '../account';
+import {
+  KeyringAccountV1Struct,
+  normalizeAccount,
+  transformAccount,
+} from '../account';
 import { isAccountV1, migrateAccountV1 } from '../migrations';
 import { SnapKeyringV1 } from '../SnapKeyringV1';
 import type {
@@ -21,7 +25,7 @@ import type {
   SnapKeyringV1Callbacks,
   SnapKeyringV1Options,
 } from '../SnapKeyringV1';
-import { equalsIgnoreCase, normalizeAccountAddress } from '../util';
+import { equalsIgnoreCase } from '../util';
 
 /**
  * Superstruct schema for {@link SnapKeyringState}.
@@ -214,8 +218,8 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
 
       try {
         for (const snapAccount of snapAccounts) {
-          let account = transformAccount(snapAccount);
-          const address = normalizeAccountAddress(account);
+          let account = normalizeAccount(transformAccount(snapAccount));
+          const { address } = account;
 
           // Check for idempotency.
           const existingAccount = this.getExistingAccount(account);


### PR DESCRIPTION
Always normalize account address to keep compatibility with the rest of the codebase (for EVM accounts only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized address normalization at account-ingestion points; EVM-only lowercasing preserves existing non-EVM behavior and aligns with prior duplicate-address checks.
> 
> **Overview**
> Snap keyring accounts now get **canonical addresses when they enter keyring state**, not only when addresses are read for comparisons or RPC.
> 
> `normalizeAccountAddress` and new **`normalizeAccount`** live in `account.ts` (moved out of `util.ts`). **EVM** addresses are lowercased; **non-EVM** (e.g. Solana) stay unchanged.
> 
> **Account creation paths** apply normalization on the full `KeyringAccount` after `transformAccount`: v1 **`AccountCreated`** handling and v2 **`createAccounts`** (changelog’s `setAccounts`). Stored registry objects use the normalized `address` field, so checksum-style EVM addresses from Snaps match the rest of MetaMask.
> 
> Unit tests cover both helpers for EVM and Solana accounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d057b6720b3161479ea5128221e5b706ec658169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->