### PR TITLE
fix(keyring-snap-sdk): use `KeyringRpc`

### DIFF
--- a/packages/keyring-snap-sdk/CHANGELOG.md
+++ b/packages/keyring-snap-sdk/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `KeyringRpc` instaed of `Keyring` (v2) in `handleKeyringRequest` ([#561](https://github.com/MetaMask/accounts/pull/561))
+  - Snaps do not need to implement the full `Keyring` (v2) interface, this one is meant to be used in the "client-world".
+  - `KeyringRpc` is a subset of `Keyring` which only exposes the method that can be used through `onKeyringRequest` (`keyring_*` requests).
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
 
 ## [9.0.1]

--- a/packages/keyring-snap-sdk/src/v2/rpc-handler.test.ts
+++ b/packages/keyring-snap-sdk/src/v2/rpc-handler.test.ts
@@ -4,7 +4,6 @@ import type {
   GetAccountRequest,
   GetAccountsRequest,
   DeleteAccountRequest,
-  Keyring,
   ExportAccountRequest,
   SubmitRequestRequest,
   KeyringRpc,

--- a/packages/keyring-snap-sdk/src/v2/rpc-handler.test.ts
+++ b/packages/keyring-snap-sdk/src/v2/rpc-handler.test.ts
@@ -1,6 +1,5 @@
 import { KeyringRpcMethod, PrivateKeyEncoding } from '@metamask/keyring-api/v2';
 import type {
-  KeyringType,
   CreateAccountsRequest,
   GetAccountRequest,
   GetAccountsRequest,
@@ -8,6 +7,7 @@ import type {
   Keyring,
   ExportAccountRequest,
   SubmitRequestRequest,
+  KeyringRpc,
 } from '@metamask/keyring-api/v2';
 import type { JsonRpcRequest } from '@metamask/keyring-utils';
 
@@ -21,13 +21,6 @@ describe('handleKeyringRequest', () => {
     deleteAccount: jest.fn(),
     exportAccount: jest.fn(),
     submitRequest: jest.fn(),
-    // Not required by this test.
-    type: 'Mocked Keyring' as KeyringType,
-    capabilities: {
-      scopes: [],
-    },
-    serialize: jest.fn(),
-    deserialize: jest.fn(),
   };
 
   afterEach(() => {
@@ -196,7 +189,7 @@ describe('handleKeyringRequest', () => {
       params: { id: '4f983fa2-4f53-4c63-a7c2-f9a5ed750041' },
     };
 
-    const partialKeyring: Keyring = {
+    const partialKeyring: KeyringRpc = {
       ...keyring,
     };
     delete partialKeyring.exportAccount;

--- a/packages/keyring-snap-sdk/src/v2/rpc-handler.ts
+++ b/packages/keyring-snap-sdk/src/v2/rpc-handler.ts
@@ -7,7 +7,7 @@ import {
   ExportAccountRequestStruct,
   SubmitRequestRequestStruct,
 } from '@metamask/keyring-api/v2';
-import type { Keyring } from '@metamask/keyring-api/v2';
+import type { KeyringRpc } from '@metamask/keyring-api/v2';
 import type { JsonRpcRequest } from '@metamask/keyring-utils';
 import { JsonRpcRequestStruct } from '@metamask/keyring-utils';
 import { assert } from '@metamask/superstruct';
@@ -28,7 +28,7 @@ import { MethodNotSupportedError } from '../rpc-handler';
  * @returns A promise that resolves to the keyring response.
  */
 async function dispatchKeyringRequest(
-  keyring: Keyring,
+  keyring: KeyringRpc,
   request: JsonRpcRequest,
 ): Promise<Json | void> {
   // We first have to make sure that the request is a valid JSON-RPC request so
@@ -95,7 +95,7 @@ async function dispatchKeyringRequest(
  * ```
  */
 export async function handleKeyringRequest(
-  keyring: Keyring,
+  keyring: KeyringRpc,
   request: JsonRpcRequest,
 ): Promise<Json | void> {
   try {


### PR DESCRIPTION
Use `KeyringRpc` instead of `Keyring` (v2) type, since the Snap does not need to implement the full `Keyring` (v2) interface, only a subset of it (`KeyringRpc`, just the RPC-callable methods basically)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only API tightening in the Snap SDK with no change to RPC dispatch logic or security-sensitive paths.
> 
> **Overview**
> **`handleKeyringRequest`** (v2) now types its keyring argument as **`KeyringRpc`** instead of the full v2 **`Keyring`**, matching what Snap `onKeyringRequest` handlers actually need to implement (RPC-callable methods only, not client-side concerns like `serialize` / `deserialize` / `type` / `capabilities`).
> 
> Tests and the **Unreleased** changelog are updated accordingly; runtime dispatch behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be3cea91d0a9a192874e40864b8c5299ef3df389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->