### PR TITLE
feat(keyring-snap-bridge): populate v2 SnapKeyring capabilities from the manifest

### DIFF
--- a/packages/keyring-internal-snap-client/package.json
+++ b/packages/keyring-internal-snap-client/package.json
@@ -78,7 +78,7 @@
     "@metamask/auto-changelog": "^6.1.0",
     "@metamask/snaps-controllers": "^19.0.1",
     "@metamask/snaps-sdk": "^11.0.0",
-    "@metamask/snaps-utils": "^12.1.3",
+    "@metamask/snaps-utils": "^12.2.1",
     "@metamask/utils": "^11.11.0",
     "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Populate v2 `SnapKeyring` `capabilities` from the Snap manifest (`endowment:keyring`) on `deserialize` ([#579](https://github.com/MetaMask/accounts/pull/579))
+
+### Changed
+
+- Bump `@metamask/snaps-utils` from `^12.1.3` to `^12.2.1` ([#579](https://github.com/MetaMask/accounts/pull/579))
+
 ## [22.3.0]
 
 ### Added

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Populate v2 `SnapKeyring` `capabilities` from the Snap manifest (`endowment:keyring`) on `deserialize` ([#579](https://github.com/MetaMask/accounts/pull/579))
+- Populate v2 `SnapKeyring` `capabilities` from the Snap manifest (`endowment:keyring`) on `deserialize` ([#581](https://github.com/MetaMask/accounts/pull/581))
+- Guard v2 `SnapKeyring` operations until `deserialize` has run (throws "SnapKeyring has not been initialized") ([#581](https://github.com/MetaMask/accounts/pull/581))
 
 ### Changed
 
-- Bump `@metamask/snaps-utils` from `^12.1.3` to `^12.2.1` ([#579](https://github.com/MetaMask/accounts/pull/579))
+- Bump `@metamask/snaps-utils` from `^12.1.3` to `^12.2.1` ([#581](https://github.com/MetaMask/accounts/pull/581))
 
 ## [22.3.0]
 

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -77,7 +77,7 @@
     "@metamask/messenger": "^1.1.1",
     "@metamask/snaps-controllers": "^19.0.1",
     "@metamask/snaps-sdk": "^11.0.0",
-    "@metamask/snaps-utils": "^12.1.3",
+    "@metamask/snaps-utils": "^12.2.1",
     "@metamask/superstruct": "^3.1.0",
     "@metamask/utils": "^11.11.0",
     "@types/uuid": "^9.0.8",

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -158,6 +158,34 @@ describe('SnapKeyring', () => {
       const keyring = await makeKeyringWithSnap(undefined);
       expect(keyring.capabilities).toStrictEqual({ scopes: [] });
     });
+
+    it('clears stale capabilities on a later deserialize without capabilities', async () => {
+      const snapWith = (keyringPermission: unknown): unknown => ({
+        manifest: {
+          initialPermissions: { 'endowment:keyring': keyringPermission },
+        },
+      });
+      const getSnap = jest
+        .fn()
+        .mockReturnValueOnce(snapWith({ capabilities: manifestCapabilities }))
+        .mockReturnValueOnce(snapWith({ allowedOrigins: [] }));
+      const messenger = {
+        call: jest.fn((action: string) =>
+          action === 'SnapController:getSnap' ? getSnap() : undefined,
+        ),
+        publish: jest.fn(),
+      } as unknown as SnapKeyringMessenger;
+      const keyring = new SnapKeyring({
+        messenger,
+        callbacks: makeMockCallbacks(),
+      });
+
+      await keyring.deserialize({ snapId: SNAP_ID, accounts: {} });
+      expect(keyring.capabilities).toStrictEqual(manifestCapabilities);
+
+      await keyring.deserialize({ snapId: SNAP_ID, accounts: {} });
+      expect(keyring.capabilities).toStrictEqual({ scopes: [] });
+    });
   });
 
   describe('initialization guard', () => {

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -160,6 +160,56 @@ describe('SnapKeyring', () => {
     });
   });
 
+  describe('initialization guard', () => {
+    const ERROR = 'SnapKeyring has not been initialized';
+
+    /**
+     * Build a `SnapKeyring` WITHOUT calling `deserialize`.
+     *
+     * @returns The uninitialized keyring.
+     */
+    function makeUninitializedKeyring(): SnapKeyring {
+      const messenger = {
+        call: jest.fn(),
+        publish: jest.fn(),
+      } as unknown as SnapKeyringMessenger;
+      return new SnapKeyring({ messenger, callbacks: makeMockCallbacks() });
+    }
+
+    it('rejects getAccounts before deserialize is called', async () => {
+      await expect(makeUninitializedKeyring().getAccounts()).rejects.toThrow(
+        ERROR,
+      );
+    });
+
+    it('rejects getAccount before deserialize is called', async () => {
+      await expect(
+        makeUninitializedKeyring().getAccount(account1.id),
+      ).rejects.toThrow(ERROR);
+    });
+
+    it('rejects createAccounts before deserialize is called', async () => {
+      await expect(
+        makeUninitializedKeyring().createAccounts({
+          type: 'bip44:derive-index',
+          entropySource: 'mock-entropy-source',
+          groupIndex: 0,
+        } as CreateAccountOptions),
+      ).rejects.toThrow(ERROR);
+    });
+
+    it('rejects deleteAccount before deserialize is called', async () => {
+      await expect(
+        makeUninitializedKeyring().deleteAccount(account1.id),
+      ).rejects.toThrow(ERROR);
+    });
+
+    it('allows operations after deserialize', async () => {
+      const { keyring } = await makeKeyring();
+      expect(await keyring.getAccounts()).toStrictEqual([]);
+    });
+  });
+
   describe('snapId', () => {
     it('returns the snap ID set during deserialize', async () => {
       const { keyring } = await makeKeyring();

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -101,6 +101,65 @@ describe('SnapKeyring', () => {
     });
   });
 
+  describe('capabilities', () => {
+    const manifestCapabilities = {
+      scopes: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+      bip44: { deriveIndex: true, deriveIndexRange: true, discover: true },
+    };
+
+    /**
+     * Build and deserialize a keyring whose messenger returns a snap with the
+     * given `endowment:keyring` permission value from `SnapController:getSnap`.
+     *
+     * @param keyringPermission - The `endowment:keyring` initial-permission value
+     * (or `undefined` to simulate a snap that is not found).
+     * @returns The deserialized keyring.
+     */
+    async function makeKeyringWithSnap(
+      keyringPermission: unknown,
+    ): Promise<SnapKeyring> {
+      const messenger = {
+        call: jest.fn((action: string) =>
+          action === 'SnapController:getSnap' && keyringPermission !== undefined
+            ? {
+                manifest: {
+                  initialPermissions: {
+                    'endowment:keyring': keyringPermission,
+                  },
+                },
+              }
+            : undefined,
+        ),
+        publish: jest.fn(),
+      } as unknown as SnapKeyringMessenger;
+      const keyring = new SnapKeyring({
+        messenger,
+        callbacks: makeMockCallbacks(),
+      });
+      await keyring.deserialize({ snapId: SNAP_ID, accounts: {} });
+      return keyring;
+    }
+
+    it('populates capabilities from the snap manifest on deserialize', async () => {
+      const keyring = await makeKeyringWithSnap({
+        capabilities: manifestCapabilities,
+      });
+      expect(keyring.capabilities).toStrictEqual(manifestCapabilities);
+    });
+
+    it('keeps the empty default when the snap declares no capabilities', async () => {
+      const keyring = await makeKeyringWithSnap({
+        allowedOrigins: ['https://portfolio.metamask.io'],
+      });
+      expect(keyring.capabilities).toStrictEqual({ scopes: [] });
+    });
+
+    it('keeps the empty default when the snap cannot be found', async () => {
+      const keyring = await makeKeyringWithSnap(undefined);
+      expect(keyring.capabilities).toStrictEqual({ scopes: [] });
+    });
+  });
+
   describe('snapId', () => {
     it('returns the snap ID set during deserialize', async () => {
       const { keyring } = await makeKeyring();

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -10,7 +10,7 @@ import type { SnapId } from '@metamask/snaps-sdk';
 
 import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
 import type { SnapKeyringCallbacks } from './SnapKeyring';
-import { isSnapKeyring, SnapKeyring } from './SnapKeyring';
+import { EMPTY_CAPABILITIES, isSnapKeyring, SnapKeyring } from './SnapKeyring';
 
 const SNAP_ID = 'npm:@metamask/test-snap' as SnapId;
 
@@ -151,12 +151,12 @@ describe('SnapKeyring', () => {
       const keyring = await makeKeyringWithSnap({
         allowedOrigins: ['https://portfolio.metamask.io'],
       });
-      expect(keyring.capabilities).toStrictEqual({ scopes: [] });
+      expect(keyring.capabilities).toStrictEqual(EMPTY_CAPABILITIES);
     });
 
     it('keeps the empty default when the snap cannot be found', async () => {
       const keyring = await makeKeyringWithSnap(undefined);
-      expect(keyring.capabilities).toStrictEqual({ scopes: [] });
+      expect(keyring.capabilities).toStrictEqual(EMPTY_CAPABILITIES);
     });
 
     it('clears stale capabilities on a later deserialize without capabilities', async () => {
@@ -165,13 +165,10 @@ describe('SnapKeyring', () => {
           initialPermissions: { 'endowment:keyring': keyringPermission },
         },
       });
-      const getSnap = jest
-        .fn()
-        .mockReturnValueOnce(snapWith({ capabilities: manifestCapabilities }))
-        .mockReturnValueOnce(snapWith({ allowedOrigins: [] }));
+      const mockGetSnap = jest.fn();
       const messenger = {
         call: jest.fn((action: string) =>
-          action === 'SnapController:getSnap' ? getSnap() : undefined,
+          action === 'SnapController:getSnap' ? mockGetSnap() : undefined,
         ),
         publish: jest.fn(),
       } as unknown as SnapKeyringMessenger;
@@ -179,12 +176,16 @@ describe('SnapKeyring', () => {
         messenger,
         callbacks: makeMockCallbacks(),
       });
-
+      mockGetSnap.mockReturnValueOnce(
+        snapWith({ capabilities: manifestCapabilities }),
+      );
       await keyring.deserialize({ snapId: SNAP_ID, accounts: {} });
       expect(keyring.capabilities).toStrictEqual(manifestCapabilities);
-
+      // Manifest won't yield any capabilities this time, so we end up
+      // clearing the old ones and fallback to the `EMPTY_CAPABILITIES`.
+      mockGetSnap.mockReturnValueOnce(snapWith({ allowedOrigins: [] }));
       await keyring.deserialize({ snapId: SNAP_ID, accounts: {} });
-      expect(keyring.capabilities).toStrictEqual({ scopes: [] });
+      expect(keyring.capabilities).toStrictEqual(EMPTY_CAPABILITIES);
     });
   });
 

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -28,6 +28,13 @@ import type {
 import { equalsIgnoreCase } from '../util';
 
 /**
+ * Default, empty capabilities used until the snap manifest is read on
+ * `deserialize`. Typed (no cast) so that adding a new required
+ * `KeyringCapabilities` field surfaces here as a compile error.
+ */
+const EMPTY_CAPABILITIES: KeyringCapabilities = { scopes: [] };
+
+/**
  * Superstruct schema for {@link SnapKeyringState}.
  *
  * Accepts both v1 accounts (missing `scopes`) and v2 accounts so that
@@ -133,10 +140,8 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     this.#callbacks = options.callbacks;
     this.#lock = new Mutex();
 
-    // Default capabilities — parent updates this when snap metadata is available.
-    // We cast here because KeyringCapabilities requires a non-empty scopes array,
-    // but we don't have the snap metadata at construction time (e.g. during deserialization).
-    this.capabilities = { scopes: [] } as unknown as KeyringCapabilities;
+    // Default capabilities; replaced from the snap manifest on `deserialize`.
+    this.capabilities = EMPTY_CAPABILITIES;
   }
 
   /**
@@ -501,9 +506,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     // Refresh capabilities from the snap manifest on every deserialize, falling
     // back to the empty default so a re-hydrate clears any previously-loaded
     // capabilities when the snap no longer declares them.
-    this.capabilities =
-      this.#resolveKeyringCapabilities() ??
-      ({ scopes: [] } as unknown as KeyringCapabilities);
+    this.capabilities = this.#resolveKeyringCapabilities() ?? EMPTY_CAPABILITIES;
 
     // Migrate v1 accounts to v2.
     const migratedAccounts: Record<string, KeyringAccount> = {};

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -534,6 +534,11 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
   // Private helpers
   // ──────────────────────────────────────────────
 
+  /**
+   * Assert that the keyring has been initialized.
+   *
+   * @throws An error if the keyring has not been initialized.
+   */
   #assertInitialized(): void {
     if (!this.#initialized) {
       throw new Error(
@@ -542,6 +547,11 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     }
   }
 
+  /**
+   * Resolve the keyring capabilities from the snap manifest.
+   *
+   * @returns The keyring capabilities, or `undefined` if the snap manifest does not declare any capabilities.
+   */
   #resolveKeyringCapabilities(): KeyringCapabilities | undefined {
     const snap = this.messenger.call('SnapController:getSnap', this.snapId);
     return snap?.manifest.initialPermissions['endowment:keyring']

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -108,6 +108,12 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    */
   readonly #lock: Mutex;
 
+  /**
+   * Whether `deserialize` has completed. Keyring operations are guarded against
+   * use before the keyring has been bound to a snap and its state loaded.
+   */
+  #initialized = false;
+
   // ──────────────────────────────────────────────
   // Keyring properties
   // ──────────────────────────────────────────────
@@ -172,6 +178,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @returns A promise that resolves to an array of all accounts.
    */
   async getAccounts(): Promise<KeyringAccount[]> {
+    this.#assertInitialized();
     return this.accounts();
   }
 
@@ -182,6 +189,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @returns A promise that resolves to the account.
    */
   async getAccount(accountId: AccountId): Promise<KeyringAccount> {
+    this.#assertInitialized();
     const account = this.lookupAccount(accountId);
     if (!account) {
       throw new Error(
@@ -209,6 +217,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
   async createAccounts(
     options: CreateAccountOptions,
   ): Promise<KeyringAccount[]> {
+    this.#assertInitialized();
     return this.#withLock(async () => {
       // Keep track of address/account ID part of this batch, to avoid having duplicates.
       const batchAddresses = new Set<string>();
@@ -294,6 +303,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @param accountId - ID of the account to delete.
    */
   async deleteAccount(accountId: AccountId): Promise<void> {
+    this.#assertInitialized();
     // Always remove the account from the registry, even if the Snap is going to
     // fail to delete it. removeAccount fires onUnregister to clean #accountIndex.
     this.removeAccount(accountId);
@@ -338,6 +348,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
       params?: Json[] | Record<string, Json>;
     };
   }): Promise<Json> {
+    this.#assertInitialized();
     const account = this.lookupAccount(request.account);
     if (!account) {
       throw new Error(
@@ -514,11 +525,21 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     for (const account of Object.values(migratedAccounts)) {
       this.setAccount(account);
     }
+
+    this.#initialized = true;
   }
 
   // ──────────────────────────────────────────────
   // Private helpers
   // ──────────────────────────────────────────────
+
+  #assertInitialized(): void {
+    if (!this.#initialized) {
+      throw new Error(
+        'SnapKeyring has not been initialized: call deserialize() first',
+      );
+    }
+  }
 
   #resolveKeyringCapabilities(): KeyringCapabilities | undefined {
     const snap = this.messenger.call('SnapController:getSnap', this.snapId);

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -558,9 +558,12 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    */
   #resolveKeyringCapabilities(): KeyringCapabilities | undefined {
     const snap = this.messenger.call('SnapController:getSnap', this.snapId);
-    // we are not validating the shape of the capabilities here, because there is
+    // READ THIS CAREFULLY:
+    // We are not validating the shape of the capabilities here, because there is
     // manifest validation done already on the snaps side, the snaps repo maintains
-    // a copy of the KeyringCapabilitiesStruct
+    // a copy of the `KeyringCapabilitiesStruct`.
+    // We must ensure that both structs are always in-sync, otherwise the type-cast
+    // could cause runtime issues!
     return snap?.manifest.initialPermissions['endowment:keyring']
       ?.capabilities as KeyringCapabilities | undefined;
   }

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -487,6 +487,12 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     // mismatch to prevent swapping a keyring's identity via deserialize).
     this.bindSnapId(state.snapId as SnapId);
 
+    const capabilities = this.#resolveKeyringCapabilities();
+
+    if (capabilities) {
+      this.capabilities = capabilities;
+    }
+
     // Migrate v1 accounts to v2.
     const migratedAccounts: Record<string, KeyringAccount> = {};
     for (const [id, rawAccount] of Object.entries(state.accounts)) {
@@ -513,4 +519,10 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
   // ──────────────────────────────────────────────
   // Private helpers
   // ──────────────────────────────────────────────
+
+  #resolveKeyringCapabilities(): KeyringCapabilities | undefined {
+    const snap = this.messenger.call('SnapController:getSnap', this.snapId);
+    return snap?.manifest.initialPermissions['endowment:keyring']
+      ?.capabilities as KeyringCapabilities | undefined;
+  }
 }

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -32,7 +32,7 @@ import { equalsIgnoreCase } from '../util';
  * `deserialize`. Typed (no cast) so that adding a new required
  * `KeyringCapabilities` field surfaces here as a compile error.
  */
-const EMPTY_CAPABILITIES: KeyringCapabilities = { scopes: [] };
+const EMPTY_CAPABILITIES: KeyringCapabilities = Object.freeze({ scopes: [] });
 
 /**
  * Superstruct schema for {@link SnapKeyringState}.

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -498,11 +498,12 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     // mismatch to prevent swapping a keyring's identity via deserialize).
     this.bindSnapId(state.snapId as SnapId);
 
-    const capabilities = this.#resolveKeyringCapabilities();
-
-    if (capabilities) {
-      this.capabilities = capabilities;
-    }
+    // Refresh capabilities from the snap manifest on every deserialize, falling
+    // back to the empty default so a re-hydrate clears any previously-loaded
+    // capabilities when the snap no longer declares them.
+    this.capabilities =
+      this.#resolveKeyringCapabilities() ??
+      ({ scopes: [] } as unknown as KeyringCapabilities);
 
     // Migrate v1 accounts to v2.
     const migratedAccounts: Record<string, KeyringAccount> = {};

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -558,6 +558,9 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    */
   #resolveKeyringCapabilities(): KeyringCapabilities | undefined {
     const snap = this.messenger.call('SnapController:getSnap', this.snapId);
+    // we are not validating the shape of the capabilities here, because there is
+    // manifest validation done already on the snaps side, the snaps repo maintains
+    // a copy of the KeyringCapabilitiesStruct
     return snap?.manifest.initialPermissions['endowment:keyring']
       ?.capabilities as KeyringCapabilities | undefined;
   }

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -506,7 +506,8 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     // Refresh capabilities from the snap manifest on every deserialize, falling
     // back to the empty default so a re-hydrate clears any previously-loaded
     // capabilities when the snap no longer declares them.
-    this.capabilities = this.#resolveKeyringCapabilities() ?? EMPTY_CAPABILITIES;
+    this.capabilities =
+      this.#resolveKeyringCapabilities() ?? EMPTY_CAPABILITIES;
 
     // Migrate v1 accounts to v2.
     const migratedAccounts: Record<string, KeyringAccount> = {};

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -32,7 +32,9 @@ import { equalsIgnoreCase } from '../util';
  * `deserialize`. Typed (no cast) so that adding a new required
  * `KeyringCapabilities` field surfaces here as a compile error.
  */
-const EMPTY_CAPABILITIES: KeyringCapabilities = Object.freeze({ scopes: [] });
+export const EMPTY_CAPABILITIES: KeyringCapabilities = Object.freeze({
+  scopes: [],
+});
 
 /**
  * Superstruct schema for {@link SnapKeyringState}.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1727,14 +1727,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/base-controller@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "@metamask/base-controller@npm:9.0.1"
+"@metamask/base-controller@npm:^9.0.1, @metamask/base-controller@npm:^9.1.0":
+  version: 9.1.0
+  resolution: "@metamask/base-controller@npm:9.1.0"
   dependencies:
-    "@metamask/messenger": "npm:^1.0.0"
+    "@metamask/messenger": "npm:^1.1.1"
     "@metamask/utils": "npm:^11.9.0"
     immer: "npm:^9.0.6"
-  checksum: 10/bc5052c9a38c21a52003e9a79de1f609ff127d939c87eb7b9ebe01cdf05ce2a9ee8e4635dd96f193e9951983e9554d9381af303fbadaae740445ffb2424698e8
+  checksum: 10/752b70b35026fdf31ea8feef638f06286dbbde8d17e1ba804085fdbedbb076d900d2d7b6db3d2af284b3aa8fa84c95a0ceea6a3a46ee7b7e29433f037e9afc69
   languageName: node
   linkType: hard
 
@@ -1768,6 +1768,28 @@ __metadata:
   peerDependencies:
     "@babel/runtime": ^7.0.0
   checksum: 10/a2ba778d00508a606ef4657cd6591a89f8f54136b3dd41f4f96f8effa2e9ad20de347e3c554f643cb248a002a17b478f95eafd4e3b4c3eca4bb40ae2e6bf7fdc
+  languageName: node
+  linkType: hard
+
+"@metamask/controller-utils@npm:^12.0.0":
+  version: 12.3.0
+  resolution: "@metamask/controller-utils@npm:12.3.0"
+  dependencies:
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@metamask/eth-query": "npm:^4.0.0"
+    "@metamask/ethjs-unit": "npm:^0.3.0"
+    "@metamask/utils": "npm:^11.11.0"
+    "@spruceid/siwe-parser": "npm:2.1.0"
+    "@types/bn.js": "npm:^5.1.5"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    cockatiel: "npm:^3.1.2"
+    eth-ens-namehash: "npm:^2.0.8"
+    fast-deep-equal: "npm:^3.1.3"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@babel/runtime": ^7.0.0
+  checksum: 10/4f67b480a8522f3f89e1988631f57cfde5a7fca6c6df68f4f88e1cdcb54efccb4239befd3a8b3b7b2735479a47733b99eb059d8a0c7ddf28bdc85be4b8c04afb
   languageName: node
   linkType: hard
 
@@ -2088,7 +2110,7 @@ __metadata:
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/snaps-controllers": "npm:^19.0.1"
     "@metamask/snaps-sdk": "npm:^11.0.0"
-    "@metamask/snaps-utils": "npm:^12.1.3"
+    "@metamask/snaps-utils": "npm:^12.2.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
@@ -2188,17 +2210,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.1.1, @metamask/json-rpc-engine@npm:^10.2.4":
-  version: 10.2.4
-  resolution: "@metamask/json-rpc-engine@npm:10.2.4"
+"@metamask/json-rpc-engine@npm:^10.0.2, @metamask/json-rpc-engine@npm:^10.1.1, @metamask/json-rpc-engine@npm:^10.2.4, @metamask/json-rpc-engine@npm:^10.5.0":
+  version: 10.5.0
+  resolution: "@metamask/json-rpc-engine@npm:10.5.0"
   dependencies:
+    "@metamask/messenger": "npm:^1.2.0"
     "@metamask/rpc-errors": "npm:^7.0.2"
     "@metamask/safe-event-emitter": "npm:^3.0.0"
     "@metamask/utils": "npm:^11.9.0"
     "@types/deep-freeze-strict": "npm:^1.1.0"
     deep-freeze-strict: "npm:^1.1.1"
     klona: "npm:^2.0.6"
-  checksum: 10/b207dd2a9a44674c141c2e027c082974464a37beada98a27e80fe59c9bd44e2c2a992edf8a8d7e3ed461fa27ed372c95d4e27df18752b558c10bf540b7fe7bcd
+  checksum: 10/2fa42bc57e6e268f0dfcdfe22d15f3c1c593acb5c96df1469403c389fc2a4e4ccb7c75efc00a02d987834d7f0dfb52f31328929ebb37d73b6719aa2e53a75466
   languageName: node
   linkType: hard
 
@@ -2294,7 +2317,7 @@ __metadata:
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/snaps-controllers": "npm:^19.0.1"
     "@metamask/snaps-sdk": "npm:^11.0.0"
-    "@metamask/snaps-utils": "npm:^12.1.3"
+    "@metamask/snaps-utils": "npm:^12.2.1"
     "@metamask/utils": "npm:^11.11.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -2439,9 +2462,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/messenger@npm:^1.0.0, @metamask/messenger@npm:^1.1.0, @metamask/messenger@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@metamask/messenger@npm:1.1.1"
+"@metamask/messenger@npm:^1.0.0, @metamask/messenger@npm:^1.1.0, @metamask/messenger@npm:^1.1.1, @metamask/messenger@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "@metamask/messenger@npm:1.2.0"
   dependencies:
     "@metamask/utils": "npm:^11.9.0"
     yargs: "npm:^17.7.2"
@@ -2449,7 +2472,7 @@ __metadata:
     typescript: ">=5.0.0"
   bin:
     messenger-generate-action-types: ./dist/generate-action-types/cli.mjs
-  checksum: 10/a959af95e9e117aa0f7ad1c280f7817fef2c0b575c76837b1a6c884c9c9ef1dd0faeaef0c2c0c2035f68c7638d1f87cd172956ee962dec97d8ab6176fa6964e3
+  checksum: 10/6818e4609d6162a436cc07955905f9e57ff6dbef841e9066a5fb9cc0538e981526fbcb5eef1fa1968d79212d57ddda2fce4dda5f87eb64d8d98f7db1216a6a98
   languageName: node
   linkType: hard
 
@@ -2512,6 +2535,25 @@ __metadata:
     immer: "npm:^9.0.6"
     nanoid: "npm:^3.3.8"
   checksum: 10/a5fe9f2bab8c2d41cd829cd6c1af970e71da97eac42de17071c10f90d975e9135a4e6987ed6b2f3ea2209b1c6c51b822508f800225fda2207cdc598c16ea77dd
+  languageName: node
+  linkType: hard
+
+"@metamask/permission-controller@npm:^13.1.1":
+  version: 13.1.1
+  resolution: "@metamask/permission-controller@npm:13.1.1"
+  dependencies:
+    "@metamask/approval-controller": "npm:^9.0.1"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/controller-utils": "npm:^12.0.0"
+    "@metamask/json-rpc-engine": "npm:^10.5.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/rpc-errors": "npm:^7.0.2"
+    "@metamask/utils": "npm:^11.9.0"
+    "@types/deep-freeze-strict": "npm:^1.1.0"
+    deep-freeze-strict: "npm:^1.1.1"
+    immer: "npm:^9.0.6"
+    nanoid: "npm:^3.3.8"
+  checksum: 10/12c6a675217ff510b837543c6e71ea851a3a7bd4592195f9579e76e2779177d2d4f03fcdd4d5c12585598df73250f32d0d49cb114274fc8187cbc7081bbc913b
   languageName: node
   linkType: hard
 
@@ -2673,35 +2715,35 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/snaps-sdk@npm:^11.0.0":
-  version: 11.0.0
-  resolution: "@metamask/snaps-sdk@npm:11.0.0"
+"@metamask/snaps-sdk@npm:^11.0.0, @metamask/snaps-sdk@npm:^11.1.1":
+  version: 11.1.1
+  resolution: "@metamask/snaps-sdk@npm:11.1.1"
   dependencies:
     "@metamask/key-tree": "npm:^10.1.1"
     "@metamask/providers": "npm:^22.1.1"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/superstruct": "npm:^3.2.1"
-    "@metamask/utils": "npm:^11.10.0"
+    "@metamask/utils": "npm:^11.11.0"
     luxon: "npm:^3.5.0"
-  checksum: 10/83dc24c9c583ca257874498ed2b124160c559afd56f043a6e0f617fc3edc4fcbd4b1ef15efb4a197a71a8a6dd2ab20b6da87463b4261928311d39eb29f64668a
+  checksum: 10/8419625775b83045d98c4ed920002ad884471e2303f6650104c97457c238f095ff35030663ddf111ebb6ce8f4cd915f57b7b9a5597d00288093701dbb79e787c
   languageName: node
   linkType: hard
 
-"@metamask/snaps-utils@npm:^12.1.3":
-  version: 12.1.3
-  resolution: "@metamask/snaps-utils@npm:12.1.3"
+"@metamask/snaps-utils@npm:^12.1.3, @metamask/snaps-utils@npm:^12.2.1":
+  version: 12.2.1
+  resolution: "@metamask/snaps-utils@npm:12.2.1"
   dependencies:
     "@babel/core": "npm:^7.23.2"
     "@babel/types": "npm:^7.23.0"
     "@metamask/key-tree": "npm:^10.1.1"
-    "@metamask/messenger": "npm:^1.1.0"
-    "@metamask/permission-controller": "npm:^12.3.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/permission-controller": "npm:^13.1.1"
     "@metamask/rpc-errors": "npm:^7.0.3"
     "@metamask/slip44": "npm:^4.4.0"
     "@metamask/snaps-registry": "npm:^4.0.0"
-    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-sdk": "npm:^11.1.1"
     "@metamask/superstruct": "npm:^3.2.1"
-    "@metamask/utils": "npm:^11.10.0"
+    "@metamask/utils": "npm:^11.11.0"
     "@scure/base": "npm:^1.1.1"
     chalk: "npm:^4.1.2"
     cron-parser: "npm:^4.5.0"
@@ -2714,7 +2756,7 @@ __metadata:
     semver: "npm:^7.5.4"
     ses: "npm:^1.15.0"
     validate-npm-package-name: "npm:^5.0.0"
-  checksum: 10/857b213eedbb9024d79e6a872df0c48c6dd7e41cda654cd56a094c1518a5485b6545c6dc7adf7740919de2160d26d930cfd78131b090c10e42f672f71f9a8ca2
+  checksum: 10/fda8caefa414d9755a2305b345b5bbbf30ee614215a49070449f314d5d906c645457cf0d7f4881a82f69d398aff5ad2fe9c648bbb2a5003c29c2d01e2f42f199
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Populate the v2 `SnapKeyring.capabilities` from the Snap manifest (`endowment:keyring`) on `deserialize`, via `SnapController:getSnap`, fulfilling the v2 `Keyring` contract's required `capabilities` field. Falls back to the empty default when the Snap declares none.
- Guard v2 `SnapKeyring` operations (`getAccounts`/`getAccount`/`createAccounts`/`deleteAccount`/`submitRequest`) until `deserialize` has run; they now throw `"SnapKeyring has not been initialized"` instead of operating on an unbound keyring.
- Bump `@metamask/snaps-utils` to `^12.2.1` (`keyring-snap-bridge` + `keyring-internal-snap-client`) for the `capabilities` field on the `endowment:keyring` manifest type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes snap keyring lifecycle and when account operations are allowed; capabilities are taken from the manifest without local shape validation, so struct drift could cause runtime issues.
> 
> **Overview**
> v2 **`SnapKeyring`** now sets **`capabilities`** during **`deserialize`** by reading the Snap manifest’s **`endowment:keyring`** entry via **`SnapController:getSnap`**, with **`EMPTY_CAPABILITIES`** as the typed default when the snap is missing or declares none (including clearing stale values on re-hydrate).
> 
> **`getAccounts`**, **`getAccount`**, **`createAccounts`**, **`deleteAccount`**, and **`submitRequest`** are blocked until **`deserialize`** finishes, throwing *SnapKeyring has not been initialized* instead of running on an unbound keyring.
> 
> **`@metamask/snaps-utils`** is bumped to **`^12.2.1`** in **`keyring-snap-bridge`** and **`keyring-internal-snap-client`** for manifest typing around **`capabilities`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39a8b9423f98dfd6024e731ac7bbc4c259704902. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->