### PR TITLE
release: 116.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/accounts-monorepo",
-  "version": "115.0.0",
+  "version": "116.0.0",
   "private": true,
   "description": "Monorepo for MetaMask accounts related packages",
   "repository": {

--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
+
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
-
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
-- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.4.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
 
 ## [1.0.4]
 

--- a/packages/account-api/package.json
+++ b/packages/account-api/package.json
@@ -66,7 +66,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-utils": "^3.3.1",
     "uuid": "^9.0.1"
   },

--- a/packages/hw-wallet-sdk/CHANGELOG.md
+++ b/packages/hw-wallet-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
+- chore: update tooling (same as `core`) ([#517](https://github.com/MetaMask/accounts/pull/517))
+- chore: add `yarn constraints` support ([#514](https://github.com/MetaMask/accounts/pull/514))
+
 ## [0.8.0]
 
 ### Added

--- a/packages/hw-wallet-sdk/CHANGELOG.md
+++ b/packages/hw-wallet-sdk/CHANGELOG.md
@@ -7,12 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
-- chore: update tooling (same as `core`) ([#517](https://github.com/MetaMask/accounts/pull/517))
-- chore: add `yarn constraints` support ([#514](https://github.com/MetaMask/accounts/pull/514))
-
 ## [0.8.0]
 
 ### Added

--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [23.4.0]
+
 ### Added
 
 - Add `KeyringRpc` and `KeyringSnapRpc` RPC interfaces to v1 ([#582](https://github.com/MetaMask/accounts/pull/582))
@@ -779,7 +781,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SnapController keyring client. It is intended to be used by MetaMask to talk to the snap.
 - Helper functions to create keyring handler in the snap.
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@23.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@23.4.0...HEAD
+[23.4.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@23.3.0...@metamask/keyring-api@23.4.0
 [23.3.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@23.2.0...@metamask/keyring-api@23.3.0
 [23.2.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@23.1.0...@metamask/keyring-api@23.2.0
 [23.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-api@23.0.1...@metamask/keyring-api@23.1.0

--- a/packages/keyring-api/package.json
+++ b/packages/keyring-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-api",
-  "version": "23.3.0",
+  "version": "23.4.0",
   "description": "MetaMask Keyring API",
   "keywords": [
     "keyring",

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
-- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
-
 ### Changed
 
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.2.0` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546), [#562](https://github.com/MetaMask/accounts/pull/562))

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
+- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
+
 ### Changed
 
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.2.0` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546), [#562](https://github.com/MetaMask/accounts/pull/562))

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.2.0` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546), [#562](https://github.com/MetaMask/accounts/pull/562))
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
-- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.4.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
 
 ## [14.1.1]
 

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -70,7 +70,7 @@
     "@ethereumjs/util": "^9.1.0",
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/key-tree": "^10.0.2",
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-sdk": "^2.2.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/scure-bip39": "^2.1.1",

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/keyring-api` from `^23.3.0` to `^23.4.0` ([#583](https://github.com/MetaMask/accounts/pull/583))
+
 ## [12.2.0]
 
 ### Added

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -78,7 +78,7 @@
     "@ledgerhq/hw-transport": "^6.31.3",
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/hw-wallet-sdk": "^0.8.0",
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-sdk": "^2.2.0",
     "hdkey": "^2.1.0",
     "rxjs": "^7.8.2"

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
-
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
@@ -66,7 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Replace inheritance with composition; `MoneyKeyring` now wraps an inner `HdKeyring` instead of extending it ([#484](https://github.com/MetaMask/accounts/pull/484), [#492](https://github.com/MetaMask/accounts/pull/492), [#488](https://github.com/MetaMask/accounts/pull/488))
+- **BREAKING:** Replace inheritance with composition; `MoneyKeyring` now wraps an inner `HdKeyring` instead of extending it ([#484](https://github.com/MetaMask/accounts/pull/484), [#492](https://github.com/MetaMask/accounts/pull/488), [#488](https://github.com/MetaMask/accounts/pull/492))
   - Constructor now requires a `MoneyKeyringOptions` object with a `getMnemonic` callback. The `entropySource` is set by `deserialize()` from the serialized state.
   - The inner `HdKeyring` is created on the first signing call (lazily), protected by a mutex to ensure single initialization under concurrency.
   - Serialized state now stores `entropySource` instead of `mnemonic`; the mnemonic is resolved at deserialization time via the callback.

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
+
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
@@ -62,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **BREAKING:** Replace inheritance with composition; `MoneyKeyring` now wraps an inner `HdKeyring` instead of extending it ([#484](https://github.com/MetaMask/accounts/pull/484), [#492](https://github.com/MetaMask/accounts/pull/488), [#488](https://github.com/MetaMask/accounts/pull/492))
+- **BREAKING:** Replace inheritance with composition; `MoneyKeyring` now wraps an inner `HdKeyring` instead of extending it ([#484](https://github.com/MetaMask/accounts/pull/484), [#492](https://github.com/MetaMask/accounts/pull/492), [#488](https://github.com/MetaMask/accounts/pull/488))
   - Constructor now requires a `MoneyKeyringOptions` object with a `getMnemonic` callback. The `entropySource` is set by `deserialize()` from the serialized state.
   - The inner `HdKeyring` is created on the first signing call (lazily), protected by a mutex to ensure single initialization under concurrency.
   - Serialized state now stores `entropySource` instead of `mnemonic`; the mnemonic is resolved at deserialization time via the callback.

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.4.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
 - Bump `@metamask/keyring-sdk` from `^2.1.1` to `^2.2.0` ([#562](https://github.com/MetaMask/accounts/pull/562))
 
 ## [3.0.0]

--- a/packages/keyring-eth-money/package.json
+++ b/packages/keyring-eth-money/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@metamask/eth-hd-keyring": "^14.1.1",
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-sdk": "^2.2.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/superstruct": "^3.1.0",

--- a/packages/keyring-eth-qr/CHANGELOG.md
+++ b/packages/keyring-eth-qr/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
+
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))

--- a/packages/keyring-eth-qr/CHANGELOG.md
+++ b/packages/keyring-eth-qr/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
-
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))

--- a/packages/keyring-eth-qr/CHANGELOG.md
+++ b/packages/keyring-eth-qr/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.4.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
 - Bump `@metamask/keyring-sdk` from `^2.1.1` to `^2.2.0` ([#562](https://github.com/MetaMask/accounts/pull/562))
 
 ## [2.1.0]

--- a/packages/keyring-eth-qr/package.json
+++ b/packages/keyring-eth-qr/package.json
@@ -75,7 +75,7 @@
     "@ethereumjs/util": "^9.1.0",
     "@keystonehq/bc-ur-registry-eth": "^0.19.1",
     "@metamask/eth-sig-util": "^8.2.0",
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-sdk": "^2.2.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/utils": "^11.11.0",

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
-- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
-
 ### Changed
 
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.2.0` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546), [#562](https://github.com/MetaMask/accounts/pull/562))

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
+- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
+
 ### Changed
 
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.2.0` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546), [#562](https://github.com/MetaMask/accounts/pull/562))

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/keyring-sdk` from `^2.0.2` to `^2.2.0` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546), [#562](https://github.com/MetaMask/accounts/pull/562))
-- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.4.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
 
 ## [12.0.2]
 

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",
     "@metamask/eth-sig-util": "^8.2.0",
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-sdk": "^2.2.0",
     "@metamask/utils": "^11.11.0",
     "ethereum-cryptography": "^2.2.1",

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
+
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
-
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.4.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
 - Bump `@metamask/keyring-sdk` from `^2.1.1` to `^2.2.0` ([#562](https://github.com/MetaMask/accounts/pull/562))
 
 ## [10.1.0]

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -72,7 +72,7 @@
     "@ethereumjs/util": "^9.1.0",
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/hw-wallet-sdk": "^0.8.0",
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-sdk": "^2.2.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/utils": "^11.11.0",

--- a/packages/keyring-internal-api/CHANGELOG.md
+++ b/packages/keyring-internal-api/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
+- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
+
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/keyring-internal-api/CHANGELOG.md
+++ b/packages/keyring-internal-api/CHANGELOG.md
@@ -7,11 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Uncategorized
-
-- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
-- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
-
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/keyring-internal-api/CHANGELOG.md
+++ b/packages/keyring-internal-api/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
-- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.4.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
 
 ## [11.0.1]
 

--- a/packages/keyring-internal-api/package.json
+++ b/packages/keyring-internal-api/package.json
@@ -55,7 +55,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/superstruct": "^3.1.0"
   },

--- a/packages/keyring-internal-snap-client/CHANGELOG.md
+++ b/packages/keyring-internal-snap-client/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.4]
+
 ### Uncategorized
 
 - feat(keyring-snap-bridge): populate v2 SnapKeyring capabilities from the manifest ([#581](https://github.com/MetaMask/accounts/pull/581))
@@ -239,7 +241,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This new version fixes a bug with CJS re-exports.
 - Initial release ([#24](https://github.com/MetaMask/accounts/pull/24))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@10.0.3...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@10.0.4...HEAD
+[10.0.4]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@10.0.3...@metamask/keyring-internal-snap-client@10.0.4
 [10.0.3]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@10.0.2...@metamask/keyring-internal-snap-client@10.0.3
 [10.0.2]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@10.0.1...@metamask/keyring-internal-snap-client@10.0.2
 [10.0.1]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-internal-snap-client@10.0.0...@metamask/keyring-internal-snap-client@10.0.1

--- a/packages/keyring-internal-snap-client/CHANGELOG.md
+++ b/packages/keyring-internal-snap-client/CHANGELOG.md
@@ -9,12 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.0.4]
 
-### Uncategorized
-
-- feat(keyring-snap-bridge): populate v2 SnapKeyring capabilities from the manifest ([#581](https://github.com/MetaMask/accounts/pull/581))
-- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
-- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
-
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/keyring-internal-snap-client/CHANGELOG.md
+++ b/packages/keyring-internal-snap-client/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
-- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.4.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
+- Bump `@metamask/keyring-snap-client` from `^9.0.2` to `^9.1.0` ([#583](https://github.com/MetaMask/accounts/pull/583))
 
 ## [10.0.3]
 

--- a/packages/keyring-internal-snap-client/CHANGELOG.md
+++ b/packages/keyring-internal-snap-client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- feat(keyring-snap-bridge): populate v2 SnapKeyring capabilities from the manifest ([#581](https://github.com/MetaMask/accounts/pull/581))
+- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
+- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
+
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/keyring-internal-snap-client/package.json
+++ b/packages/keyring-internal-snap-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-internal-snap-client",
-  "version": "10.0.3",
+  "version": "10.0.4",
   "description": "MetaMask Keyring Snap internal clients",
   "keywords": [
     "keyring",
@@ -66,9 +66,9 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-internal-api": "^11.0.1",
-    "@metamask/keyring-snap-client": "^9.0.2",
+    "@metamask/keyring-snap-client": "^9.1.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/messenger": "^1.1.1"
   },

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/keyring-api` from `^23.2.0` to `^23.3.0` ([#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.2.0` to `^23.4.0` ([#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
 
 ## [2.2.0]
 

--- a/packages/keyring-sdk/package.json
+++ b/packages/keyring-sdk/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^5.4.0",
     "@metamask/eth-sig-util": "^8.2.0",
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/superstruct": "^3.1.0",

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [22.4.0]
+
 ### Added
 
 - Populate v2 `SnapKeyring` `capabilities` from the Snap manifest (`endowment:keyring`) on `deserialize` ([#581](https://github.com/MetaMask/accounts/pull/581))
@@ -754,7 +756,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release.
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@22.3.0...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@22.4.0...HEAD
+[22.4.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@22.3.0...@metamask/eth-snap-keyring@22.4.0
 [22.3.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@22.2.0...@metamask/eth-snap-keyring@22.3.0
 [22.2.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@22.1.0...@metamask/eth-snap-keyring@22.2.0
 [22.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-snap-keyring@22.0.1...@metamask/eth-snap-keyring@22.1.0

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/snaps-utils` from `^12.1.3` to `^12.2.1` ([#581](https://github.com/MetaMask/accounts/pull/581))
+- Bump `@metamask/keyring-internal-snap-client` from `^10.0.3` to `^10.0.4` ([#583](https://github.com/MetaMask/accounts/pull/583))
+- Bump `@metamask/keyring-snap-sdk` from `^9.0.2` to `^10.0.0` ([#583](https://github.com/MetaMask/accounts/pull/583))
 
 ## [22.3.0]
 

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/snaps-utils` from `^12.1.3` to `^12.2.1` ([#581](https://github.com/MetaMask/accounts/pull/581))
 - Bump `@metamask/keyring-internal-snap-client` from `^10.0.3` to `^10.0.4` ([#583](https://github.com/MetaMask/accounts/pull/583))
-- Bump `@metamask/keyring-snap-sdk` from `^9.0.2` to `^10.0.0` ([#583](https://github.com/MetaMask/accounts/pull/583))
+- Bump `@metamask/keyring-snap-sdk` from `^9.0.2` to `^9.1.0` ([#583](https://github.com/MetaMask/accounts/pull/583))
 
 ## [22.3.0]
 

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-snap-keyring",
-  "version": "22.3.0",
+  "version": "22.4.0",
   "description": "Snaps keyring bridge",
   "keywords": [
     "keyring",
@@ -70,9 +70,9 @@
     "@ethereumjs/tx": "^5.4.0",
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/keyring-internal-api": "^11.0.1",
-    "@metamask/keyring-internal-snap-client": "^10.0.3",
+    "@metamask/keyring-internal-snap-client": "^10.0.4",
     "@metamask/keyring-sdk": "^2.2.0",
-    "@metamask/keyring-snap-sdk": "^9.0.2",
+    "@metamask/keyring-snap-sdk": "^10.0.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/messenger": "^1.1.1",
     "@metamask/snaps-controllers": "^19.0.1",

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -72,7 +72,7 @@
     "@metamask/keyring-internal-api": "^11.0.1",
     "@metamask/keyring-internal-snap-client": "^10.0.4",
     "@metamask/keyring-sdk": "^2.2.0",
-    "@metamask/keyring-snap-sdk": "^10.0.0",
+    "@metamask/keyring-snap-sdk": "^9.1.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/messenger": "^1.1.1",
     "@metamask/snaps-controllers": "^19.0.1",

--- a/packages/keyring-snap-client/CHANGELOG.md
+++ b/packages/keyring-snap-client/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [9.1.0]
+
 ### Uncategorized
 
 - chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
@@ -198,7 +200,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This new version fixes a bug with CJS re-exports.
 - Initial release ([#24](https://github.com/MetaMask/accounts/pull/24))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@9.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@9.1.0...HEAD
+[9.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@9.0.2...@metamask/keyring-snap-client@9.1.0
 [9.0.2]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@9.0.1...@metamask/keyring-snap-client@9.0.2
 [9.0.1]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@9.0.0...@metamask/keyring-snap-client@9.0.1
 [9.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-client@8.2.1...@metamask/keyring-snap-client@9.0.0

--- a/packages/keyring-snap-client/CHANGELOG.md
+++ b/packages/keyring-snap-client/CHANGELOG.md
@@ -9,11 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [9.1.0]
 
-### Uncategorized
-
-- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
-- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
-
 ### Added
 
 - Implements `KeyringSnapRpc` (v2) in `KeyringClient` (v2) ([#582](https://github.com/MetaMask/accounts/pull/582))

--- a/packages/keyring-snap-client/CHANGELOG.md
+++ b/packages/keyring-snap-client/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Uncategorized
+
+- chore: fix changelogs PR grouping ([#563](https://github.com/MetaMask/accounts/pull/563))
+- build: fix `yarn` warnings + align `typescript` version with `core`/`snaps` ([#536](https://github.com/MetaMask/accounts/pull/536))
+
 ### Added
 
 - Implements `KeyringSnapRpc` (v2) in `KeyringClient` (v2) ([#582](https://github.com/MetaMask/accounts/pull/582))

--- a/packages/keyring-snap-client/CHANGELOG.md
+++ b/packages/keyring-snap-client/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))
-- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.3.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569))
+- Bump `@metamask/keyring-api` from `^23.1.0` to `^23.4.0` ([#562](https://github.com/MetaMask/accounts/pull/562), [#569](https://github.com/MetaMask/accounts/pull/569), [#583](https://github.com/MetaMask/accounts/pull/583))
 
 ## [9.0.2]
 

--- a/packages/keyring-snap-client/package.json
+++ b/packages/keyring-snap-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-snap-client",
-  "version": "9.0.2",
+  "version": "9.1.0",
   "description": "MetaMask Keyring Snap clients",
   "keywords": [
     "keyring",
@@ -66,7 +66,7 @@
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch"
   },
   "dependencies": {
-    "@metamask/keyring-api": "^23.3.0",
+    "@metamask/keyring-api": "^23.4.0",
     "@metamask/keyring-utils": "^3.3.1",
     "@metamask/superstruct": "^3.1.0",
     "@types/uuid": "^9.0.8",

--- a/packages/keyring-snap-sdk/CHANGELOG.md
+++ b/packages/keyring-snap-sdk/CHANGELOG.md
@@ -7,11 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [10.0.0]
+## [9.1.0]
 
 ### Added
 
-- **BREAKING:** Supports new `KeyringSnapRpc` (v2) in `handleKeyringRequest` (v2) ([#582](https://github.com/MetaMask/accounts/pull/582))
+- Supports new `KeyringSnapRpc` (v2) in `handleKeyringRequest` (v2) ([#582](https://github.com/MetaMask/accounts/pull/582))
   - Handles the four snap-specific methods (`keyring_setSelectedAccounts`, `keyring_getAccountTransactions`, `keyring_getAccountAssets`, `keyring_getAccountBalances`) in addition to all core v2 methods.
   - Includes backwards-compatible dispatch for the deprecated v1 method names `keyring_listAccountTransactions` and `keyring_listAccountAssets`, forwarding them to `getAccountTransactions` and `getAccountAssets` respectively.
 
@@ -194,8 +194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This new version fixes a bug with CJS re-exports.
 - Initial release ([#24](https://github.com/MetaMask/accounts/pull/24))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@10.0.0...HEAD
-[10.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@9.0.2...@metamask/keyring-snap-sdk@10.0.0
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@9.1.0...HEAD
+[9.1.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@9.0.2...@metamask/keyring-snap-sdk@9.1.0
 [9.0.2]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@9.0.1...@metamask/keyring-snap-sdk@9.0.2
 [9.0.1]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@9.0.0...@metamask/keyring-snap-sdk@9.0.1
 [9.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@8.0.0...@metamask/keyring-snap-sdk@9.0.0

--- a/packages/keyring-snap-sdk/CHANGELOG.md
+++ b/packages/keyring-snap-sdk/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [10.0.0]
+
 ### Added
 
 - Supports new `KeyringSnapRpc` (v2) in `handleKeyringRequest` (v2) ([#582](https://github.com/MetaMask/accounts/pull/582))
@@ -192,7 +194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - This new version fixes a bug with CJS re-exports.
 - Initial release ([#24](https://github.com/MetaMask/accounts/pull/24))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@9.0.2...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@10.0.0...HEAD
+[10.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@9.0.2...@metamask/keyring-snap-sdk@10.0.0
 [9.0.2]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@9.0.1...@metamask/keyring-snap-sdk@9.0.2
 [9.0.1]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@9.0.0...@metamask/keyring-snap-sdk@9.0.1
 [9.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/keyring-snap-sdk@8.0.0...@metamask/keyring-snap-sdk@9.0.0

--- a/packages/keyring-snap-sdk/CHANGELOG.md
+++ b/packages/keyring-snap-sdk/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Supports new `KeyringSnapRpc` (v2) in `handleKeyringRequest` (v2) ([#582](https://github.com/MetaMask/accounts/pull/582))
+- **BREAKING:** Supports new `KeyringSnapRpc` (v2) in `handleKeyringRequest` (v2) ([#582](https://github.com/MetaMask/accounts/pull/582))
   - Handles the four snap-specific methods (`keyring_setSelectedAccounts`, `keyring_getAccountTransactions`, `keyring_getAccountAssets`, `keyring_getAccountBalances`) in addition to all core v2 methods.
   - Includes backwards-compatible dispatch for the deprecated v1 method names `keyring_listAccountTransactions` and `keyring_listAccountAssets`, forwarding them to `getAccountTransactions` and `getAccountAssets` respectively.
 

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-snap-sdk",
-  "version": "10.0.0",
+  "version": "9.1.0",
   "description": "MetaMask Keyring Snap SDK",
   "keywords": [
     "keyring",

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/keyring-snap-sdk",
-  "version": "9.0.2",
+  "version": "10.0.0",
   "description": "MetaMask Keyring Snap SDK",
   "keywords": [
     "keyring",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1612,7 +1612,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
@@ -1900,7 +1900,7 @@ __metadata:
     "@metamask/bip39": "npm:^4.0.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/key-tree": "npm:^10.0.2"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/old-hd-keyring": "npm:@metamask/eth-hd-keyring@^4.0.1"
@@ -1938,7 +1938,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/hw-wallet-sdk": "npm:^0.8.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/utils": "npm:^11.11.0"
@@ -1973,7 +1973,7 @@ __metadata:
     "@metamask/eth-hd-keyring": "npm:^14.1.1"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/key-tree": "npm:^10.0.2"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -2002,7 +2002,7 @@ __metadata:
     "@metamask/account-api": "npm:^1.0.4"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/utils": "npm:^11.11.0"
@@ -2070,7 +2070,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/utils": "npm:^11.11.0"
@@ -2103,9 +2103,9 @@ __metadata:
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/keyring-api": "npm:^23.0.1"
     "@metamask/keyring-internal-api": "npm:^11.0.1"
-    "@metamask/keyring-internal-snap-client": "npm:^10.0.3"
+    "@metamask/keyring-internal-snap-client": "npm:^10.0.4"
     "@metamask/keyring-sdk": "npm:^2.2.0"
-    "@metamask/keyring-snap-sdk": "npm:^9.0.2"
+    "@metamask/keyring-snap-sdk": "npm:^10.0.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/snaps-controllers": "npm:^19.0.1"
@@ -2146,7 +2146,7 @@ __metadata:
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/hw-wallet-sdk": "npm:^0.8.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/utils": "npm:^11.11.0"
@@ -2250,7 +2250,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-api@npm:^23.0.1, @metamask/keyring-api@npm:^23.3.0, @metamask/keyring-api@workspace:packages/keyring-api":
+"@metamask/keyring-api@npm:^23.0.1, @metamask/keyring-api@npm:^23.4.0, @metamask/keyring-api@workspace:packages/keyring-api":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-api@workspace:packages/keyring-api"
   dependencies:
@@ -2284,7 +2284,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/superstruct": "npm:^3.1.0"
     "@ts-bridge/cli": "npm:^0.6.3"
@@ -2303,16 +2303,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/keyring-internal-snap-client@npm:^10.0.3, @metamask/keyring-internal-snap-client@workspace:packages/keyring-internal-snap-client":
+"@metamask/keyring-internal-snap-client@npm:^10.0.4, @metamask/keyring-internal-snap-client@workspace:packages/keyring-internal-snap-client":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-internal-snap-client@workspace:packages/keyring-internal-snap-client"
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-internal-api": "npm:^11.0.1"
-    "@metamask/keyring-snap-client": "npm:^9.0.2"
+    "@metamask/keyring-snap-client": "npm:^9.1.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/snaps-controllers": "npm:^19.0.1"
@@ -2344,7 +2344,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/eth-sig-util": "npm:^8.2.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -2369,14 +2369,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/keyring-snap-client@npm:^9.0.2, @metamask/keyring-snap-client@workspace:packages/keyring-snap-client":
+"@metamask/keyring-snap-client@npm:^9.1.0, @metamask/keyring-snap-client@workspace:packages/keyring-snap-client":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-snap-client@workspace:packages/keyring-snap-client"
   dependencies:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/keyring-api": "npm:^23.3.0"
+    "@metamask/keyring-api": "npm:^23.4.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/providers": "npm:^19.0.0"
     "@metamask/superstruct": "npm:^3.1.0"
@@ -2402,7 +2402,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/keyring-snap-sdk@npm:^9.0.2, @metamask/keyring-snap-sdk@workspace:packages/keyring-snap-sdk":
+"@metamask/keyring-snap-sdk@npm:^10.0.0, @metamask/keyring-snap-sdk@workspace:packages/keyring-snap-sdk":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-snap-sdk@workspace:packages/keyring-snap-sdk"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2105,7 +2105,7 @@ __metadata:
     "@metamask/keyring-internal-api": "npm:^11.0.1"
     "@metamask/keyring-internal-snap-client": "npm:^10.0.4"
     "@metamask/keyring-sdk": "npm:^2.2.0"
-    "@metamask/keyring-snap-sdk": "npm:^10.0.0"
+    "@metamask/keyring-snap-sdk": "npm:^9.1.0"
     "@metamask/keyring-utils": "npm:^3.3.1"
     "@metamask/messenger": "npm:^1.1.1"
     "@metamask/snaps-controllers": "npm:^19.0.1"
@@ -2402,7 +2402,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@metamask/keyring-snap-sdk@npm:^10.0.0, @metamask/keyring-snap-sdk@workspace:packages/keyring-snap-sdk":
+"@metamask/keyring-snap-sdk@npm:^9.1.0, @metamask/keyring-snap-sdk@workspace:packages/keyring-snap-sdk":
   version: 0.0.0-use.local
   resolution: "@metamask/keyring-snap-sdk@workspace:packages/keyring-snap-sdk"
   dependencies:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The release propagates new snap keyring RPC and capability contracts across many packages; risk is integration/regression in snap keyring flows rather than logic changed in this diff.
> 
> **Overview**
> Monorepo release **116.0.0** that cuts new package versions and aligns dependents on **`@metamask/keyring-api@23.4.0`**.
> 
> **`@metamask/keyring-api@23.4.0`** documents the shipped API surface: v1/v2 **`KeyringRpc`** / **`KeyringSnapRpc`**, optional snap RPC methods (assets, balances, transactions, selected accounts), and v2 **`KeyringCapabilities.snap`** flags.
> 
> Downstream packages are bumped to consume that API: **`@metamask/keyring-snap-client@9.1.0`** and **`@metamask/keyring-snap-sdk@9.1.0`** (snap RPC client/handler wiring), **`@metamask/keyring-internal-snap-client@10.0.4`**, and **`@metamask/eth-snap-keyring@22.4.0`** (manifest-derived v2 capabilities, deserialize initialization guard, plus related dependency bumps). ETH and account packages in the diff only refresh **`keyring-api`** (and changelog links); **`yarn.lock`** is updated accordingly.
> 
> This PR contains **no application source changes**—only version numbers, changelogs, and lockfile entries for publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61106cea7b63080871c0c0df7574e7ba73f84a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->