### PR TITLE
feat: support the v2 keyring wire protocol for accounts Snaps

### DIFF
--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Wrap v2 `CreateAccountsRequestStruct` params in `options` to be wire-compatible with v1 ([#579](https://github.com/MetaMask/accounts/pull/579))
+
 ## [23.3.0]
 
 ### Added

--- a/packages/keyring-api/src/v2/api/keyring-rpc.test.ts
+++ b/packages/keyring-api/src/v2/api/keyring-rpc.test.ts
@@ -1,4 +1,10 @@
-import { KeyringRpcMethod, isKeyringRpcMethod } from '.';
+import { is } from '@metamask/superstruct';
+
+import {
+  KeyringRpcMethod,
+  isKeyringRpcMethod,
+  CreateAccountsRequestStruct,
+} from '.';
 
 describe('isKeyringRpcMethod', () => {
   it.each(Object.values(KeyringRpcMethod))(
@@ -10,5 +16,33 @@ describe('isKeyringRpcMethod', () => {
 
   it('returns false for unknown method', () => {
     expect(isKeyringRpcMethod('keyring_unknownMethod')).toBe(false);
+  });
+});
+
+describe('CreateAccountsRequestStruct', () => {
+  const options = {
+    type: 'bip44:derive-index',
+    entropySource: 'mock-entropy-source',
+    groupIndex: 0,
+  };
+
+  it('accepts params wrapped in `options`', () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: '1',
+      method: KeyringRpcMethod.CreateAccounts,
+      params: { options },
+    };
+    expect(is(request, CreateAccountsRequestStruct)).toBe(true);
+  });
+
+  it('rejects unwrapped (flat) params', () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: '1',
+      method: KeyringRpcMethod.CreateAccounts,
+      params: options,
+    };
+    expect(is(request, CreateAccountsRequestStruct)).toBe(false);
   });
 });

--- a/packages/keyring-api/src/v2/api/keyring-rpc.ts
+++ b/packages/keyring-api/src/v2/api/keyring-rpc.ts
@@ -99,7 +99,9 @@ export type GetAccountResponse = Infer<typeof GetAccountResponseStruct>;
 export const CreateAccountsRequestStruct = object({
   ...CommonHeader,
   method: literal(`${KeyringRpcMethod.CreateAccounts}`),
-  params: CreateAccountOptionsStruct,
+  params: object({
+    options: CreateAccountOptionsStruct,
+  }),
 });
 
 export type CreateAccountsRequest = Infer<typeof CreateAccountsRequestStruct>;

--- a/packages/keyring-snap-client/CHANGELOG.md
+++ b/packages/keyring-snap-client/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Send v2 `createAccounts` params wrapped in `options` ([#579](https://github.com/MetaMask/accounts/pull/579))
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
 

--- a/packages/keyring-snap-client/src/v2/KeyringClient.test.ts
+++ b/packages/keyring-snap-client/src/v2/KeyringClient.test.ts
@@ -89,7 +89,7 @@ describe('KeyringClient', () => {
           jsonrpc: '2.0',
           id: expect.any(String),
           method: `${KeyringRpcMethod.CreateAccounts}`,
-          params: createAccountOptions,
+          params: { options: createAccountOptions },
         });
         expect(account).toStrictEqual(expectedResponse);
       });

--- a/packages/keyring-snap-client/src/v2/KeyringClient.ts
+++ b/packages/keyring-snap-client/src/v2/KeyringClient.ts
@@ -80,7 +80,7 @@ export class KeyringClient implements KeyringRpc {
         jsonrpc: '2.0',
         id: uuid(),
         method: KeyringRpcMethod.CreateAccounts,
-        params,
+        params: { options: params },
       }),
       CreateAccountsResponseStruct,
     );

--- a/packages/keyring-snap-sdk/CHANGELOG.md
+++ b/packages/keyring-snap-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Read `params.options` for v2 `keyring_createAccounts` to match the wrapped request shape ([#579](https://github.com/MetaMask/accounts/pull/579))
+
 ## [9.0.2]
 
 ### Changed

--- a/packages/keyring-snap-sdk/src/v2/rpc-handler.test.ts
+++ b/packages/keyring-snap-sdk/src/v2/rpc-handler.test.ts
@@ -104,9 +104,11 @@ describe('handleKeyringRequest', () => {
       id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
       method: `${KeyringRpcMethod.CreateAccounts}`,
       params: {
-        type: 'bip44:derive-index',
-        groupIndex: 0,
-        entropySource: 'mock-entropy-source',
+        options: {
+          type: 'bip44:derive-index',
+          groupIndex: 0,
+          entropySource: 'mock-entropy-source',
+        },
       },
     };
 
@@ -114,8 +116,27 @@ describe('handleKeyringRequest', () => {
     keyring.createAccounts.mockResolvedValue(mockedResult);
     const result = await handleKeyringRequest(keyring, request);
 
-    expect(keyring.createAccounts).toHaveBeenCalledWith(request.params);
+    expect(keyring.createAccounts).toHaveBeenCalledWith(request.params.options);
     expect(result).toBe(mockedResult);
+  });
+
+  it('fails to call `keyring_v2_createAccounts` with unwrapped (flat) params', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: '7c507ff0-365f-4de0-8cd5-eb83c30ebda4',
+      method: `${KeyringRpcMethod.CreateAccounts}`,
+      // Flat options (v1 shape) instead of `{ options }` — must be rejected.
+      params: {
+        type: 'bip44:derive-index',
+        groupIndex: 0,
+        entropySource: 'mock-entropy-source',
+      },
+    };
+
+    await expect(
+      handleKeyringRequest(keyring, request as unknown as JsonRpcRequest),
+    ).rejects.toThrow('At path: params.options');
+    expect(keyring.createAccounts).not.toHaveBeenCalled();
   });
 
   it('calls `keyring_v2_deleteAccount`', async () => {

--- a/packages/keyring-snap-sdk/src/v2/rpc-handler.ts
+++ b/packages/keyring-snap-sdk/src/v2/rpc-handler.ts
@@ -48,7 +48,7 @@ async function dispatchKeyringRequest(
 
     case `${KeyringRpcMethod.CreateAccounts}`: {
       assert(request, CreateAccountsRequestStruct);
-      return keyring.createAccounts(request.params);
+      return keyring.createAccounts(request.params.options);
     }
 
     case `${KeyringRpcMethod.DeleteAccount}`: {


### PR DESCRIPTION
Enables the v2 keyring wire protocol end-to-end for accounts Snaps:

- `keyring-api`: wrap `CreateAccountsRequestStruct` params in `options` for v1 wire-compatibility; re-export `CaipChainId`/`DiscoveredAccount`/`EntropySourceId` from `/v2`
- `keyring-snap-sdk`: read `params.options` for `keyring_createAccounts`
- `keyring-snap-client`: send `createAccounts` params wrapped in `options`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a wire-format change for account creation RPCs; any caller still sending flat params will fail validation until upgraded alongside the client packages.
> 
> **Overview**
> Aligns v2 **`keyring_createAccounts`** JSON-RPC wire shape with v1 by requiring **`params: { options: … }`** instead of flat creation options on `params`.
> 
> **`@metamask/keyring-api`** updates `CreateAccountsRequestStruct` and adds struct tests that accept the wrapped shape and reject flat params. **`keyring-snap-client`** sends `{ options: params }` from `KeyringClient.createAccounts`. **`keyring-snap-sdk`** unmarshals `request.params.options` in the v2 RPC handler and rejects the old flat layout. Changelogs note the change for each package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9067296c9acd5e0dc9a78d6f4f260c2c352f552. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->