### PR TITLE
ci: add missing permissions.contents = read

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,6 +8,9 @@ on:
       SLACK_WEBHOOK_URL:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:


### PR DESCRIPTION
Was missing in:
- https://github.com/MetaMask/accounts/pull/565

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only permission defaulting with no application or release logic changes; job-level elevated permissions are unchanged.
> 
> **Overview**
> Adds **workflow-level** `permissions: contents: read` to the reusable **Publish Release** workflow (`.github/workflows/publish-release.yml`).
> 
> That sets a least-privilege default for the whole callable workflow. The `publish-release` job still requests `contents: write` for release publishing, and `publish-npm` keeps its existing `contents: read` / `id-token: write` job permissions—only the missing top-level `contents: read` block is added, aligned with other workflows in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a7f26a1a052efdace33df68afa1f40bace89897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->