### PR TITLE
feat(keyring-snap-bridge): add missing static `SnapKeyring.type` (v2)

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `static type` for v2 `SnapKeyring` ([#570](https://github.com/MetaMask/accounts/pull/570))
+
 ## [22.2.0]
 
 ### Added

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -92,6 +92,15 @@ async function makeKeyring(
 }
 
 describe('SnapKeyring', () => {
+  describe('type', () => {
+    it('returns `KeyringType.Snap`', async () => {
+      expect(SnapKeyring.type).toBe(KeyringType.Snap);
+
+      const { keyring } = await makeKeyring();
+      expect(keyring.type).toBe(KeyringType.Snap);
+    });
+  });
+
   describe('snapId', () => {
     it('returns the snap ID set during deserialize', async () => {
       const { keyring } = await makeKeyring();

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -114,6 +114,8 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
 
   readonly type = `${KeyringType.Snap}` as const;
 
+  static readonly type = `${KeyringType.Snap}` as const;
+
   /**
    * Capabilities are snap-specific. Initialized empty and can be updated
    * by the parent when snap metadata becomes available.


### PR DESCRIPTION
Old v1 keyrings used to have this `static` field too.

NOTE: Current v2 wrappers are using the v1 legacy type, and that's something we might want to change in the future. But the `SnapKeyring` v2 is different from those, since it is not wrapping any existing keyring, so we can use a v2 type here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API surface addition with no behavior change to account or signing flows.
> 
> **Overview**
> Adds **`static readonly type`** on v2 **`SnapKeyring`**, set to **`KeyringType.Snap`** alongside the existing instance **`type`** field. This restores the same class-level type identifier pattern legacy v1 snap keyrings exposed, so callers can read the keyring kind without instantiating the class.
> 
> Tests assert both **`SnapKeyring.type`** and **`keyring.type`** resolve to **`KeyringType.Snap`**. The package changelog records the addition under **Unreleased**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49fb77c99ec5d1f77de995bc61e9e2b303b778d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->