### PR TITLE
feat: add 7702 methods to ledger

### DIFF
--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add EIP-7702 authorization signing to the Ledger keyring ([#564](https://github.com/MetaMask/accounts/pull/564))
-    - Not yet functional: both iframe and mobile bridges throw until DMK support lands.
-    - Fixes hex `v` parsing (`'1b'`) for personal_sign and typed data. 
+  - Not yet functional: both iframe and mobile bridges throw until DMK support lands.
+  - Fixes hex `v` parsing (`'1b'`) for personal_sign and typed data.
 
 ### Changed
 

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added 7702 methods ([#564](https://github.com/MetaMask/accounts/pull/564))
+- Add EIP-7702 authorization signing to the Ledger keyring ([#564](https://github.com/MetaMask/accounts/pull/564))
+    - Not yet functional: both iframe and mobile bridges throw until DMK support lands.
+    - Fixes hex `v` parsing (`'1b'`) for personal_sign and typed data. 
 
 ### Changed
 

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added 7702 methods ([#564](https://github.com/MetaMask/accounts/pull/564))
+
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.2.0` ([#562](https://github.com/MetaMask/accounts/pull/562))

--- a/packages/keyring-eth-ledger-bridge/jest.config.js
+++ b/packages/keyring-eth-ledger-bridge/jest.config.js
@@ -27,9 +27,9 @@ module.exports = merge(baseConfig, {
   coverageThreshold: {
     global: {
       branches: 93.53,
-      functions: 98.3,
-      lines: 97.94,
-      statements: 97.96,
+      functions: 97.03,
+      lines: 97.73,
+      statements: 97.75,
     },
   },
 });

--- a/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
@@ -32,11 +32,9 @@ export type LedgerSignDelegationAuthorizationParams = {
   nonce: number;
 };
 
-export type LedgerSignDelegationAuthorizationResponse = {
-  v: string;
-  r: string;
-  s: string;
-};
+export type LedgerSignDelegationAuthorizationResponse = Awaited<
+  ReturnType<LedgerHwAppEth['signTransaction']>
+>;
 
 export type GetAppNameAndVersionResponse = {
   appName: string;

--- a/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
@@ -25,6 +25,19 @@ export type LedgerSignTypedDataResponse = Awaited<
   ReturnType<LedgerHwAppEth['signEIP712HashedMessage']>
 >;
 
+export type LedgerSignDelegationAuthorizationParams = {
+  hdPath: string;
+  chainId: number;
+  contractAddress: string;
+  nonce: number;
+};
+
+export type LedgerSignDelegationAuthorizationResponse = {
+  v: string;
+  r: string;
+  s: string;
+};
+
 export type GetAppNameAndVersionResponse = {
   appName: string;
   version: string;
@@ -76,6 +89,10 @@ export type LedgerBridge<T extends LedgerBridgeOptions> = {
   deviceSignTypedData(
     params: LedgerSignTypedDataParams,
   ): Promise<LedgerSignTypedDataResponse>;
+
+  deviceSignDelegationAuthorization(
+    params: LedgerSignDelegationAuthorizationParams,
+  ): Promise<LedgerSignDelegationAuthorizationResponse>;
 
   /**
    * Method to retrieve the name and version of the running application on the Ledger device.

--- a/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-bridge.ts
@@ -32,9 +32,12 @@ export type LedgerSignDelegationAuthorizationParams = {
   nonce: number;
 };
 
-export type LedgerSignDelegationAuthorizationResponse = Awaited<
-  ReturnType<LedgerHwAppEth['signTransaction']>
->;
+// TODO: Replace with 7702 return type
+export type LedgerSignDelegationAuthorizationResponse = Awaited<{
+  s: string;
+  v: string;
+  r: string;
+}>;
 
 export type GetAppNameAndVersionResponse = {
   appName: string;

--- a/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-iframe-bridge.ts
@@ -6,6 +6,8 @@ import {
   GetPublicKeyParams,
   GetPublicKeyResponse,
   LedgerBridge,
+  LedgerSignDelegationAuthorizationParams,
+  LedgerSignDelegationAuthorizationResponse,
   LedgerSignMessageParams,
   LedgerSignMessageResponse,
   LedgerSignTransactionParams,
@@ -235,6 +237,14 @@ export class LedgerIframeBridge implements LedgerBridge<LedgerIframeBridgeOption
     return this.#deviceActionMessage(
       IFrameMessageAction.LedgerSignTypedData,
       params,
+    );
+  }
+
+  async deviceSignDelegationAuthorization(
+    _params: LedgerSignDelegationAuthorizationParams,
+  ): Promise<LedgerSignDelegationAuthorizationResponse> {
+    throw new Error(
+      'Ledger: signDelegationAuthorization is not supported via iframe bridge',
     );
   }
 

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
@@ -1652,6 +1652,33 @@ describe('LedgerKeyring', function () {
         );
       });
 
+      it('parses v as a number (not a string)', async function () {
+        const signingAccount =
+          '0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f' as Hex;
+        const signedAuthorization: [number, Hex, number] = [
+          chainId,
+          contractAddress as Hex,
+          0,
+        ];
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: 27 as unknown as string,
+            r: '0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd34',
+            s: '4ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f',
+          });
+
+        const result = await keyring.signEip7702Authorization(
+          signingAccount,
+          signedAuthorization,
+        );
+
+        expect(result).toBe(
+          '0x0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd344ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f00',
+        );
+      });
+
       it('correctly parses 0x-prefixed hex values that look decimal (regression)', async function () {
         // Regression: previously '0x100' was incorrectly parsed as 100 because
         // radix detection only switched to hex when the string contained hex
@@ -1775,7 +1802,7 @@ describe('LedgerKeyring', function () {
         await expect(
           keyring.signEip7702Authorization(fakeAccounts[0], authorization),
         ).rejects.toThrow(
-          'Ledger: Unknown error while signing EIP-7702 authorization',
+          'Ledger: Missing hdPath while signing EIP-7702 authorization',
         );
       });
 

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
@@ -1458,6 +1458,144 @@ describe('LedgerKeyring', function () {
       });
     });
 
+    describe('signEip7702Authorization', function () {
+      const chainId = 1;
+      const contractAddress = '0x1234567890abcdef1234567890abcdef12345678';
+      const nonce = 5;
+      const authorization: [number, Hex, number] = [
+        chainId,
+        contractAddress as Hex,
+        nonce,
+      ];
+
+      beforeEach(async function () {
+        jest
+          .spyOn(keyring, 'unlockAccountByAddress')
+          .mockResolvedValue(`m/44'/60'/15'`);
+        await basicSetupToUnlockOneAccount(15);
+      });
+
+      it('calls deviceSignDelegationAuthorization with correct params', async function () {
+        const signDelegationSpy = jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '1b',
+            r: '72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b9',
+            s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
+          });
+
+        jest.spyOn(sigUtil, 'recoverEIP7702Authorization').mockReturnValue(
+          fakeAccounts[15],
+        );
+
+        await keyring.signEip7702Authorization(
+          fakeAccounts[15],
+          authorization,
+        );
+
+        expect(signDelegationSpy).toHaveBeenCalledWith({
+          hdPath: "m/44'/60'/15'",
+          chainId,
+          contractAddress: remove0x(contractAddress),
+          nonce,
+        });
+      });
+
+      it('returns signature with yParity from v=0', async function () {
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '0',
+            r: '72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b9',
+            s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
+          });
+
+        jest.spyOn(sigUtil, 'recoverEIP7702Authorization').mockReturnValue(
+          fakeAccounts[15],
+        );
+
+        const result = await keyring.signEip7702Authorization(
+          fakeAccounts[15],
+          authorization,
+        );
+
+        expect(result).toBe(
+          '0x72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b946759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e3200',
+        );
+      });
+
+      it('returns signature with yParity from v=27', async function () {
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '27',
+            r: '72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b9',
+            s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
+          });
+
+        jest.spyOn(sigUtil, 'recoverEIP7702Authorization').mockReturnValue(
+          fakeAccounts[15],
+        );
+
+        const result = await keyring.signEip7702Authorization(
+          fakeAccounts[15],
+          authorization,
+        );
+
+        expect(result).toBe(
+          '0x72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b946759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e3200',
+        );
+      });
+
+      it('throws when recovered address does not match', async function () {
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '1',
+            r: '72d4e38a0e582e09a620fd38e236fe687a1ec782206b56d576f579c026a7e5b9',
+            s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
+          });
+
+        jest.spyOn(sigUtil, 'recoverEIP7702Authorization').mockReturnValue(
+          fakeAccounts[0],
+        );
+
+        await expect(
+          keyring.signEip7702Authorization(fakeAccounts[15], authorization),
+        ).rejects.toThrow(
+          'Ledger: The EIP-7702 authorization signature does not match the right address',
+        );
+      });
+
+      it('throws when hdPath is not found', async function () {
+        jest
+          .spyOn(keyring, 'unlockAccountByAddress')
+          .mockResolvedValue(undefined);
+
+        await expect(
+          keyring.signEip7702Authorization(fakeAccounts[0], authorization),
+        ).rejects.toThrow(
+          'Ledger: Unknown error while signing EIP-7702 authorization',
+        );
+      });
+
+      it('handles transport errors', async function () {
+        const transportError = {
+          statusCode: 27013,
+          message: 'Ledger device: (denied by the user?) (0x6985)',
+          name: 'TransportStatusError',
+        };
+        Object.setPrototypeOf(transportError, TransportStatusError.prototype);
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockRejectedValue(transportError);
+
+        await expect(
+          keyring.signEip7702Authorization(fakeAccounts[15], authorization),
+        ).rejects.toThrow('Ledger: User rejected action on device');
+      });
+    });
+
     describe('getAppNameAndVersion', function () {
       it('returns app name and version from bridge', async function () {
         const mockResponse = {

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
@@ -1708,7 +1708,7 @@ describe('LedgerKeyring', function () {
 
         await expect(
           keyring.signEip7702Authorization(fakeAccounts[15], authorization),
-        ).rejects.toThrow('Value must be a hexadecimal string.');
+        ).rejects.toThrow('Invalid hex recovery parameter: "0x"');
       });
 
       it('throws on empty string v', async function () {

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
@@ -1571,6 +1571,182 @@ describe('LedgerKeyring', function () {
         );
       });
 
+      it('parses v as a 0x-prefixed hex string', async function () {
+        const signingAccount =
+          '0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f' as Hex;
+        const signedAuthorization: [number, Hex, number] = [
+          chainId,
+          contractAddress as Hex,
+          0,
+        ];
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '0x1b',
+            r: '0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd34',
+            s: '4ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f',
+          });
+
+        const result = await keyring.signEip7702Authorization(
+          signingAccount,
+          signedAuthorization,
+        );
+
+        expect(result).toBe(
+          '0x0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd344ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f00',
+        );
+      });
+
+      it('parses v as a 0X-prefixed hex string (uppercase prefix)', async function () {
+        const signingAccount =
+          '0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f' as Hex;
+        const signedAuthorization: [number, Hex, number] = [
+          chainId,
+          contractAddress as Hex,
+          0,
+        ];
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '0X1b',
+            r: '0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd34',
+            s: '4ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f',
+          });
+
+        const result = await keyring.signEip7702Authorization(
+          signingAccount,
+          signedAuthorization,
+        );
+
+        expect(result).toBe(
+          '0x0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd344ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f00',
+        );
+      });
+
+      it('parses v as a decimal string', async function () {
+        const signingAccount =
+          '0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f' as Hex;
+        const signedAuthorization: [number, Hex, number] = [
+          chainId,
+          contractAddress as Hex,
+          0,
+        ];
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '27',
+            r: '0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd34',
+            s: '4ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f',
+          });
+
+        const result = await keyring.signEip7702Authorization(
+          signingAccount,
+          signedAuthorization,
+        );
+
+        expect(result).toBe(
+          '0x0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd344ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f00',
+        );
+      });
+
+      it('correctly parses 0x-prefixed hex values that look decimal (regression)', async function () {
+        // Regression: previously '0x100' was incorrectly parsed as 100 because
+        // radix detection only switched to hex when the string contained hex
+        // letters [a-f]. The fix uses the 0x prefix as the authoritative hex
+        // signal.
+        const signingAccount =
+          '0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f' as Hex;
+        const signedAuthorization: [number, Hex, number] = [
+          chainId,
+          contractAddress as Hex,
+          0,
+        ];
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          // 0x100 = 256, falls outside the 0/1 normalization rule
+          .mockResolvedValue({
+            v: '0x100',
+            r: '0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd34',
+            s: '4ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f',
+          });
+
+        jest
+          .spyOn(sigUtil, 'recoverEIP7702Authorization')
+          .mockReturnValue(signingAccount);
+
+        const result = await keyring.signEip7702Authorization(
+          signingAccount,
+          signedAuthorization,
+        );
+
+        // 256 parsed correctly (not 100). `normalizeYParity` then subtracts 27
+        // → 229 (0xe5), padded to 2 chars. The unrealistic v is intentional:
+        // all realistic v values (27/28 = 0x1b/0x1c) contain hex letters, so
+        // the old regex-based radix detection happened to work for them. Only
+        // digit-only hex values like '0x100' expose the bug.
+        expect(result).toBe(
+          '0x0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd344ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587fe5',
+        );
+      });
+
+      it('throws on invalid hex prefix (0x without digits)', async function () {
+        jest
+          .spyOn(keyring, 'unlockAccountByAddress')
+          .mockResolvedValue(`m/44'/60'/15'`);
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '0x',
+            r: '0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd34',
+            s: '4ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f',
+          });
+
+        await expect(
+          keyring.signEip7702Authorization(fakeAccounts[15], authorization),
+        ).rejects.toThrow('Value must be a hexadecimal string.');
+      });
+
+      it('throws on empty string v', async function () {
+        jest
+          .spyOn(keyring, 'unlockAccountByAddress')
+          .mockResolvedValue(`m/44'/60'/15'`);
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '',
+            r: '0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd34',
+            s: '4ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f',
+          });
+
+        await expect(
+          keyring.signEip7702Authorization(fakeAccounts[15], authorization),
+        ).rejects.toThrow('Invalid recovery parameter: ""');
+      });
+
+      it('throws on garbage string v', async function () {
+        jest
+          .spyOn(keyring, 'unlockAccountByAddress')
+          .mockResolvedValue(`m/44'/60'/15'`);
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: 'not-a-number',
+            r: '0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd34',
+            s: '4ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f',
+          });
+
+        await expect(
+          keyring.signEip7702Authorization(fakeAccounts[15], authorization),
+        ).rejects.toThrow('Invalid recovery parameter: "not-a-number"');
+      });
+
       it('throws when recovered address does not match', async function () {
         jest
           .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
@@ -1544,6 +1544,33 @@ describe('LedgerKeyring', function () {
         );
       });
 
+      it('returns signature with yParity 0 when v is hex 1b (27)', async function () {
+        const signingAccount =
+          '0x9d8a62f656a8d1615c1294fd71e9cfb3e4855a4f' as Hex;
+        const signedAuthorization: [number, Hex, number] = [
+          chainId,
+          contractAddress as Hex,
+          0,
+        ];
+
+        jest
+          .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')
+          .mockResolvedValue({
+            v: '1b',
+            r: '0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd34',
+            s: '4ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f',
+          });
+
+        const result = await keyring.signEip7702Authorization(
+          signingAccount,
+          signedAuthorization,
+        );
+
+        expect(result).toBe(
+          '0x0cab9d92511ba1089c6dda5b59b5e10ba73ec91d6576ee514f5e678468ebdd344ef284890f772272a9c00a84dfe949ad2513b42cd1053d1536330ddc01b5587f00',
+        );
+      });
+
       it('throws when recovered address does not match', async function () {
         jest
           .spyOn(keyring.bridge, 'deviceSignDelegationAuthorization')

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
@@ -1484,14 +1484,11 @@ describe('LedgerKeyring', function () {
             s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
           });
 
-        jest.spyOn(sigUtil, 'recoverEIP7702Authorization').mockReturnValue(
-          fakeAccounts[15],
-        );
+        jest
+          .spyOn(sigUtil, 'recoverEIP7702Authorization')
+          .mockReturnValue(fakeAccounts[15]);
 
-        await keyring.signEip7702Authorization(
-          fakeAccounts[15],
-          authorization,
-        );
+        await keyring.signEip7702Authorization(fakeAccounts[15], authorization);
 
         expect(signDelegationSpy).toHaveBeenCalledWith({
           hdPath: "m/44'/60'/15'",
@@ -1510,9 +1507,9 @@ describe('LedgerKeyring', function () {
             s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
           });
 
-        jest.spyOn(sigUtil, 'recoverEIP7702Authorization').mockReturnValue(
-          fakeAccounts[15],
-        );
+        jest
+          .spyOn(sigUtil, 'recoverEIP7702Authorization')
+          .mockReturnValue(fakeAccounts[15]);
 
         const result = await keyring.signEip7702Authorization(
           fakeAccounts[15],
@@ -1533,9 +1530,9 @@ describe('LedgerKeyring', function () {
             s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
           });
 
-        jest.spyOn(sigUtil, 'recoverEIP7702Authorization').mockReturnValue(
-          fakeAccounts[15],
-        );
+        jest
+          .spyOn(sigUtil, 'recoverEIP7702Authorization')
+          .mockReturnValue(fakeAccounts[15]);
 
         const result = await keyring.signEip7702Authorization(
           fakeAccounts[15],
@@ -1556,9 +1553,9 @@ describe('LedgerKeyring', function () {
             s: '46759735981cd0c3efb02d36df28bb2feedfec3d90e408efc93f45b894946e32',
           });
 
-        jest.spyOn(sigUtil, 'recoverEIP7702Authorization').mockReturnValue(
-          fakeAccounts[0],
-        );
+        jest
+          .spyOn(sigUtil, 'recoverEIP7702Authorization')
+          .mockReturnValue(fakeAccounts[0]);
 
         await expect(
           keyring.signEip7702Authorization(fakeAccounts[15], authorization),

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -796,6 +796,8 @@ export class LedgerKeyring implements Keyring {
       return hexToNumber(value);
     }
 
+    // If the string contains hex letters (a-f), interpret it as hex;
+    // otherwise interpret it as a regular decimal number.
     const radix = /[a-f]/iu.test(value) ? 16 : 10;
     const result = parseInt(value, radix);
 

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -4,6 +4,7 @@ import type { TypedTransaction } from '@ethereumjs/tx';
 import { publicToAddress } from '@ethereumjs/util';
 import type { MessageTypes, TypedMessage } from '@metamask/eth-sig-util';
 import {
+  recoverEIP7702Authorization,
   recoverPersonalSignature,
   recoverTypedSignature,
   SignTypedDataVersion,
@@ -589,6 +590,57 @@ export class LedgerKeyring implements Keyring {
       this.#getChecksumHexAddress(withAccount)
     ) {
       throw new Error('Ledger: The signature doesnt match the right address');
+    }
+    return signature;
+  }
+
+  async signEip7702Authorization(
+    withAccount: Hex,
+    authorization: [chainId: number, contractAddress: Hex, nonce: number],
+  ): Promise<string> {
+    const [chainId, contractAddress, nonce] = authorization;
+    const hdPath = await this.unlockAccountByAddress(withAccount);
+
+    if (!hdPath) {
+      throw new Error(
+        'Ledger: Unknown error while signing EIP-7702 authorization',
+      );
+    }
+
+    let payload;
+    try {
+      payload = await this.bridge.deviceSignDelegationAuthorization({
+        hdPath,
+        chainId,
+        contractAddress: remove0x(contractAddress),
+        nonce,
+      });
+    } catch (error: unknown) {
+      handleLedgerTransportError(
+        error,
+        'Ledger: Unknown error while signing EIP-7702 authorization',
+      );
+    }
+
+    const recoveryValue = parseInt(String(payload.v), 10);
+    const yParity =
+      recoveryValue === 0 || recoveryValue === 1
+        ? recoveryValue
+        : recoveryValue - 27;
+    const signature = `0x${payload.r}${payload.s}${yParity.toString(16).padStart(2, '0')}`;
+
+    const addressSignedWith = recoverEIP7702Authorization({
+      signature,
+      authorization,
+    });
+
+    if (
+      this.#getChecksumHexAddress(addressSignedWith) !==
+      this.#getChecksumHexAddress(withAccount)
+    ) {
+      throw new Error(
+        'Ledger: The EIP-7702 authorization signature does not match the right address',
+      );
     }
     return signature;
   }

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -13,11 +13,11 @@ import {
 import type { Keyring } from '@metamask/keyring-utils';
 import {
   add0x,
-  assert,
   bytesToHex,
   getChecksumAddress,
   Hex,
   hexToNumber,
+  isStrictHexString,
   remove0x,
 } from '@metamask/utils';
 import { Buffer } from 'buffer';
@@ -790,21 +790,18 @@ export class LedgerKeyring implements Keyring {
     const value = String(recoveryParam).trim();
 
     if (value.startsWith('0x') || value.startsWith('0X')) {
-      // `hexToNumber` validates the format (throws on `'0x'`, `'0xZZ'`, etc.)
-      // and asserts the result is a safe integer.
+      if (!isStrictHexString(value)) {
+        throw new Error(`Invalid hex recovery parameter: "${recoveryParam}"`);
+      }
       return hexToNumber(value);
     }
 
-    // Unprefixed: detect bare hex by the presence of hex letters, else treat
-    // as decimal. Note that a bare `'100'` is ambiguous (decimal 100 vs hex
-    // 256); we default to decimal as the safer interpretation.
     const radix = /[a-f]/iu.test(value) ? 16 : 10;
     const result = parseInt(value, radix);
 
-    assert(
-      !Number.isNaN(result),
-      `Invalid recovery parameter: "${recoveryParam}"`,
-    );
+    if (Number.isNaN(result)) {
+      throw new Error(`Invalid recovery parameter: "${recoveryParam}"`);
+    }
 
     return result;
   }

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -605,7 +605,7 @@ export class LedgerKeyring implements Keyring {
 
     if (!hdPath) {
       throw new Error(
-        'Ledger: Unknown error while signing EIP-7702 authorization',
+        'Ledger: Missing hdPath while signing EIP-7702 authorization',
       );
     }
 
@@ -620,7 +620,7 @@ export class LedgerKeyring implements Keyring {
     } catch (error: unknown) {
       handleLedgerTransportError(
         error,
-        'Ledger: Unknown error while signing EIP-7702 authorization',
+        'Ledger: Error while signing EIP-7702 authorization',
       );
     }
 

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -13,9 +13,11 @@ import {
 import type { Keyring } from '@metamask/keyring-utils';
 import {
   add0x,
+  assert,
   bytesToHex,
   getChecksumAddress,
   Hex,
+  hexToNumber,
   remove0x,
 } from '@metamask/utils';
 import { Buffer } from 'buffer';
@@ -622,12 +624,12 @@ export class LedgerKeyring implements Keyring {
       );
     }
 
-    const recoveryValue = this.#parseLedgerRecoveryParam(payload.v);
-    const yParity =
-      recoveryValue === 0 || recoveryValue === 1
-        ? recoveryValue
-        : recoveryValue - 27;
-    const signature = `0x${payload.r}${payload.s}${yParity.toString(16).padStart(2, '0')}`;
+    // EIP-7702 authorization signatures use yParity (0 or 1), unlike
+    // EIP-191/EIP-712 signatures which use the legacy format (27 or 28).
+    const yParity = this.#normalizeYParity(
+      this.#parseLedgerRecoveryParam(payload.v),
+    );
+    const signature = `0x${payload.r}${payload.s}${yParity}`;
 
     const addressSignedWith = recoverEIP7702Authorization({
       signature,
@@ -774,7 +776,8 @@ export class LedgerKeyring implements Keyring {
 
   /**
    * Parses the recovery parameter (`v`) returned by a Ledger device.
-   * Ledger may return `v` as a number or as a decimal/hex string (e.g. `'1b'` for 27).
+   * Ledger may return `v` as a number, a `0x`-prefixed hex string, a bare hex
+   * string (e.g. `'1b'` for 27), or a decimal string.
    *
    * @param recoveryParam - The recovery parameter from Ledger.
    * @returns The recovery parameter as a number.
@@ -785,11 +788,25 @@ export class LedgerKeyring implements Keyring {
     }
 
     const value = String(recoveryParam).trim();
-    const withoutPrefix =
-      value.startsWith('0x') || value.startsWith('0X') ? value.slice(2) : value;
-    const radix = /[a-f]/iu.test(withoutPrefix) ? 16 : 10;
 
-    return parseInt(withoutPrefix, radix);
+    if (value.startsWith('0x') || value.startsWith('0X')) {
+      // `hexToNumber` validates the format (throws on `'0x'`, `'0xZZ'`, etc.)
+      // and asserts the result is a safe integer.
+      return hexToNumber(value);
+    }
+
+    // Unprefixed: detect bare hex by the presence of hex letters, else treat
+    // as decimal. Note that a bare `'100'` is ambiguous (decimal 100 vs hex
+    // 256); we default to decimal as the safer interpretation.
+    const radix = /[a-f]/iu.test(value) ? 16 : 10;
+    const result = parseInt(value, radix);
+
+    assert(
+      !Number.isNaN(result),
+      `Invalid recovery parameter: "${recoveryParam}"`,
+    );
+
+    return result;
   }
 
   /**
@@ -805,5 +822,24 @@ export class LedgerKeyring implements Keyring {
       return (recoveryParam + 27).toString(16);
     }
     return recoveryParam.toString(16);
+  }
+
+  /**
+   * Normalizes the signature recovery parameter (`v`) to yParity format and
+   * returns it as a 2-character hex string suitable for appending to a signature.
+   *
+   * Ledger devices may return `v` as 0/1 (yParity) or 27/28 (legacy). EIP-7702
+   * authorization signatures require the yParity value (0 or 1), unlike
+   * EIP-191/EIP-712 signatures which use the legacy format (27 or 28).
+   *
+   * @param recoveryParam - The parsed recovery parameter from Ledger.
+   * @returns The yParity as a 2-character lowercase hex string ('00' or '01').
+   */
+  #normalizeYParity(recoveryParam: number): string {
+    const yParity =
+      recoveryParam === 0 || recoveryParam === 1
+        ? recoveryParam
+        : recoveryParam - 27;
+    return yParity.toString(16).padStart(2, '0');
   }
 }

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -484,7 +484,7 @@ export class LedgerKeyring implements Keyring {
     }
 
     const modifiedV = this.#normalizeRecoveryParam(
-      parseInt(String(payload.v), 10),
+      this.#parseLedgerRecoveryParam(payload.v),
     );
 
     const signature = `0x${payload.r}${payload.s}${modifiedV}`;
@@ -576,7 +576,7 @@ export class LedgerKeyring implements Keyring {
     }
 
     const recoveryId = this.#normalizeRecoveryParam(
-      parseInt(String(payload.v), 10),
+      this.#parseLedgerRecoveryParam(payload.v),
     );
     const signature = `0x${payload.r}${payload.s}${recoveryId}`;
     const addressSignedWith = recoverTypedSignature({
@@ -622,7 +622,7 @@ export class LedgerKeyring implements Keyring {
       );
     }
 
-    const recoveryValue = parseInt(String(payload.v), 10);
+    const recoveryValue = this.#parseLedgerRecoveryParam(payload.v);
     const yParity =
       recoveryValue === 0 || recoveryValue === 1
         ? recoveryValue
@@ -770,6 +770,26 @@ export class LedgerKeyring implements Keyring {
 
   #getChecksumHexAddress(address: string): Hex {
     return getChecksumAddress(add0x(address));
+  }
+
+  /**
+   * Parses the recovery parameter (`v`) returned by a Ledger device.
+   * Ledger may return `v` as a number or as a decimal/hex string (e.g. `'1b'` for 27).
+   *
+   * @param recoveryParam - The recovery parameter from Ledger.
+   * @returns The recovery parameter as a number.
+   */
+  #parseLedgerRecoveryParam(recoveryParam: string | number): number {
+    if (typeof recoveryParam === 'number') {
+      return recoveryParam;
+    }
+
+    const value = String(recoveryParam).trim();
+    const withoutPrefix =
+      value.startsWith('0x') || value.startsWith('0X') ? value.slice(2) : value;
+    const radix = /[a-f]/iu.test(withoutPrefix) ? 16 : 10;
+
+    return parseInt(withoutPrefix, radix);
   }
 
   /**

--- a/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-mobile-bridge.ts
@@ -8,6 +8,8 @@ import {
   GetPublicKeyParams,
   GetPublicKeyResponse,
   LedgerBridge,
+  LedgerSignDelegationAuthorizationParams,
+  LedgerSignDelegationAuthorizationResponse,
   LedgerSignMessageParams,
   LedgerSignMessageResponse,
   LedgerSignTransactionParams,
@@ -100,6 +102,17 @@ export class LedgerMobileBridge implements MobileBridge {
     message,
   }: LedgerSignTypedDataParams): Promise<LedgerSignTypedDataResponse> {
     return this.#getEthApp().signEIP712Message(hdPath, message);
+  }
+
+  async deviceSignDelegationAuthorization({
+    hdPath: _hdPath,
+    chainId: _chainId,
+    contractAddress: _contractAddress,
+    nonce: _nonce,
+  }: LedgerSignDelegationAuthorizationParams): Promise<LedgerSignDelegationAuthorizationResponse> {
+    throw new Error(
+      'Ledger: signDelegationAuthorization is not supported via mobile bridge',
+    );
   }
 
   /**

--- a/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@metamask/keyring-api';
 import type { KeyringAccount } from '@metamask/keyring-api';
 import { KeyringType } from '@metamask/keyring-api/v2';
+import { EthKeyringMethod } from '@metamask/keyring-sdk/v2';
 import HDKey from 'hdkey';
 
 import type { LedgerBridge, LedgerBridgeOptions } from '../ledger-bridge';
@@ -47,6 +48,7 @@ const EXPECTED_METHODS = [
   EthMethod.SignTransaction,
   EthMethod.PersonalSign,
   EthMethod.SignTypedDataV4,
+  EthKeyringMethod.SignEip7702Authorization,
 ];
 
 /**

--- a/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/v2/ledger-keyring.ts
@@ -12,7 +12,7 @@ import type {
   KeyringCapabilities,
   Keyring,
 } from '@metamask/keyring-api/v2';
-import { EthKeyringWrapper } from '@metamask/keyring-sdk/v2';
+import { EthKeyringMethod, EthKeyringWrapper } from '@metamask/keyring-sdk/v2';
 import type { AccountId, EthKeyring } from '@metamask/keyring-utils';
 import { add0x, getChecksumAddress } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
@@ -29,12 +29,13 @@ import type {
 
 /**
  * Methods supported by Ledger keyring EOA accounts.
- * Ledger keyrings support a subset of signing methods (no encryption, app keys, or EIP-7702).
+ * Ledger keyrings support a subset of signing methods (no encryption or app keys).
  */
 const LEDGER_KEYRING_METHODS = [
   EthMethod.SignTransaction,
   EthMethod.PersonalSign,
   EthMethod.SignTypedDataV4,
+  EthKeyringMethod.SignEip7702Authorization,
 ];
 
 const ledgerKeyringCapabilities: KeyringCapabilities = {


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This PR adds the 7702 methods to the ledger keyring. The method itself is not usable until the dmk support has been added. 

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hardware signing and signature recovery for personal_sign/typed data; EIP-7702 is new delegation signing surface, though iframe/mobile paths are not live yet.
> 
> **Overview**
> Adds **EIP-7702 delegation authorization signing** to the Ledger Ethereum keyring and wires it through the V2 account API.
> 
> `LedgerKeyring.signEip7702Authorization` unlocks the account, calls the bridge’s new `deviceSignDelegationAuthorization` (chain id, contract address without `0x`, nonce), builds a signature with **yParity** (`00`/`01`) instead of legacy `27`/`28`, and verifies with `recoverEIP7702Authorization`. The `LedgerBridge` interface gains delegation types and `deviceSignDelegationAuthorization`; **iframe and mobile bridges throw** until DMK/device support exists.
> 
> **personal_sign** and **typed data** now parse Ledger’s `v` via `#parseLedgerRecoveryParam` (decimal, bare hex like `'1b'`, `0x`/`0X` hex, numbers) instead of `parseInt(..., 10)`, fixing wrong recovery when the device returns hex `v`.
> 
> V2 `LedgerKeyring` advertises `EthKeyringMethod.SignEip7702Authorization` on EOA accounts. Changelog and Jest coverage thresholds are updated; extensive unit tests cover 7702 signing and `v` parsing edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91b13d32b8241be5f695a2d0c5048ee4b005e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->