### PR TITLE
feat(keyring-snap-bridge): add `SnapKeyringV1Adapter`

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `SnapKeyringV1Adapter` to adapt Snap v2 keyrings to legacy v1 keyring operations ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Add `SnapKeyringV1Adapter` to adapt Snap v2 keyrings to legacy v1 keyring operations ([#557](https://github.com/MetaMask/accounts/pull/557))
+  - This adapter mostly exposes EVM signing operations through `EthKeyringV1Adapter`.
+  - This adapter also implements `removeAccount` the way it was implemented by the legacy Snap keyring (compatible with the `KeyringController` account removal flow).
 
 ### Changed
 

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `SnapKeyringV1Adapter` to adapt Snap v2 keyrings to legacy v1 keyring operations ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 ### Changed
 
 - Normalize `KeyringAccount`'s address with `:accountCreated` and `setAccounts` ([#556](https://github.com/MetaMask/accounts/pull/556))

--- a/packages/keyring-snap-bridge/src/index.ts
+++ b/packages/keyring-snap-bridge/src/index.ts
@@ -1,5 +1,6 @@
 export * from './options';
 export * from './types';
 export * from './SnapKeyring';
+export * from './v2/SnapKeyringV1Adapter';
 export * from './SnapKeyringV1';
 export type * from './SnapKeyringMessenger';

--- a/packages/keyring-snap-bridge/src/index.ts
+++ b/packages/keyring-snap-bridge/src/index.ts
@@ -1,6 +1,5 @@
 export * from './options';
 export * from './types';
 export * from './SnapKeyring';
-export * from './v2/SnapKeyringV1Adapter';
 export * from './SnapKeyringV1';
 export type * from './SnapKeyringMessenger';

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
@@ -79,7 +79,7 @@ async function setup({
   const lookupByAddress = jest.spyOn(inner, 'lookupByAddress');
 
   return {
-    adapter: new SnapKeyringV1Adapter({ keyring: inner }),
+    adapter: new SnapKeyringV1Adapter(inner),
     inner,
     mocks: {
       deleteAccount,

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
@@ -1,0 +1,186 @@
+import type { KeyringAccount } from '@metamask/keyring-api';
+import { EthAccountType, EthScope } from '@metamask/keyring-api';
+import { KeyringType } from '@metamask/keyring-api/v2';
+import { KeyringV1Adapter } from '@metamask/keyring-sdk/v2';
+import type { AccountId } from '@metamask/keyring-utils';
+import type { SnapId } from '@metamask/snaps-sdk';
+
+import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
+import { SnapKeyring } from './SnapKeyring';
+import type { SnapKeyringCallbacks, SnapKeyringState } from './SnapKeyring';
+import { SnapKeyringV1Adapter } from './SnapKeyringV1Adapter';
+
+const ACCOUNT_ID = 'f2b88e0e-82a4-4e93-8c60-4fe59c6892d7';
+const ACCOUNT_ADDRESS = '0xdeadbeef00000000000000000000000000000000';
+const OTHER_ACCOUNT_ID = '978b6a3d-ce0f-4fc9-9746-70ea61fa714f';
+const OTHER_ACCOUNT_ADDRESS = '0xcafecafe00000000000000000000000000000000';
+const SNAP_ID = 'local:snap.mock' as SnapId;
+
+type SetupOptions = {
+  accounts?: KeyringAccount[];
+};
+
+function buildAccount({
+  id = ACCOUNT_ID,
+  address = ACCOUNT_ADDRESS,
+}: {
+  id?: AccountId;
+  address?: string;
+} = {}): KeyringAccount {
+  return {
+    id,
+    type: EthAccountType.Eoa,
+    address,
+    scopes: [EthScope.Eoa],
+    options: {},
+    methods: [],
+  };
+}
+
+type SetupResult = {
+  adapter: SnapKeyringV1Adapter;
+  inner: SnapKeyring;
+  mocks: {
+    deleteAccount: jest.SpyInstance<
+      ReturnType<SnapKeyring['deleteAccount']>,
+      Parameters<SnapKeyring['deleteAccount']>
+    >;
+    deserialize: jest.SpyInstance<
+      ReturnType<SnapKeyring['deserialize']>,
+      Parameters<SnapKeyring['deserialize']>
+    >;
+    lookupByAddress: jest.SpyInstance<
+      ReturnType<SnapKeyring['lookupByAddress']>,
+      Parameters<SnapKeyring['lookupByAddress']>
+    >;
+  };
+};
+
+async function setup({
+  accounts = [buildAccount()],
+}: SetupOptions = {}): Promise<SetupResult> {
+  const state: SnapKeyringState = {
+    snapId: SNAP_ID,
+    accounts: Object.fromEntries(
+      accounts.map((account) => [account.id, account]),
+    ),
+  };
+
+  const inner = new SnapKeyring({
+    callbacks: buildCallbacks(),
+    messenger: buildMessenger(),
+  });
+  await inner.deserialize(state);
+
+  const deleteAccount = jest
+    .spyOn(inner, 'deleteAccount')
+    .mockResolvedValue(undefined);
+  const deserialize = jest.spyOn(inner, 'deserialize');
+  const lookupByAddress = jest.spyOn(inner, 'lookupByAddress');
+
+  return {
+    adapter: new SnapKeyringV1Adapter({ keyring: inner }),
+    inner,
+    mocks: {
+      deleteAccount,
+      deserialize,
+      lookupByAddress,
+    },
+  };
+}
+
+function buildCallbacks(): SnapKeyringCallbacks {
+  return {
+    addAccount: jest
+      .fn<
+        ReturnType<SnapKeyringCallbacks['addAccount']>,
+        Parameters<SnapKeyringCallbacks['addAccount']>
+      >()
+      .mockResolvedValue(undefined),
+    removeAccount: jest
+      .fn<
+        ReturnType<SnapKeyringCallbacks['removeAccount']>,
+        Parameters<SnapKeyringCallbacks['removeAccount']>
+      >()
+      .mockResolvedValue(undefined),
+    saveState: jest
+      .fn<
+        ReturnType<SnapKeyringCallbacks['saveState']>,
+        Parameters<SnapKeyringCallbacks['saveState']>
+      >()
+      .mockResolvedValue(undefined),
+    redirectUser: jest
+      .fn<
+        ReturnType<SnapKeyringCallbacks['redirectUser']>,
+        Parameters<SnapKeyringCallbacks['redirectUser']>
+      >()
+      .mockResolvedValue(undefined),
+    assertAccountCanBeUsed: jest
+      .fn<
+        ReturnType<SnapKeyringCallbacks['assertAccountCanBeUsed']>,
+        Parameters<SnapKeyringCallbacks['assertAccountCanBeUsed']>
+      >()
+      .mockResolvedValue(undefined),
+  };
+}
+
+function buildMessenger(): SnapKeyringMessenger {
+  return {
+    call: jest.fn(),
+    publish: jest.fn(),
+  } as unknown as SnapKeyringMessenger;
+}
+
+describe('SnapKeyringV1Adapter', () => {
+  it('inherits generic v1 adapter behavior', async () => {
+    const account = buildAccount();
+    const otherAccount = buildAccount({
+      id: OTHER_ACCOUNT_ID,
+      address: OTHER_ACCOUNT_ADDRESS,
+    });
+    const { adapter, inner, mocks } = await setup({
+      accounts: [account, otherAccount],
+    });
+    const state: SnapKeyringState = {
+      snapId: SNAP_ID,
+      accounts: {},
+    };
+
+    expect(adapter).toBeInstanceOf(KeyringV1Adapter);
+    expect(adapter.type).toBe(KeyringType.Snap);
+    expect(adapter.unwrap()).toBe(inner);
+    expect(await adapter.getAccounts()).toStrictEqual([
+      ACCOUNT_ADDRESS,
+      OTHER_ACCOUNT_ADDRESS,
+    ]);
+    expect(await adapter.serialize()).toStrictEqual({
+      snapId: SNAP_ID,
+      accounts: {
+        [ACCOUNT_ID]: account,
+        [OTHER_ACCOUNT_ID]: otherAccount,
+      },
+    });
+
+    await adapter.deserialize(state);
+
+    expect(mocks.deserialize).toHaveBeenCalledWith(state);
+  });
+
+  it('removes an account by resolving its address and deleting its account ID', async () => {
+    const { adapter, mocks } = await setup();
+
+    await adapter.removeAccount(ACCOUNT_ADDRESS);
+
+    expect(mocks.lookupByAddress).toHaveBeenCalledWith(ACCOUNT_ADDRESS);
+    expect(mocks.deleteAccount).toHaveBeenCalledWith(ACCOUNT_ID);
+  });
+
+  it('throws if no account matches the address', async () => {
+    const { adapter, mocks } = await setup({ accounts: [] });
+
+    await expect(adapter.removeAccount(ACCOUNT_ADDRESS)).rejects.toThrow(
+      `Account '${ACCOUNT_ADDRESS}' not found`,
+    );
+    expect(mocks.deleteAccount).not.toHaveBeenCalled();
+  });
+});

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.ts
@@ -1,0 +1,23 @@
+import { EthKeyringV1Adapter } from '@metamask/keyring-sdk/v2';
+
+import type { SnapKeyring } from './SnapKeyring';
+
+/**
+ * Adapts a v2 Snap keyring to the legacy v1 keyring API.
+ */
+export class SnapKeyringV1Adapter extends EthKeyringV1Adapter<SnapKeyring> {
+  /**
+   * Remove an account matching the given address.
+   *
+   * @param address - Address of the account to remove.
+   */
+  async removeAccount(address: string): Promise<void> {
+    const account = this.inner.lookupByAddress(address);
+
+    if (!account) {
+      throw new Error(`Account '${address}' not found`);
+    }
+
+    await this.inner.deleteAccount(account.id);
+  }
+}

--- a/packages/keyring-snap-bridge/src/v2/index.ts
+++ b/packages/keyring-snap-bridge/src/v2/index.ts
@@ -1,1 +1,2 @@
 export * from './SnapKeyring';
+export * from './SnapKeyringV1Adapter';


### PR DESCRIPTION
A more specialized adapter for the `SnapKeyring` v2 instances. For recall, each v2 instances are being wrapped in a v1 equivalent adapter since the `KeyringController` requires it.

We now have a more specific one mostly to address a different implementation of `removeAccount` (it always had been `async` even in the legacy Snap keyring) AND [the `KeyringController` already `await` for this call](https://github.com/MetaMask/core/blob/5e36b5f8f733177d120815d0c2f8819007a159da/packages/keyring-controller/src/KeyringController.ts#L1353-L1360).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, focused adapter with tests; account removal behavior is intentional compatibility with KeyringController, not new crypto or auth logic.
> 
> **Overview**
> Introduces **`SnapKeyringV1Adapter`**, a thin wrapper around v2 **`SnapKeyring`** so it can be used where **`KeyringController`** still expects the legacy v1 keyring surface.
> 
> Most v1 behavior (including EVM signing) comes from **`EthKeyringV1Adapter`** in `@metamask/keyring-sdk`. This PR adds Snap-specific **`removeAccount(address)`**: resolve the account by address, then **`deleteAccount`** by id—matching the legacy Snap keyring’s async removal flow that the controller already awaits.
> 
> The adapter is **exported** from `@metamask/keyring-snap-bridge/v2`, documented in the package changelog, and covered by unit tests for generic v1 adapter behavior and account removal errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c29631076ad4c6082aa3d2ebc04c199f968bdc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->