### PR TITLE
feat: add `superstruct.sensitive`

### DIFF
--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use `sensitive` struct for `privateKey` in `PrivateKeyExportedAccountStruct` ([#577](https://github.com/MetaMask/accounts/pull/577))
-  - This make sure the private key value is always redacted in case of validation errors.
+  - This ensures the private key value is always redacted in case of validation errors.
 - Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
 
 ## [23.5.0]

--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support for `base32` private key encoding in `exportAccount` ([#589](https://github.com/MetaMask/accounts/pull/589))
 
+### Changed
+
+- Use `sensitive` struct for `privateKey` in `PrivateKeyExportedAccountStruct` ([#577](https://github.com/MetaMask/accounts/pull/577))
+  - This make sure the private key value is always redacted in case of validation errors.
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
+
 ## [23.5.0]
 
 ### Added

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@metamask/keyring-utils": "^3.3.1",
-    "@metamask/superstruct": "^3.4.0",
+    "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",
     "bitcoin-address-validation": "^2.2.3"
   },

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@metamask/keyring-utils": "^3.3.1",
-    "@metamask/superstruct": "^3.3.0",
+    "@metamask/superstruct": "^3.4.0",
     "@metamask/utils": "^11.11.0",
     "bitcoin-address-validation": "^2.2.3"
   },

--- a/packages/keyring-api/src/v2/api/create-account/private-key.test.ts
+++ b/packages/keyring-api/src/v2/api/create-account/private-key.test.ts
@@ -1,0 +1,91 @@
+import type { StructError } from '@metamask/superstruct';
+import { assert, object, string } from '@metamask/superstruct';
+
+import { CreateAccountPrivateKeyOptionsStruct } from './private-key';
+
+const SENSITIVE_REDACTED = '***';
+
+const RAW_PRIVATE_KEY =
+  '0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678';
+
+const VALID_OPTIONS = {
+  type: 'private-key:import' as const,
+  privateKey: RAW_PRIVATE_KEY,
+  encoding: 'hexadecimal' as const,
+};
+
+describe('CreateAccountPrivateKeyOptionsStruct', () => {
+  it('accepts a valid options object', () => {
+    expect(() => assert(VALID_OPTIONS, CreateAccountPrivateKeyOptionsStruct)).not.toThrow();
+  });
+
+  it('redacts the private key value from the error when `privateKey` is invalid', () => {
+    let error: StructError | undefined;
+    try {
+      assert(
+        { type: 'private-key:import', privateKey: 123, encoding: 'hexadecimal' },
+        CreateAccountPrivateKeyOptionsStruct,
+      );
+    } catch (caughtError) {
+      error = caughtError as StructError;
+    }
+    expect(error?.value).toBe(SENSITIVE_REDACTED);
+    expect(error?.message).toContain(SENSITIVE_REDACTED);
+    expect(error?.message).not.toContain('123');
+  });
+
+  it('redacts the private key from `branch` when a sibling field fails', () => {
+    let error: StructError | undefined;
+    try {
+      assert(
+        {
+          type: 'private-key:import',
+          privateKey: RAW_PRIVATE_KEY,
+          encoding: 'invalid-encoding',
+        },
+        CreateAccountPrivateKeyOptionsStruct,
+      );
+    } catch (caughtError) {
+      error = caughtError as StructError;
+    }
+    expect(error?.message).toContain('encoding');
+    const allBranchItems = (error?.failures() ?? []).flatMap(
+      (failure) => failure.branch,
+    );
+    expect(allBranchItems).not.toContainEqual(
+      expect.objectContaining({ privateKey: RAW_PRIVATE_KEY }),
+    );
+  });
+
+  it('redacts the private key from nested `branch` items when wrapped in an outer struct', () => {
+    const WrapperStruct = object({
+      options: CreateAccountPrivateKeyOptionsStruct,
+      tag: string(),
+    });
+
+    let error: StructError | undefined;
+    try {
+      assert(
+        {
+          options: {
+            type: 'private-key:import',
+            privateKey: RAW_PRIVATE_KEY,
+            encoding: 'invalid-encoding', // Triggers failure inside the nested struct.
+          },
+          tag: 'ok',
+        },
+        WrapperStruct,
+      );
+    } catch (caughtError) {
+      error = caughtError as StructError;
+    }
+
+    // The branch for the `encoding` failure travels through the outer object
+    // -> options object -> 'invalid-encoding'. The options object sitting in
+    // that branch must not expose the raw private key.
+    const allBranchItems = (error?.failures() ?? []).flatMap(
+      (failure) => failure.branch,
+    );
+    expect(JSON.stringify(allBranchItems)).not.toContain(RAW_PRIVATE_KEY);
+  });
+});

--- a/packages/keyring-api/src/v2/api/create-account/private-key.test.ts
+++ b/packages/keyring-api/src/v2/api/create-account/private-key.test.ts
@@ -16,14 +16,20 @@ const VALID_OPTIONS = {
 
 describe('CreateAccountPrivateKeyOptionsStruct', () => {
   it('accepts a valid options object', () => {
-    expect(() => assert(VALID_OPTIONS, CreateAccountPrivateKeyOptionsStruct)).not.toThrow();
+    expect(() =>
+      assert(VALID_OPTIONS, CreateAccountPrivateKeyOptionsStruct),
+    ).not.toThrow();
   });
 
   it('redacts the private key value from the error when `privateKey` is invalid', () => {
     let error: StructError | undefined;
     try {
       assert(
-        { type: 'private-key:import', privateKey: 123, encoding: 'hexadecimal' },
+        {
+          type: 'private-key:import',
+          privateKey: 123,
+          encoding: 'hexadecimal',
+        },
         CreateAccountPrivateKeyOptionsStruct,
       );
     } catch (caughtError) {

--- a/packages/keyring-api/src/v2/api/create-account/private-key.ts
+++ b/packages/keyring-api/src/v2/api/create-account/private-key.ts
@@ -1,4 +1,10 @@
-import { exactOptional, literal, object, sensitive, string } from '@metamask/superstruct';
+import {
+  exactOptional,
+  literal,
+  object,
+  sensitive,
+  string,
+} from '@metamask/superstruct';
 import type { Infer } from '@metamask/superstruct';
 
 import { KeyringAccountTypeStruct } from '../../../api/account';

--- a/packages/keyring-api/src/v2/api/create-account/private-key.ts
+++ b/packages/keyring-api/src/v2/api/create-account/private-key.ts
@@ -1,4 +1,4 @@
-import { exactOptional, literal, object, string } from '@metamask/superstruct';
+import { exactOptional, literal, object, sensitive, string } from '@metamask/superstruct';
 import type { Infer } from '@metamask/superstruct';
 
 import { KeyringAccountTypeStruct } from '../../../api/account';
@@ -15,7 +15,7 @@ export const CreateAccountPrivateKeyOptionsStruct = object({
   /**
    * The encoded private key to be imported.
    */
-  privateKey: string(),
+  privateKey: sensitive(string()),
   /**
    * The encoding of the private key.
    */

--- a/packages/keyring-api/src/v2/api/export-account/private-key.test.ts
+++ b/packages/keyring-api/src/v2/api/export-account/private-key.test.ts
@@ -1,0 +1,61 @@
+import { SENSITIVE_REDACTED } from '@metamask/keyring-utils';
+import type { StructError } from '@metamask/superstruct';
+import { assert } from '@metamask/superstruct';
+
+import { PrivateKeyExportedAccountStruct } from './private-key';
+
+const RAW_PRIVATE_KEY =
+  '0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678';
+
+describe('PrivateKeyExportedAccountStruct', () => {
+  it('accepts a valid exported account', () => {
+    expect(() =>
+      assert(
+        {
+          type: 'private-key',
+          privateKey: RAW_PRIVATE_KEY,
+          encoding: 'hexadecimal',
+        },
+        PrivateKeyExportedAccountStruct,
+      ),
+    ).not.toThrow();
+  });
+
+  it('redacts the private key value from the error when `privateKey` is invalid', () => {
+    let error: StructError | undefined;
+    try {
+      assert(
+        { type: 'private-key', privateKey: 123, encoding: 'hexadecimal' },
+        PrivateKeyExportedAccountStruct,
+      );
+    } catch (caughtError) {
+      error = caughtError as StructError;
+    }
+    expect(error?.value).toBe(SENSITIVE_REDACTED);
+    expect(error?.message).toContain(SENSITIVE_REDACTED);
+    expect(error?.message).not.toContain('123');
+  });
+
+  it('redacts the private key from `branch` when a sibling field fails', () => {
+    let error: StructError | undefined;
+    try {
+      assert(
+        {
+          type: 'private-key',
+          privateKey: RAW_PRIVATE_KEY,
+          encoding: 'invalid-encoding',
+        },
+        PrivateKeyExportedAccountStruct,
+      );
+    } catch (caughtError) {
+      error = caughtError as StructError;
+    }
+    expect(error?.message).toContain('encoding');
+    const allBranchItems = (error?.failures() ?? []).flatMap(
+      (failure) => failure.branch,
+    );
+    expect(allBranchItems).not.toContainEqual(
+      expect.objectContaining({ privateKey: RAW_PRIVATE_KEY }),
+    );
+  });
+});

--- a/packages/keyring-api/src/v2/api/export-account/private-key.test.ts
+++ b/packages/keyring-api/src/v2/api/export-account/private-key.test.ts
@@ -1,8 +1,9 @@
-import { SENSITIVE_REDACTED } from '@metamask/keyring-utils';
 import type { StructError } from '@metamask/superstruct';
 import { assert } from '@metamask/superstruct';
 
 import { PrivateKeyExportedAccountStruct } from './private-key';
+
+const SENSITIVE_REDACTED = '***';
 
 const RAW_PRIVATE_KEY =
   '0xdeadbeef1234567890abcdef1234567890abcdef1234567890abcdef12345678';

--- a/packages/keyring-api/src/v2/api/export-account/private-key.test.ts
+++ b/packages/keyring-api/src/v2/api/export-account/private-key.test.ts
@@ -1,5 +1,5 @@
 import type { StructError } from '@metamask/superstruct';
-import { assert } from '@metamask/superstruct';
+import { assert, object, string } from '@metamask/superstruct';
 
 import { PrivateKeyExportedAccountStruct } from './private-key';
 
@@ -35,6 +35,38 @@ describe('PrivateKeyExportedAccountStruct', () => {
     expect(error?.value).toBe(SENSITIVE_REDACTED);
     expect(error?.message).toContain(SENSITIVE_REDACTED);
     expect(error?.message).not.toContain('123');
+  });
+
+  it('redacts the private key from nested `branch` items when wrapped in an outer struct', () => {
+    const WrapperStruct = object({
+      account: PrivateKeyExportedAccountStruct,
+      tag: string(),
+    });
+
+    let error: StructError | undefined;
+    try {
+      assert(
+        {
+          account: {
+            type: 'private-key',
+            privateKey: RAW_PRIVATE_KEY,
+            encoding: 'invalid-encoding', // Triggers failure inside the nested struct.
+          },
+          tag: 'ok',
+        },
+        WrapperStruct,
+      );
+    } catch (caughtError) {
+      error = caughtError as StructError;
+    }
+
+    // The branch for the `encoding` failure travels through the outer object
+    // -> account object -> 'invalid-encoding'. The account object sitting in
+    // that branch must not expose the raw private key.
+    const allBranchItems = (error?.failures() ?? []).flatMap(
+      (failure) => failure.branch,
+    );
+    expect(JSON.stringify(allBranchItems)).not.toContain(RAW_PRIVATE_KEY);
   });
 
   it('redacts the private key from `branch` when a sibling field fails', () => {

--- a/packages/keyring-api/src/v2/api/export-account/private-key.ts
+++ b/packages/keyring-api/src/v2/api/export-account/private-key.ts
@@ -1,4 +1,4 @@
-import { literal, object, string } from '@metamask/superstruct';
+import { object, sensitive, literal, string } from '@metamask/superstruct';
 import type { Infer } from '@metamask/superstruct';
 
 import { PrivateKeyEncodingStruct } from '../private-key';
@@ -14,7 +14,7 @@ export const PrivateKeyExportedAccountStruct = object({
   /**
    * The private key of the exported account.
    */
-  privateKey: string(),
+  privateKey: sensitive(string()),
   /**
    * The encoding of the exported private key.
    */

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.2.0` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546), [#562](https://github.com/MetaMask/accounts/pull/562))
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.5.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583), [#587](https://github.com/MetaMask/accounts/pull/587))
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
 
 ## [14.1.1]
 

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -74,7 +74,7 @@
     "@metamask/keyring-sdk": "^2.2.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/scure-bip39": "^2.1.1",
-    "@metamask/superstruct": "^3.4.0",
+    "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",
     "ethereum-cryptography": "^2.2.1"
   },

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -74,7 +74,7 @@
     "@metamask/keyring-sdk": "^2.2.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/scure-bip39": "^2.1.1",
-    "@metamask/superstruct": "^3.3.0",
+    "@metamask/superstruct": "^3.4.0",
     "@metamask/utils": "^11.11.0",
     "ethereum-cryptography": "^2.2.1"
   },

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.5.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583), [#587](https://github.com/MetaMask/accounts/pull/587))
 - Bump `@metamask/keyring-sdk` from `^2.1.1` to `^2.2.0` ([#562](https://github.com/MetaMask/accounts/pull/562))
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
 
 ## [3.0.0]
 

--- a/packages/keyring-eth-money/package.json
+++ b/packages/keyring-eth-money/package.json
@@ -70,7 +70,7 @@
     "@metamask/keyring-api": "^23.5.0",
     "@metamask/keyring-sdk": "^2.2.0",
     "@metamask/keyring-utils": "^3.3.1",
-    "@metamask/superstruct": "^3.3.0",
+    "@metamask/superstruct": "^3.4.0",
     "async-mutex": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/keyring-eth-money/package.json
+++ b/packages/keyring-eth-money/package.json
@@ -70,7 +70,7 @@
     "@metamask/keyring-api": "^23.5.0",
     "@metamask/keyring-sdk": "^2.2.0",
     "@metamask/keyring-utils": "^3.3.1",
-    "@metamask/superstruct": "^3.4.0",
+    "@metamask/superstruct": "^3.4.1",
     "async-mutex": "^0.5.0"
   },
   "devDependencies": {

--- a/packages/keyring-internal-api/CHANGELOG.md
+++ b/packages/keyring-internal-api/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.5.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583), [#587](https://github.com/MetaMask/accounts/pull/587))
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
 
 ## [11.0.1]
 

--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@metamask/keyring-api": "^23.5.0",
     "@metamask/keyring-utils": "^3.3.1",
-    "@metamask/superstruct": "^3.3.0"
+    "@metamask/superstruct": "^3.4.0"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",

--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@metamask/keyring-api": "^23.5.0",
     "@metamask/keyring-utils": "^3.3.1",
-    "@metamask/superstruct": "^3.4.0"
+    "@metamask/superstruct": "^3.4.1"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^3.2.1",

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.2.0` to `^23.5.0` ([#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583), [#587](https://github.com/MetaMask/accounts/pull/587))
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
 
 ## [2.2.0]
 

--- a/packages/keyring-sdk/package.json
+++ b/packages/keyring-sdk/package.json
@@ -71,7 +71,7 @@
     "@metamask/keyring-api": "^23.5.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/scure-bip39": "^2.1.1",
-    "@metamask/superstruct": "^3.4.0",
+    "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",
     "async-mutex": "^0.5.0",
     "ethereum-cryptography": "^2.2.1",

--- a/packages/keyring-sdk/package.json
+++ b/packages/keyring-sdk/package.json
@@ -71,7 +71,7 @@
     "@metamask/keyring-api": "^23.5.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/scure-bip39": "^2.1.1",
-    "@metamask/superstruct": "^3.3.0",
+    "@metamask/superstruct": "^3.4.0",
     "@metamask/utils": "^11.11.0",
     "async-mutex": "^0.5.0",
     "ethereum-cryptography": "^2.2.1",

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
+
 ## [23.0.1]
 
 ### Fixed

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -78,7 +78,7 @@
     "@metamask/snaps-controllers": "^19.0.1",
     "@metamask/snaps-sdk": "^11.0.0",
     "@metamask/snaps-utils": "^12.2.1",
-    "@metamask/superstruct": "^3.3.0",
+    "@metamask/superstruct": "^3.4.0",
     "@metamask/utils": "^11.11.0",
     "@types/uuid": "^9.0.8",
     "async-mutex": "^0.5.0",

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -78,7 +78,7 @@
     "@metamask/snaps-controllers": "^19.0.1",
     "@metamask/snaps-sdk": "^11.0.0",
     "@metamask/snaps-utils": "^12.2.1",
-    "@metamask/superstruct": "^3.4.0",
+    "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",
     "@types/uuid": "^9.0.8",
     "async-mutex": "^0.5.0",

--- a/packages/keyring-snap-client/CHANGELOG.md
+++ b/packages/keyring-snap-client/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
+
 ## [9.2.0]
 
 ### Added

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@metamask/keyring-api": "^23.5.0",
     "@metamask/keyring-utils": "^3.3.1",
-    "@metamask/superstruct": "^3.3.0",
+    "@metamask/superstruct": "^3.4.0",
     "@types/uuid": "^9.0.8",
     "uuid": "^9.0.1",
     "webextension-polyfill": "^0.12.0"

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@metamask/keyring-api": "^23.5.0",
     "@metamask/keyring-utils": "^3.3.1",
-    "@metamask/superstruct": "^3.4.0",
+    "@metamask/superstruct": "^3.4.1",
     "@types/uuid": "^9.0.8",
     "uuid": "^9.0.1",
     "webextension-polyfill": "^0.12.0"

--- a/packages/keyring-snap-sdk/CHANGELOG.md
+++ b/packages/keyring-snap-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
+
 ## [9.2.0]
 
 ### Added

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/snaps-sdk": "^11.0.0",
-    "@metamask/superstruct": "^3.3.0",
+    "@metamask/superstruct": "^3.4.0",
     "@metamask/utils": "^11.11.0",
     "webextension-polyfill": "^0.12.0"
   },

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/snaps-sdk": "^11.0.0",
-    "@metamask/superstruct": "^3.4.0",
+    "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",
     "webextension-polyfill": "^0.12.0"
   },

--- a/packages/keyring-utils/CHANGELOG.md
+++ b/packages/keyring-utils/CHANGELOG.md
@@ -7,14 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
+
 ### Removed
 
 - **BREAKING:** Removed `object`, `type` and `exactOptional` superstruct support ([#580](https://github.com/MetaMask/accounts/pull/580))
   - Use `@metamask/superstruct` instead.
-
-### Changed
-
-- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
 
 ## [3.3.1]
 

--- a/packages/keyring-utils/CHANGELOG.md
+++ b/packages/keyring-utils/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Removed `object`, `type` and `exactOptional` superstruct support ([#580](https://github.com/MetaMask/accounts/pull/580))
   - Use `@metamask/superstruct` instead.
 
+### Changed
+
+- Bump `@metamask/superstruct` from `^3.3.0` to `^3.4.0` ([#577](https://github.com/MetaMask/accounts/pull/577))
+
 ## [3.3.1]
 
 ### Fixed

--- a/packages/keyring-utils/package.json
+++ b/packages/keyring-utils/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@ethereumjs/tx": "^5.4.0",
-    "@metamask/superstruct": "^3.4.0",
+    "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",
     "bitcoin-address-validation": "^2.2.3"
   },

--- a/packages/keyring-utils/package.json
+++ b/packages/keyring-utils/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "@ethereumjs/tx": "^5.4.0",
-    "@metamask/superstruct": "^3.3.0",
+    "@metamask/superstruct": "^3.4.0",
     "@metamask/utils": "^11.11.0",
     "bitcoin-address-validation": "^2.2.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2286,7 +2286,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
-    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/superstruct": "npm:^3.4.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
@@ -2770,7 +2770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.1, @metamask/superstruct@npm:^3.3.0, @metamask/superstruct@npm:^3.4.0":
+"@metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.1, @metamask/superstruct@npm:^3.4.0":
   version: 3.4.0
   resolution: "@metamask/superstruct@npm:3.4.0"
   checksum: 10/915a6c10019631855368c75c4295a48ece7891cd6e1ab67ed65070142ef24ab019b12d6a71aff7a747a7d5273f64f61fcc42cded4def5d7519ed8441f12884a0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,7 +1905,7 @@ __metadata:
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/old-hd-keyring": "npm:@metamask/eth-hd-keyring@^4.0.1"
     "@metamask/scure-bip39": "npm:^2.1.1"
-    "@metamask/superstruct": "npm:^3.4.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -1976,7 +1976,7 @@ __metadata:
     "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
-    "@metamask/superstruct": "npm:^3.4.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2111,7 +2111,7 @@ __metadata:
     "@metamask/snaps-controllers": "npm:^19.0.1"
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/snaps-utils": "npm:^12.2.1"
-    "@metamask/superstruct": "npm:^3.4.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2258,7 +2258,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
-    "@metamask/superstruct": "npm:^3.4.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2286,7 +2286,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
-    "@metamask/superstruct": "npm:^3.4.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"
@@ -2347,7 +2347,7 @@ __metadata:
     "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/scure-bip39": "npm:^2.1.1"
-    "@metamask/superstruct": "npm:^3.4.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2379,7 +2379,7 @@ __metadata:
     "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/providers": "npm:^19.0.0"
-    "@metamask/superstruct": "npm:^3.4.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2413,7 +2413,7 @@ __metadata:
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/providers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"
-    "@metamask/superstruct": "npm:^3.4.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2443,7 +2443,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/superstruct": "npm:^3.4.0"
+    "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2770,10 +2770,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.1, @metamask/superstruct@npm:^3.4.0":
-  version: 3.4.0
-  resolution: "@metamask/superstruct@npm:3.4.0"
-  checksum: 10/915a6c10019631855368c75c4295a48ece7891cd6e1ab67ed65070142ef24ab019b12d6a71aff7a747a7d5273f64f61fcc42cded4def5d7519ed8441f12884a0
+"@metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.1, @metamask/superstruct@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "@metamask/superstruct@npm:3.4.1"
+  checksum: 10/d37b5662dc9bbe0d99e06eb951167fa745829ae3abfa103423e9d8c05e8712f1451376f8479d484722e1e1c1d881732da1efddccaca8868b530a786264b903b5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1905,7 +1905,7 @@ __metadata:
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/old-hd-keyring": "npm:@metamask/eth-hd-keyring@^4.0.1"
     "@metamask/scure-bip39": "npm:^2.1.1"
-    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/superstruct": "npm:^3.4.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -1976,7 +1976,7 @@ __metadata:
     "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
-    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/superstruct": "npm:^3.4.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2111,7 +2111,7 @@ __metadata:
     "@metamask/snaps-controllers": "npm:^19.0.1"
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/snaps-utils": "npm:^12.2.1"
-    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/superstruct": "npm:^3.4.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2258,7 +2258,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
-    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/superstruct": "npm:^3.4.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2347,7 +2347,7 @@ __metadata:
     "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/scure-bip39": "npm:^2.1.1"
-    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/superstruct": "npm:^3.4.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2379,7 +2379,7 @@ __metadata:
     "@metamask/keyring-api": "npm:^23.5.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/providers": "npm:^19.0.0"
-    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/superstruct": "npm:^3.4.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2413,7 +2413,7 @@ __metadata:
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/providers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"
-    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/superstruct": "npm:^3.4.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2443,7 +2443,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/superstruct": "npm:^3.3.0"
+    "@metamask/superstruct": "npm:^3.4.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2770,10 +2770,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.1, @metamask/superstruct@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "@metamask/superstruct@npm:3.3.0"
-  checksum: 10/664d5e330484a86420bc004b1c7f8301e1501cce712f611fe657176b2979edbd7cc6f4c77c8b1610486a685ebbd0b72dacf4bd6cf143d6b52038069d2f4e84ab
+"@metamask/superstruct@npm:^3.1.0, @metamask/superstruct@npm:^3.2.1, @metamask/superstruct@npm:^3.3.0, @metamask/superstruct@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@metamask/superstruct@npm:3.4.0"
+  checksum: 10/915a6c10019631855368c75c4295a48ece7891cd6e1ab67ed65070142ef24ab019b12d6a71aff7a747a7d5273f64f61fcc42cded4def5d7519ed8441f12884a0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adding a new `superstruct` "decorator" to mark a field as "sensitive" this way, it never gets logged by mistake in `superstruct` error messages.

Requires:
- [x] https://github.com/MetaMask/superstruct/pull/41


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how private keys appear in validation errors (security-sensitive), but behavior is strictly redaction with dedicated tests and no change to successful validation paths.
> 
> **Overview**
> **Private key fields in keyring API structs are now wrapped with `sensitive()`** so `@metamask/superstruct` redacts them (`***`) in validation error messages, values, and failure `branch` paths—including when a sibling field (e.g. `encoding`) fails or the struct is nested.
> 
> This applies to **`CreateAccountPrivateKeyOptionsStruct`** (import) and **`PrivateKeyExportedAccountStruct`** (export). New Jest tests assert redaction for direct failures, sibling failures, and nested wrappers.
> 
> The monorepo **`@metamask/superstruct` dependency is bumped from `^3.3.0` to `^3.4.1`** across keyring packages (changelog entries note `^3.4.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cde5760b9b30e9ae4644d1e64816db2d0e27df00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->