### PR TITLE
feat(keyring-api): add `token:disapprove` transaction type + new optional `details.typeLabel`

### DIFF
--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `TransactionType.TokenDisapprove` for token disapproval transactions and optional `typeLabel` string field to `TransactionDetails` ([#568](https://github.com/MetaMask/accounts/pull/568))
+- Add `TransactionType.TokenDisapprove` for token disapproval transactions ([#568](https://github.com/MetaMask/accounts/pull/568))
+- Add optional `TransactionDetails.typeLabel` ([#568](https://github.com/MetaMask/accounts/pull/568))
+  - This can be used to display a custom label regarding the transaction type.
 
 ## [23.2.0]
 

--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `TransactionType.Custom` and optional `transactionData` JSON field to `TransactionDetails` ([#568](https://github.com/MetaMask/accounts/pull/568))
+- Add `TransactionType.TokenDisapprove` for token disapproval transactions and optional `typeLabel` string field to `TransactionDetails` ([#568](https://github.com/MetaMask/accounts/pull/568))
 
 ## [23.2.0]
 

--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `TransactionType.Custom` and optional `transactionData` JSON field to `TransactionDetails` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Add `TransactionType.Custom` and optional `transactionData` JSON field to `TransactionDetails` ([#568](https://github.com/MetaMask/accounts/pull/568))
 
 ## [23.2.0]
 

--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `TransactionType.Custom` and optional `transactionData` JSON field to `TransactionDetails` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 ## [23.2.0]
 
 ### Added

--- a/packages/keyring-api/src/api/transaction.test.ts
+++ b/packages/keyring-api/src/api/transaction.test.ts
@@ -46,6 +46,28 @@ describe('TransactionStruct', () => {
         },
         expected: true,
       },
+      // With transactionData
+      {
+        transaction: {
+          ...baseTransaction,
+          details: {
+            transactionData: { label: 'Custom action', category: 'defi' },
+          },
+        },
+        expected: true,
+      },
+      // With all details fields
+      {
+        transaction: {
+          ...baseTransaction,
+          details: {
+            origin: 'metamask',
+            securityAlertResponse: 'Benign',
+            transactionData: { foo: 'bar' },
+          },
+        },
+        expected: true,
+      },
       // All valid securityAlertResponse values
       {
         transaction: {

--- a/packages/keyring-api/src/api/transaction.test.ts
+++ b/packages/keyring-api/src/api/transaction.test.ts
@@ -46,13 +46,11 @@ describe('TransactionStruct', () => {
         },
         expected: true,
       },
-      // With transactionData
+      // With typeLabel
       {
         transaction: {
           ...baseTransaction,
-          details: {
-            transactionData: { label: 'Custom action', category: 'defi' },
-          },
+          details: { typeLabel: 'Revoke USDC approval' },
         },
         expected: true,
       },
@@ -63,7 +61,7 @@ describe('TransactionStruct', () => {
           details: {
             origin: 'metamask',
             securityAlertResponse: 'Benign',
-            transactionData: { foo: 'bar' },
+            typeLabel: 'Some label',
           },
         },
         expected: true,
@@ -95,6 +93,14 @@ describe('TransactionStruct', () => {
         transaction: {
           ...baseTransaction,
           details: { securityAlertResponse: 'Invalid' },
+        },
+        expected: false,
+      },
+      // Invalid typeLabel
+      {
+        transaction: {
+          ...baseTransaction,
+          details: { typeLabel: 123 },
         },
         expected: false,
       },

--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -418,7 +418,7 @@ export const TransactionStruct = object({
    * Additional transaction details {@see TransactionDetailsStruct}.
    *
    * Contains contextual information about the transaction such as its origin,
-   * security assessment, and additional transaction data.
+   * security assessment and additional transaction data.
    * This field is optional and may not be present for all transactions.
    */
   details: exactOptional(TransactionDetailsStruct),

--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -175,8 +175,8 @@ export enum TransactionType {
    * Represents a custom transaction type.
    *
    * Use this when the transaction does not fit any predefined type.
-   * Additional transaction details may be provided in
-   * {@link TransactionDetailsStruct.transactionData}.
+   * Additional transaction details may be provided via the `details.transactionData`
+   * field (see {@link TransactionDetailsStruct}).
    */
   Custom = 'custom',
 

--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -250,7 +250,7 @@ export const TransactionDetailsStruct = object({
   ),
 
   /**
-   * Optional label for UI display purposes.
+   * Optional transaction type label (for UI display purposes).
    */
   typeLabel: exactOptional(string()),
 });

--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -2,6 +2,7 @@ import type { InferEquals } from '@metamask/keyring-utils';
 import { exactOptional, object, UuidStruct } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 import { array, enums, nullable, number, string } from '@metamask/superstruct';
+import { JsonStruct } from '@metamask/utils';
 
 import { AssetStruct } from './asset';
 import { CaipChainIdStruct } from './caip';
@@ -171,6 +172,15 @@ export enum TransactionType {
   TokenApprove = 'token:approve',
 
   /**
+   * Represents a custom transaction type.
+   *
+   * Use this when the transaction does not fit any predefined type.
+   * Additional transaction details may be provided in
+   * {@link TransactionDetailsStruct.transactionData}.
+   */
+  Custom = 'custom',
+
+  /**
    * The transaction type is unknown. It's not possible to determine the
    * transaction type based on the information available.
    */
@@ -215,6 +225,17 @@ export enum SecurityAlertResponse {
  *   securityAlertResponse: 'Warning',
  * }
  * ```
+ *
+ * @example
+ * ```ts
+ * {
+ *   transactionData: {
+ *     type: 'claim-rewards',
+ *     protocol: 'lido',
+ *     label: 'Claim staking rewards',
+ *   },
+ * }
+ * ```
  */
 export const TransactionDetailsStruct = object({
   /**
@@ -236,6 +257,11 @@ export const TransactionDetailsStruct = object({
       `${SecurityAlertResponse.Malicious}`,
     ]),
   ),
+
+  /**
+   * Optional JSON metadata for additional transaction details.
+   */
+  transactionData: exactOptional(JsonStruct),
 });
 
 /**
@@ -361,6 +387,7 @@ export const TransactionStruct = object({
     `${TransactionType.StakeDeposit}`,
     `${TransactionType.StakeWithdraw}`,
     `${TransactionType.TokenApprove}`,
+    `${TransactionType.Custom}`,
     `${TransactionType.Unknown}`,
   ]),
 
@@ -390,9 +417,9 @@ export const TransactionStruct = object({
   /**
    * Additional transaction details {@see TransactionDetailsStruct}.
    *
-   * Contains contextual information about the transaction such as its origin and
-   * security assessment. This field is optional and may not be present for all
-   * transactions.
+   * Contains contextual information about the transaction such as its origin,
+   * security assessment, and additional transaction data.
+   * This field is optional and may not be present for all transactions.
    */
   details: exactOptional(TransactionDetailsStruct),
 });

--- a/packages/keyring-api/src/api/transaction.ts
+++ b/packages/keyring-api/src/api/transaction.ts
@@ -2,7 +2,6 @@ import type { InferEquals } from '@metamask/keyring-utils';
 import { exactOptional, object, UuidStruct } from '@metamask/keyring-utils';
 import type { Infer } from '@metamask/superstruct';
 import { array, enums, nullable, number, string } from '@metamask/superstruct';
-import { JsonStruct } from '@metamask/utils';
 
 import { AssetStruct } from './asset';
 import { CaipChainIdStruct } from './caip';
@@ -172,13 +171,9 @@ export enum TransactionType {
   TokenApprove = 'token:approve',
 
   /**
-   * Represents a custom transaction type.
-   *
-   * Use this when the transaction does not fit any predefined type.
-   * Additional transaction details may be provided via the `details.transactionData`
-   * field (see {@link TransactionDetailsStruct}).
+   * Represents a token disapproval transaction.
    */
-  Custom = 'custom',
+  TokenDisapprove = 'token:disapprove',
 
   /**
    * The transaction type is unknown. It's not possible to determine the
@@ -229,11 +224,7 @@ export enum SecurityAlertResponse {
  * @example
  * ```ts
  * {
- *   transactionData: {
- *     type: 'claim-rewards',
- *     protocol: 'lido',
- *     label: 'Claim staking rewards',
- *   },
+ *   typeLabel: 'Some label',
  * }
  * ```
  */
@@ -259,9 +250,9 @@ export const TransactionDetailsStruct = object({
   ),
 
   /**
-   * Optional JSON metadata for additional transaction details.
+   * Optional label for UI display purposes.
    */
-  transactionData: exactOptional(JsonStruct),
+  typeLabel: exactOptional(string()),
 });
 
 /**
@@ -387,7 +378,7 @@ export const TransactionStruct = object({
     `${TransactionType.StakeDeposit}`,
     `${TransactionType.StakeWithdraw}`,
     `${TransactionType.TokenApprove}`,
-    `${TransactionType.Custom}`,
+    `${TransactionType.TokenDisapprove}`,
     `${TransactionType.Unknown}`,
   ]),
 
@@ -418,8 +409,8 @@ export const TransactionStruct = object({
    * Additional transaction details {@see TransactionDetailsStruct}.
    *
    * Contains contextual information about the transaction such as its origin,
-   * security assessment and additional transaction data.
-   * This field is optional and may not be present for all transactions.
+   * security assessment, and optional `typeLabel`. This field is optional and
+   * may not be present for all transactions.
    */
   details: exactOptional(TransactionDetailsStruct),
 });


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, backward-compatible schema and enum extensions with validation tests only; no auth or runtime behavior changes.
> 
> **Overview**
> Extends the Keyring API **transaction** model so snaps and clients can classify token revocations and show richer activity labels.
> 
> Adds **`TransactionType.TokenDisapprove`** (`token:disapprove`) alongside the existing `token:approve` type, and wires it into **`TransactionStruct`** validation so listed transactions can use the new type.
> 
> Adds an optional **`details.typeLabel`** string on **`TransactionDetailsStruct`** for custom UI copy (e.g. “Revoke USDC approval”) without changing the canonical `type`. Tests cover valid/invalid `typeLabel` and combined `details` fields; the changelog documents both additions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98aaf02f952b929b9b077bdcf90a16d1f6c39f70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->