### PR TITLE
ci: explicit dry-run

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,6 +51,8 @@ jobs:
       - name: Dry run publish to NPM
         uses: MetaMask/action-npm-publish@v6
         with:
+          dry-run: true
+          # No need for `NPM_TOKEN` for dry-runs.
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
 
@@ -75,4 +77,5 @@ jobs:
       - name: Publish to NPM
         uses: MetaMask/action-npm-publish@v6
         with:
+          dry-run: false
           npm-token: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Just being explicit here, it shouldn't be required, but it makes sense to have them IMO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow clarity with no application or publish-behavior change intended beyond making the dry-run flag explicit.
> 
> **Overview**
> Sets **`dry-run: true`** on the `publish-npm-dry-run` job’s `MetaMask/action-npm-publish@v6` step and **`dry-run: false`** on the real `publish-npm` job, so dry vs production publish mode is explicit in the workflow.
> 
> Adds a short comment on the dry-run step noting that **`NPM_TOKEN`** is not required for dry-runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 901744c2fda5f4d552a948543de2fe77f707a9df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->