### PR TITLE
refactor(keyring-snap-bridge)!: remove `SnapKeyringV1` inheritance

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -210,7 +210,7 @@
   },
   "packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts": {
     "@typescript-eslint/no-explicit-any": {
-      "count": 4
+      "count": 1
     }
   },
   "packages/keyring-snap-sdk/src/rpc-handler.test.ts": {

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** `SnapKeyring` (v2) no longer inherits `SnapKeyringV1` ([#584](https://github.com/MetaMask/accounts/pull/584))
+  - Use `.v1` getter to access a v1 instance instead.
+  - `.v1` will yield `undefined` if the Snap declares v2 `capabilities` in its `endowment:keyring`.
+
 ## [22.4.0]
 
 ### Added

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -3793,11 +3793,11 @@ describe('SnapKeyring', () => {
 
     it('resolveAccountAddress throws for a v2 snap', async () => {
       await expect(
-        v2Keyring.resolveAccountAddress(
-          v2SnapId,
-          EthScope.Eoa,
-          { id: 1, jsonrpc: '2.0', method: 'eth_sign' } as JsonRpcRequest,
-        ),
+        v2Keyring.resolveAccountAddress(v2SnapId, EthScope.Eoa, {
+          id: 1,
+          jsonrpc: '2.0',
+          method: 'eth_sign',
+        } as JsonRpcRequest),
       ).rejects.toThrow(
         `Snap '${v2SnapId}' does not support v1 address resolution`,
       );

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -2689,7 +2689,7 @@ describe('SnapKeyring', () => {
       const result = await keyring.createAccounts(snapId, options);
 
       expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
       );
 
       // Verify all accounts were returned
@@ -2735,7 +2735,7 @@ describe('SnapKeyring', () => {
       const result = await keyring.createAccounts(snapId, options);
 
       expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
       );
 
       expect(result).toStrictEqual(accountToCreate);
@@ -2771,7 +2771,7 @@ describe('SnapKeyring', () => {
       const result = await keyring.createAccounts(snapId, options);
 
       expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
       );
 
       expect(result).toStrictEqual(accountsToCreate);
@@ -2899,7 +2899,7 @@ describe('SnapKeyring', () => {
       // We still have sent a Snap request to create accounts
       expect(mockMessenger.handleRequest).toHaveBeenNthCalledWith(
         1,
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
       );
 
       // BUT, we should roll back Snap state by deleting the accounts that were created
@@ -3736,6 +3736,139 @@ describe('SnapKeyring', () => {
       ).rejects.toThrow(
         `Cannot update generic account '${anyGenericAccount.id}'`,
       );
+    });
+  });
+
+  describe('v2 snap error paths', () => {
+    const v2SnapId = 'local:snap.v2mock' as SnapId;
+    let v2Keyring: SnapKeyring;
+
+    beforeEach(async () => {
+      // After the outer beforeEach resets mockMessenger.get, configure it to
+      // return capabilities for the v2 snap so inner SnapKeyring treats it as
+      // a v2 snap (v1 === undefined).
+      mockMessenger.get.mockImplementation((id: SnapId) =>
+        id === v2SnapId
+          ? {
+              manifest: {
+                initialPermissions: {
+                  'endowment:keyring': {
+                    capabilities: { scopes: [EthScope.Eoa] },
+                  },
+                },
+              },
+            }
+          : undefined,
+      );
+
+      v2Keyring = new SnapKeyring({
+        messenger: mockSnapKeyringMessenger,
+        callbacks: mockCallbacks,
+        isAnyAccountTypeAllowed: true,
+      });
+
+      // Load an account for the v2 snap so #snapKeyrings and #accountIndex are
+      // populated, enabling tests for address-based methods.
+      await v2Keyring.deserialize({
+        accounts: {
+          [ethEoaAccount1.id]: { account: ethEoaAccount1, snapId: v2SnapId },
+        },
+      });
+    });
+
+    it('handleKeyringSnapMessage throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.handleKeyringSnapMessage(v2SnapId, {
+          method: KeyringEvent.AccountUpdated,
+          params: { account: ethEoaAccount1 },
+        }),
+      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 messages`);
+    });
+
+    it('createAccount throws for a v2 snap', async () => {
+      await expect(v2Keyring.createAccount(v2SnapId, {})).rejects.toThrow(
+        `Snap '${v2SnapId}' does not support v1 account creation`,
+      );
+    });
+
+    it('resolveAccountAddress throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.resolveAccountAddress(
+          v2SnapId,
+          EthScope.Eoa,
+          { id: 1, jsonrpc: '2.0', method: 'eth_sign' } as JsonRpcRequest,
+        ),
+      ).rejects.toThrow(
+        `Snap '${v2SnapId}' does not support v1 address resolution`,
+      );
+    });
+
+    it('submitRequest throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.submitRequest({
+          origin: 'metamask',
+          account: ethEoaAccount1.id,
+          method: EthMethod.Sign,
+          scope: EthScope.Eoa,
+        }),
+      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 requests`);
+    });
+
+    it('signTransaction throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.signTransaction(
+          ethEoaAccount1.address,
+          TransactionFactory.fromTxData({ type: '0x0' }),
+        ),
+      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
+    });
+
+    it('signTypedData throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.signTypedData(ethEoaAccount1.address, []),
+      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
+    });
+
+    it('signMessage throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.signMessage(ethEoaAccount1.address, '0xdeadbeef'),
+      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
+    });
+
+    it('signPersonalMessage throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.signPersonalMessage(ethEoaAccount1.address, '0xdeadbeef'),
+      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
+    });
+
+    it('prepareUserOperation throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.prepareUserOperation(
+          ethEoaAccount1.address,
+          [],
+          executionContext,
+        ),
+      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
+    });
+
+    it('patchUserOperation throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.patchUserOperation(
+          ethEoaAccount1.address,
+          {} as EthUserOperation,
+          executionContext,
+        ),
+      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
+    });
+
+    it('signUserOperation throws for a v2 snap', async () => {
+      await expect(
+        v2Keyring.signUserOperation(
+          ethEoaAccount1.address,
+          {} as EthUserOperation,
+          executionContext,
+        ),
+      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
     });
   });
 });

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -2689,7 +2689,7 @@ describe('SnapKeyring', () => {
       const result = await keyring.createAccounts(snapId, options);
 
       expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
       );
 
       // Verify all accounts were returned
@@ -2735,7 +2735,7 @@ describe('SnapKeyring', () => {
       const result = await keyring.createAccounts(snapId, options);
 
       expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
       );
 
       expect(result).toStrictEqual(accountToCreate);
@@ -2771,7 +2771,7 @@ describe('SnapKeyring', () => {
       const result = await keyring.createAccounts(snapId, options);
 
       expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
       );
 
       expect(result).toStrictEqual(accountsToCreate);
@@ -2899,7 +2899,7 @@ describe('SnapKeyring', () => {
       // We still have sent a Snap request to create accounts
       expect(mockMessenger.handleRequest).toHaveBeenNthCalledWith(
         1,
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
       );
 
       // BUT, we should roll back Snap state by deleting the accounts that were created
@@ -3848,7 +3848,9 @@ describe('SnapKeyring', () => {
           [],
           executionContext,
         ),
-      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
+      ).rejects.toThrow(
+        `Snap '${v2SnapId}' does not support v1 prepareUserOperation`,
+      );
     });
 
     it('patchUserOperation throws for a v2 snap', async () => {
@@ -3858,7 +3860,9 @@ describe('SnapKeyring', () => {
           {} as EthUserOperation,
           executionContext,
         ),
-      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
+      ).rejects.toThrow(
+        `Snap '${v2SnapId}' does not support v1 patchUserOperation`,
+      );
     });
 
     it('signUserOperation throws for a v2 snap', async () => {
@@ -3868,7 +3872,9 @@ describe('SnapKeyring', () => {
           {} as EthUserOperation,
           executionContext,
         ),
-      ).rejects.toThrow(`Snap '${v2SnapId}' does not support v1 signing`);
+      ).rejects.toThrow(
+        `Snap '${v2SnapId}' does not support v1 signUserOperation`,
+      );
     });
   });
 });

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -799,6 +799,8 @@ export class SnapKeyring {
       bySnap.set(snapId, snapAccounts);
     }
 
+    // v1 snaps receive a keyring_setSelectedAccounts notification; v2 snaps
+    // have no equivalent concept in the protocol so they are intentionally skipped.
     await Promise.all(
       [...this.#snapKeyrings.entries()].map(async ([snapId, keyring]) =>
         keyring.v1?.setSelectedAccounts(

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -88,9 +88,10 @@ export class SnapKeyring {
   readonly #messenger: SnapKeyringMessenger;
 
   /**
-   * Per-snap keyring instances. Each `SnapKeyringV2` (which extends
-   * `SnapKeyringV1`) owns a single `KeyringAccountRegistry` and handles
-   * both the event-driven v1 flow and the `KeyringV2` batch interface.
+   * Per-snap keyring instances. Each `SnapKeyringV2` owns the
+   * `KeyringAccountRegistry` and handles the `KeyringV2` batch interface.
+   * For v1 snaps, `SnapKeyringV2.v1` holds a `SnapKeyringV1` instance
+   * (with a shared registry reference) for the event-driven flow.
    */
   readonly #snapKeyrings: Map<SnapId, SnapKeyringV2>;
 
@@ -344,7 +345,7 @@ export class SnapKeyring {
     }
 
     try {
-      return await keyring.handleKeyringSnapMessage(message);
+      return await (keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 messages`)).handleKeyringSnapMessage(message);
     } finally {
       // Clean up if AccountCreated was rejected (e.g. duplicate address,
       // invalid account), leaving the snap with no registered accounts.
@@ -468,7 +469,7 @@ export class SnapKeyring {
   /**
    * Create an account (v1 event-driven flow).
    *
-   * Delegates to the per-snap SnapKeyringV1 instance.
+   * Delegates to the per-snap SnapKeyringV2 instance (v1 flow).
    *
    * @param snapId - Snap ID to create the account for.
    * @param options - Account creation options. Differs between keyrings.
@@ -481,7 +482,7 @@ export class SnapKeyring {
     internalOptions?: SnapKeyringInternalOptions,
   ): Promise<KeyringAccount> {
     const keyring = await this.#getOrCreateKeyring(snapId);
-    return keyring.createAccount(options, internalOptions);
+    return (keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 account creation`)).createAccount(options, internalOptions);
   }
 
   /**
@@ -535,7 +536,7 @@ export class SnapKeyring {
     }
 
     const keyring = await this.#getOrCreateKeyring(snapId);
-    return keyring.resolveAccountAddress(scope, request);
+    return (keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 address resolution`)).resolveAccountAddress(scope, request);
   }
 
   /**
@@ -572,7 +573,7 @@ export class SnapKeyring {
       this.#snapKeyrings.get(snapId) ??
       throwError(`No keyring found for snap '${snapId}'`);
 
-    return await keyring.submitSnapRequest({
+    return await (keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 requests`)).submitSnapRequest({
       origin,
       account,
       method: method as AccountMethod,
@@ -598,7 +599,7 @@ export class SnapKeyring {
     _opts = {},
   ): Promise<Json | TypedTransaction> {
     const { account, keyring } = this.#resolveAddress(address);
-    return keyring.signTransaction(account, transaction, _opts);
+    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signTransaction(account, transaction, _opts);
   }
 
   /**
@@ -615,7 +616,7 @@ export class SnapKeyring {
     opts = { version: SignTypedDataVersion.V1 },
   ): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return keyring.signTypedData(account, data, opts);
+    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signTypedData(account, data, opts);
   }
 
   /**
@@ -627,7 +628,7 @@ export class SnapKeyring {
    */
   async signMessage(address: string, hash: any): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return keyring.signMessage(account, hash);
+    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signMessage(account, hash);
   }
 
   /**
@@ -642,7 +643,7 @@ export class SnapKeyring {
    */
   async signPersonalMessage(address: string, data: any): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return keyring.signPersonalMessage(account, data);
+    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signPersonalMessage(account, data);
   }
 
   /**
@@ -659,7 +660,7 @@ export class SnapKeyring {
     context: KeyringExecutionContext,
   ): Promise<EthBaseUserOperation> {
     const { account, keyring } = this.#resolveAddress(address);
-    return keyring.prepareUserOperation(account, transactions, context);
+    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).prepareUserOperation(account, transactions, context);
   }
 
   /**
@@ -677,7 +678,7 @@ export class SnapKeyring {
     context: KeyringExecutionContext,
   ): Promise<EthUserOperationPatch> {
     const { account, keyring } = this.#resolveAddress(address);
-    return keyring.patchUserOperation(account, userOp, context);
+    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).patchUserOperation(account, userOp, context);
   }
 
   /**
@@ -694,7 +695,7 @@ export class SnapKeyring {
     context: KeyringExecutionContext,
   ): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return keyring.signUserOperation(account, userOp, context);
+    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signUserOperation(account, userOp, context);
   }
 
   /**
@@ -768,7 +769,7 @@ export class SnapKeyring {
 
     await Promise.all(
       [...this.#snapKeyrings.entries()].map(async ([snapId, keyring]) =>
-        keyring.setSelectedAccounts(
+        keyring.v1?.setSelectedAccounts(
           /* istanbul ignore next */
           bySnap.get(snapId) ?? [],
         ),

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -345,7 +345,10 @@ export class SnapKeyring {
     }
 
     try {
-      return await (keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 messages`)).handleKeyringSnapMessage(message);
+      return await (
+        keyring.v1 ??
+        throwError(`Snap '${snapId}' does not support v1 messages`)
+      ).handleKeyringSnapMessage(message);
     } finally {
       // Clean up if AccountCreated was rejected (e.g. duplicate address,
       // invalid account), leaving the snap with no registered accounts.
@@ -482,7 +485,10 @@ export class SnapKeyring {
     internalOptions?: SnapKeyringInternalOptions,
   ): Promise<KeyringAccount> {
     const keyring = await this.#getOrCreateKeyring(snapId);
-    return (keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 account creation`)).createAccount(options, internalOptions);
+    return (
+      keyring.v1 ??
+      throwError(`Snap '${snapId}' does not support v1 account creation`)
+    ).createAccount(options, internalOptions);
   }
 
   /**
@@ -536,7 +542,10 @@ export class SnapKeyring {
     }
 
     const keyring = await this.#getOrCreateKeyring(snapId);
-    return (keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 address resolution`)).resolveAccountAddress(scope, request);
+    return (
+      keyring.v1 ??
+      throwError(`Snap '${snapId}' does not support v1 address resolution`)
+    ).resolveAccountAddress(scope, request);
   }
 
   /**
@@ -573,7 +582,9 @@ export class SnapKeyring {
       this.#snapKeyrings.get(snapId) ??
       throwError(`No keyring found for snap '${snapId}'`);
 
-    return await (keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 requests`)).submitSnapRequest({
+    return await (
+      keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 requests`)
+    ).submitSnapRequest({
       origin,
       account,
       method: method as AccountMethod,
@@ -599,7 +610,10 @@ export class SnapKeyring {
     _opts = {},
   ): Promise<Json | TypedTransaction> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signTransaction(account, transaction, _opts);
+    return (
+      keyring.v1 ??
+      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
+    ).signTransaction(account, transaction, _opts);
   }
 
   /**
@@ -616,7 +630,10 @@ export class SnapKeyring {
     opts = { version: SignTypedDataVersion.V1 },
   ): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signTypedData(account, data, opts);
+    return (
+      keyring.v1 ??
+      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
+    ).signTypedData(account, data, opts);
   }
 
   /**
@@ -628,7 +645,10 @@ export class SnapKeyring {
    */
   async signMessage(address: string, hash: any): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signMessage(account, hash);
+    return (
+      keyring.v1 ??
+      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
+    ).signMessage(account, hash);
   }
 
   /**
@@ -643,7 +663,10 @@ export class SnapKeyring {
    */
   async signPersonalMessage(address: string, data: any): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signPersonalMessage(account, data);
+    return (
+      keyring.v1 ??
+      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
+    ).signPersonalMessage(account, data);
   }
 
   /**
@@ -660,7 +683,10 @@ export class SnapKeyring {
     context: KeyringExecutionContext,
   ): Promise<EthBaseUserOperation> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).prepareUserOperation(account, transactions, context);
+    return (
+      keyring.v1 ??
+      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
+    ).prepareUserOperation(account, transactions, context);
   }
 
   /**
@@ -678,7 +704,10 @@ export class SnapKeyring {
     context: KeyringExecutionContext,
   ): Promise<EthUserOperationPatch> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).patchUserOperation(account, userOp, context);
+    return (
+      keyring.v1 ??
+      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
+    ).patchUserOperation(account, userOp, context);
   }
 
   /**
@@ -695,7 +724,10 @@ export class SnapKeyring {
     context: KeyringExecutionContext,
   ): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (keyring.v1 ?? throwError(`Snap '${keyring.snapId}' does not support v1 signing`)).signUserOperation(account, userOp, context);
+    return (
+      keyring.v1 ??
+      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
+    ).signUserOperation(account, userOp, context);
   }
 
   /**

--- a/packages/keyring-snap-bridge/src/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.ts
@@ -24,10 +24,28 @@ import { normalizeAccountAddress } from './account';
 import type { SnapKeyringInternalOptions } from './options';
 import type { SnapKeyringMessenger } from './SnapKeyringMessenger';
 import { SNAP_KEYRING_NAME } from './SnapKeyringMessenger';
-import type { AccountMethod } from './SnapKeyringV1';
+import type { AccountMethod, SnapKeyringV1 } from './SnapKeyringV1';
 import type { SnapMessage } from './types';
 import { throwError, unique } from './util';
 import { SnapKeyring as SnapKeyringV2 } from './v2/SnapKeyring';
+
+/**
+ * Return the v1 instance of a per-snap keyring, throwing if the snap only
+ * supports the v2 protocol.
+ *
+ * @param keyring - The per-snap v2 keyring.
+ * @param feature - Human-readable feature name used in the error message.
+ * @returns The v1 instance.
+ */
+function getKeyringV1For(
+  keyring: SnapKeyringV2,
+  feature: string,
+): SnapKeyringV1 {
+  return (
+    keyring.v1 ??
+    throwError(`Snap '${keyring.snapId}' does not support v1 ${feature}`)
+  );
+}
 
 export const SNAP_KEYRING_TYPE = 'Snap Keyring';
 
@@ -345,9 +363,9 @@ export class SnapKeyring {
     }
 
     try {
-      return await (
-        keyring.v1 ??
-        throwError(`Snap '${snapId}' does not support v1 messages`)
+      return await getKeyringV1For(
+        keyring,
+        'messages',
       ).handleKeyringSnapMessage(message);
     } finally {
       // Clean up if AccountCreated was rejected (e.g. duplicate address,
@@ -485,10 +503,10 @@ export class SnapKeyring {
     internalOptions?: SnapKeyringInternalOptions,
   ): Promise<KeyringAccount> {
     const keyring = await this.#getOrCreateKeyring(snapId);
-    return (
-      keyring.v1 ??
-      throwError(`Snap '${snapId}' does not support v1 account creation`)
-    ).createAccount(options, internalOptions);
+    return getKeyringV1For(keyring, 'account creation').createAccount(
+      options,
+      internalOptions,
+    );
   }
 
   /**
@@ -542,10 +560,10 @@ export class SnapKeyring {
     }
 
     const keyring = await this.#getOrCreateKeyring(snapId);
-    return (
-      keyring.v1 ??
-      throwError(`Snap '${snapId}' does not support v1 address resolution`)
-    ).resolveAccountAddress(scope, request);
+    return getKeyringV1For(keyring, 'address resolution').resolveAccountAddress(
+      scope,
+      request,
+    );
   }
 
   /**
@@ -582,9 +600,7 @@ export class SnapKeyring {
       this.#snapKeyrings.get(snapId) ??
       throwError(`No keyring found for snap '${snapId}'`);
 
-    return await (
-      keyring.v1 ?? throwError(`Snap '${snapId}' does not support v1 requests`)
-    ).submitSnapRequest({
+    return await getKeyringV1For(keyring, 'requests').submitSnapRequest({
       origin,
       account,
       method: method as AccountMethod,
@@ -610,10 +626,11 @@ export class SnapKeyring {
     _opts = {},
   ): Promise<Json | TypedTransaction> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (
-      keyring.v1 ??
-      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
-    ).signTransaction(account, transaction, _opts);
+    return getKeyringV1For(keyring, 'signing').signTransaction(
+      account,
+      transaction,
+      _opts,
+    );
   }
 
   /**
@@ -630,10 +647,11 @@ export class SnapKeyring {
     opts = { version: SignTypedDataVersion.V1 },
   ): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (
-      keyring.v1 ??
-      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
-    ).signTypedData(account, data, opts);
+    return getKeyringV1For(keyring, 'signing').signTypedData(
+      account,
+      data,
+      opts,
+    );
   }
 
   /**
@@ -645,10 +663,7 @@ export class SnapKeyring {
    */
   async signMessage(address: string, hash: any): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (
-      keyring.v1 ??
-      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
-    ).signMessage(account, hash);
+    return getKeyringV1For(keyring, 'signing').signMessage(account, hash);
   }
 
   /**
@@ -663,10 +678,10 @@ export class SnapKeyring {
    */
   async signPersonalMessage(address: string, data: any): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (
-      keyring.v1 ??
-      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
-    ).signPersonalMessage(account, data);
+    return getKeyringV1For(keyring, 'signing').signPersonalMessage(
+      account,
+      data,
+    );
   }
 
   /**
@@ -683,9 +698,9 @@ export class SnapKeyring {
     context: KeyringExecutionContext,
   ): Promise<EthBaseUserOperation> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (
-      keyring.v1 ??
-      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
+    return getKeyringV1For(
+      keyring,
+      'prepareUserOperation',
     ).prepareUserOperation(account, transactions, context);
   }
 
@@ -704,10 +719,11 @@ export class SnapKeyring {
     context: KeyringExecutionContext,
   ): Promise<EthUserOperationPatch> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (
-      keyring.v1 ??
-      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
-    ).patchUserOperation(account, userOp, context);
+    return getKeyringV1For(keyring, 'patchUserOperation').patchUserOperation(
+      account,
+      userOp,
+      context,
+    );
   }
 
   /**
@@ -724,10 +740,11 @@ export class SnapKeyring {
     context: KeyringExecutionContext,
   ): Promise<string> {
     const { account, keyring } = this.#resolveAddress(address);
-    return (
-      keyring.v1 ??
-      throwError(`Snap '${keyring.snapId}' does not support v1 signing`)
-    ).signUserOperation(account, userOp, context);
+    return getKeyringV1For(keyring, 'signUserOperation').signUserOperation(
+      account,
+      userOp,
+      context,
+    );
   }
 
   /**

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
@@ -1,7 +1,7 @@
 import type { SnapId } from '@metamask/snaps-sdk';
 
-import { SnapKeyringV1 } from './SnapKeyringV1';
 import type { SnapKeyringMessenger } from './SnapKeyringMessenger';
+import { SnapKeyringV1, SnapKeyringV1Callbacks } from './SnapKeyringV1';
 
 const SNAP_ID = 'local:snap.mock' as SnapId;
 const OTHER_SNAP_ID = 'local:snap.other' as SnapId;
@@ -13,7 +13,7 @@ function makeMessenger(): SnapKeyringMessenger {
   } as unknown as SnapKeyringMessenger;
 }
 
-function makeCallbacks() {
+function makeCallbacks(): SnapKeyringV1Callbacks {
   return {
     addAccount: jest.fn(),
     removeAccount: jest.fn(),

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.test.ts
@@ -1,0 +1,87 @@
+import type { SnapId } from '@metamask/snaps-sdk';
+
+import { SnapKeyringV1 } from './SnapKeyringV1';
+import type { SnapKeyringMessenger } from './SnapKeyringMessenger';
+
+const SNAP_ID = 'local:snap.mock' as SnapId;
+const OTHER_SNAP_ID = 'local:snap.other' as SnapId;
+
+function makeMessenger(): SnapKeyringMessenger {
+  return {
+    call: jest.fn(),
+    publish: jest.fn(),
+  } as unknown as SnapKeyringMessenger;
+}
+
+function makeCallbacks() {
+  return {
+    addAccount: jest.fn(),
+    removeAccount: jest.fn(),
+    saveState: jest.fn(),
+    redirectUser: jest.fn(),
+    assertAccountCanBeUsed: jest.fn(),
+  };
+}
+
+describe('SnapKeyringV1', () => {
+  describe('constructor', () => {
+    it('creates a new KeyringAccountRegistry when registry is not provided', () => {
+      const v1 = new SnapKeyringV1({
+        messenger: makeMessenger(),
+        callbacks: makeCallbacks(),
+        // registry intentionally omitted → covers `registry ?? new KeyringAccountRegistry()`
+      });
+      expect(v1).toBeDefined();
+    });
+
+    it('uses the false default for isAnyAccountTypeAllowed when not provided', () => {
+      const v1 = new SnapKeyringV1({
+        messenger: makeMessenger(),
+        callbacks: makeCallbacks(),
+        // isAnyAccountTypeAllowed intentionally omitted → covers default parameter branch
+      });
+      expect(v1).toBeDefined();
+    });
+  });
+
+  describe('snapId', () => {
+    it('throws before bindSnapId is called', () => {
+      const v1 = new SnapKeyringV1({
+        messenger: makeMessenger(),
+        callbacks: makeCallbacks(),
+      });
+      expect(() => v1.snapId).toThrow('SnapKeyring has not been initialized');
+    });
+
+    it('returns the snap ID after bindSnapId is called', () => {
+      const v1 = new SnapKeyringV1({
+        messenger: makeMessenger(),
+        callbacks: makeCallbacks(),
+      });
+      v1.bindSnapId(SNAP_ID);
+      expect(v1.snapId).toBe(SNAP_ID);
+    });
+  });
+
+  describe('bindSnapId', () => {
+    it('throws when called with a different snap ID than the one already bound', () => {
+      const v1 = new SnapKeyringV1({
+        messenger: makeMessenger(),
+        callbacks: makeCallbacks(),
+      });
+      v1.bindSnapId(SNAP_ID);
+      expect(() => v1.bindSnapId(OTHER_SNAP_ID)).toThrow(
+        `SnapKeyring bound to '${SNAP_ID}' cannot be rebound to '${OTHER_SNAP_ID}'`,
+      );
+    });
+
+    it('is idempotent when called again with the same snap ID', () => {
+      const v1 = new SnapKeyringV1({
+        messenger: makeMessenger(),
+        callbacks: makeCallbacks(),
+      });
+      v1.bindSnapId(SNAP_ID);
+      expect(() => v1.bindSnapId(SNAP_ID)).not.toThrow();
+    });
+  });
+});

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
@@ -157,6 +157,12 @@ export type SnapKeyringV1Options = {
    * Defaults to `false`.
    */
   isAnyAccountTypeAllowed?: boolean;
+  /**
+   * Account registry to use. When provided (e.g. by a owning `SnapKeyring`
+   * v2 instance), the registry is shared by reference. When omitted, a new
+   * registry is created (useful for standalone / test usage).
+   */
+  registry?: KeyringAccountRegistry;
 };
 
 /**
@@ -241,8 +247,9 @@ export class SnapKeyringV1 {
     messenger,
     callbacks,
     isAnyAccountTypeAllowed = false,
+    registry,
   }: SnapKeyringV1Options) {
-    this.registry = new KeyringAccountRegistry();
+    this.registry = registry ?? new KeyringAccountRegistry();
     this.messenger = messenger;
     this.#callbacks = callbacks;
     this.#isAnyAccountTypeAllowed = isAnyAccountTypeAllowed;
@@ -260,7 +267,7 @@ export class SnapKeyringV1 {
    * @param snapId - The snap ID to bind this keyring to.
    * @throws If the keyring is already bound to a different snap ID.
    */
-  protected bindSnapId(snapId: SnapId): void {
+  bindSnapId(snapId: SnapId): void {
     if (this.#context !== undefined && this.#context.snapId !== snapId) {
       throw new Error(
         `SnapKeyring bound to '${this.#context.snapId}' cannot be rebound to '${snapId}'`,

--- a/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyringV1.ts
@@ -24,6 +24,7 @@ import {
   AccountAssetListUpdatedEventStruct,
   AccountTransactionsUpdatedEventStruct,
 } from '@metamask/keyring-api';
+import type { CreateAccountOptions } from '@metamask/keyring-api/v2';
 import { toKeyringRequestWithoutOrigin } from '@metamask/keyring-internal-api';
 import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client';
 import { KeyringAccountRegistry } from '@metamask/keyring-sdk';
@@ -319,6 +320,23 @@ export class SnapKeyringV1 {
     internalOptions?: SnapKeyringInternalOptions,
   ): Promise<KeyringAccount> {
     return this.#createSnapAccount(options, internalOptions);
+  }
+
+  /**
+   * Create one or more accounts using the v1 synchronous RPC flow.
+   *
+   * Delegates to the v1 internal snap client, which wraps `options` in
+   * `{ options }` before sending `keyring_createAccounts` — unlike the v2
+   * client which sends flat `options`. Called by `SnapKeyring` (v2) when the
+   * snap has no declared capabilities (i.e. it is a v1 snap).
+   *
+   * @param options - Account creation options forwarded to the snap.
+   * @returns The array of accounts returned by the snap.
+   */
+  async createAccounts(
+    options: CreateAccountOptions,
+  ): Promise<KeyringAccount[]> {
+    return this.client.createAccounts(options);
   }
 
   /**

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -5,7 +5,7 @@ import type {
 } from '@metamask/keyring-api';
 import type { Keyring } from '@metamask/keyring-api/v2';
 import { KeyringType } from '@metamask/keyring-api/v2';
-import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client';
+import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client/v2';
 import type { SnapId } from '@metamask/snaps-sdk';
 
 import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
@@ -569,14 +569,17 @@ describe('SnapKeyring', () => {
     });
 
     describe('submitRequest', () => {
-      it('delegates to inherited submitSnapRequest for a known account', async () => {
+      it('delegates to v1.submitSnapRequest for a v1 snap (no declared capabilities)', async () => {
         const mockResult = { success: true };
         const { keyring } = await makeKeyring();
         keyring.setAccount(account1);
 
-        // Spy on the inherited V1 method directly
+        // The snap has no declared capabilities (messenger returns undefined),
+        // so keyring.v1 is set and submitRequest should delegate to it.
+        const v1 = keyring.v1;
+        expect(v1).toBeDefined();
         const submitSpy = jest
-          .spyOn(keyring, 'submitSnapRequest')
+          .spyOn(v1!, 'submitSnapRequest')
           .mockResolvedValue(mockResult as any);
 
         const request = {
@@ -599,6 +602,58 @@ describe('SnapKeyring', () => {
             noPending: false,
           }),
         );
+      });
+
+      it('calls the v2 client directly for a v2 snap (with declared capabilities)', async () => {
+        const mockResult = { success: true };
+        const messenger = {
+          call: jest.fn((action: string) =>
+            action === 'SnapController:getSnap'
+              ? {
+                  manifest: {
+                    initialPermissions: {
+                      'endowment:keyring': {
+                        capabilities: {
+                          scopes: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+                        },
+                      },
+                    },
+                  },
+                }
+              : undefined,
+          ),
+          publish: jest.fn(),
+        } as unknown as SnapKeyringMessenger;
+        const keyring = new SnapKeyring({ messenger, callbacks: makeMockCallbacks() });
+        await keyring.deserialize({ snapId: SNAP_ID, accounts: {} });
+
+        keyring.setAccount(account1);
+        expect(keyring.v1).toBeUndefined();
+
+        const submitSpy = jest
+          .spyOn(KeyringInternalSnapClient.prototype, 'submitRequest')
+          .mockResolvedValue(mockResult as any);
+
+        const request = {
+          id: 'req-1',
+          origin: 'metamask',
+          scope: 'eip155:1',
+          account: account1.id,
+          request: { method: 'eth_sign' },
+        };
+
+        const result = await keyring.submitRequest(request);
+
+        expect(result).toStrictEqual(mockResult);
+        expect(submitSpy).toHaveBeenCalledWith({
+          id: 'req-1',
+          origin: 'metamask',
+          scope: 'eip155:1',
+          account: account1.id,
+          request: { method: 'eth_sign' },
+        });
+
+        submitSpy.mockRestore();
       });
 
       it('throws for an unknown account', async () => {

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -9,6 +9,7 @@ import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-clien
 import type { SnapId } from '@metamask/snaps-sdk';
 
 import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
+import { SnapKeyringV1 } from '../SnapKeyringV1';
 import type { SnapKeyringCallbacks } from './SnapKeyring';
 import { EMPTY_CAPABILITIES, isSnapKeyring, SnapKeyring } from './SnapKeyring';
 
@@ -574,8 +575,8 @@ describe('SnapKeyring', () => {
 
         // The snap has no declared capabilities (messenger returns undefined),
         // so keyring.v1 is set and submitRequest should delegate to it.
-        const { v1 } = keyring;
-        expect(v1).toBeDefined();
+        expect(keyring.v1).toBeDefined();
+        const v1 = keyring.v1 as SnapKeyringV1;
         const submitSpy = jest
           .spyOn(v1, 'submitSnapRequest')
           .mockResolvedValue(mockResult as any);

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -40,13 +40,11 @@ const account2: KeyringAccount = {
 function makeMockCallbacks(): SnapKeyringCallbacks {
   return {
     // V1 base callbacks
-    addAccount: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
-    removeAccount: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
-    saveState: jest.fn<Promise<void>, []>().mockResolvedValue(undefined),
-    redirectUser: jest.fn<Promise<void>, any[]>().mockResolvedValue(undefined),
-    assertAccountCanBeUsed: jest
-      .fn<Promise<void>, [KeyringAccount]>()
-      .mockResolvedValue(undefined),
+    addAccount: jest.fn().mockResolvedValue(undefined),
+    removeAccount: jest.fn().mockResolvedValue(undefined),
+    saveState: jest.fn().mockResolvedValue(undefined),
+    redirectUser: jest.fn().mockResolvedValue(undefined),
+    assertAccountCanBeUsed: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -576,10 +574,10 @@ describe('SnapKeyring', () => {
 
         // The snap has no declared capabilities (messenger returns undefined),
         // so keyring.v1 is set and submitRequest should delegate to it.
-        const v1 = keyring.v1;
+        const { v1 } = keyring;
         expect(v1).toBeDefined();
         const submitSpy = jest
-          .spyOn(v1!, 'submitSnapRequest')
+          .spyOn(v1, 'submitSnapRequest')
           .mockResolvedValue(mockResult as any);
 
         const request = {
@@ -624,7 +622,10 @@ describe('SnapKeyring', () => {
           ),
           publish: jest.fn(),
         } as unknown as SnapKeyringMessenger;
-        const keyring = new SnapKeyring({ messenger, callbacks: makeMockCallbacks() });
+        const keyring = new SnapKeyring({
+          messenger,
+          callbacks: makeMockCallbacks(),
+        });
         await keyring.deserialize({ snapId: SNAP_ID, accounts: {} });
 
         keyring.setAccount(account1);
@@ -632,7 +633,7 @@ describe('SnapKeyring', () => {
 
         const submitSpy = jest
           .spyOn(KeyringInternalSnapClient.prototype, 'submitRequest')
-          .mockResolvedValue(mockResult as any);
+          .mockResolvedValue(mockResult);
 
         const request = {
           id: 'req-1',

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -472,7 +472,7 @@ describe('SnapKeyring', () => {
       it('creates new accounts and saves state', async () => {
         const { keyring, callbacks, registered } = await makeKeyring();
         jest
-          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .spyOn(SnapKeyringV1.prototype, 'createAccounts')
           .mockResolvedValue([account1, account2]);
 
         const result = await keyring.createAccounts(options);
@@ -486,7 +486,7 @@ describe('SnapKeyring', () => {
       it('skips existing accounts (idempotent)', async () => {
         const { keyring, callbacks } = await makeKeyring();
         jest
-          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .spyOn(SnapKeyringV1.prototype, 'createAccounts')
           .mockResolvedValue([account1]);
         // Pre-populate the account
         keyring.setAccount(account1);
@@ -508,7 +508,7 @@ describe('SnapKeyring', () => {
             .mockRejectedValueOnce(new Error('duplicate address')),
         });
         jest
-          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .spyOn(SnapKeyringV1.prototype, 'createAccounts')
           .mockResolvedValue([account1, account2]);
         const deleteSpy = jest
           .spyOn(KeyringInternalSnapClient.prototype, 'deleteAccount')
@@ -524,12 +524,68 @@ describe('SnapKeyring', () => {
       it('rejects duplicate accounts within a batch', async () => {
         const { keyring } = await makeKeyring();
         jest
-          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .spyOn(SnapKeyringV1.prototype, 'createAccounts')
           .mockResolvedValue([account1, account1]);
 
         await expect(keyring.createAccounts(options)).rejects.toThrow(
           'already part of this batch',
         );
+      });
+
+      it('delegates to v1.createAccounts for a v1 snap (uses { options } wrapper)', async () => {
+        // makeKeyring() yields a v1 snap (messenger returns no capabilities)
+        const { keyring } = await makeKeyring();
+        expect(keyring.v1).toBeDefined();
+
+        const v1Spy = jest
+          .spyOn(SnapKeyringV1.prototype, 'createAccounts')
+          .mockResolvedValue([account1]);
+        const v2Spy = jest.spyOn(
+          KeyringInternalSnapClient.prototype,
+          'createAccounts',
+        );
+
+        await keyring.createAccounts(options);
+
+        expect(v1Spy).toHaveBeenCalledWith(options);
+        expect(v2Spy).not.toHaveBeenCalled();
+      });
+
+      it('calls the v2 client directly for a v2 snap (flat options, no wrapper)', async () => {
+        const messenger = {
+          call: jest.fn((action: string) =>
+            action === 'SnapController:getSnap'
+              ? {
+                  manifest: {
+                    initialPermissions: {
+                      'endowment:keyring': {
+                        capabilities: {
+                          scopes: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+                        },
+                      },
+                    },
+                  },
+                }
+              : undefined,
+          ),
+          publish: jest.fn(),
+        } as unknown as SnapKeyringMessenger;
+        const keyring = new SnapKeyring({
+          messenger,
+          callbacks: makeMockCallbacks(),
+        });
+        await keyring.deserialize({ snapId: SNAP_ID, accounts: {} });
+        expect(keyring.v1).toBeUndefined();
+
+        const v2Spy = jest
+          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .mockResolvedValue([account1]);
+        const v1Spy = jest.spyOn(SnapKeyringV1.prototype, 'createAccounts');
+
+        await keyring.createAccounts(options);
+
+        expect(v2Spy).toHaveBeenCalledWith(options);
+        expect(v1Spy).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -1,4 +1,4 @@
-import { EthAccountType, EthScope } from '@metamask/keyring-api';
+import { EthAccountType, EthScope, KeyringEvent } from '@metamask/keyring-api';
 import type {
   KeyringAccount,
   CreateAccountOptions,
@@ -728,6 +728,46 @@ describe('SnapKeyring', () => {
         await expect(keyring.submitRequest(request)).rejects.toThrow(
           "Account 'unknown-id' not found",
         );
+      });
+    });
+
+    describe('v1/v2 shared registry', () => {
+      it('accounts created via v1 createAccounts are visible through v2 getAccounts', async () => {
+        const { keyring } = await makeKeyring();
+        jest
+          .spyOn(SnapKeyringV1.prototype, 'createAccounts')
+          .mockResolvedValue([account1]);
+
+        await keyring.createAccounts({} as unknown as CreateAccountOptions);
+
+        expect(await keyring.getAccounts()).toStrictEqual([account1]);
+      });
+
+      it('accounts added via v1 AccountCreated event are visible through v2 getAccounts', async () => {
+        // The default addAccount mock resolves without calling handleUserInput,
+        // so the account never reaches the registry. Override it to accept.
+        const { keyring } = await makeKeyring(SNAP_ID, {
+          addAccount: jest
+            .fn()
+            .mockImplementation(
+              async (
+                _address: string,
+                _snapId: string,
+                handleUserInput: (accepted: boolean) => Promise<void>,
+              ) => {
+                await handleUserInput(true);
+              },
+            ),
+        });
+        expect(keyring.v1).toBeDefined();
+        const v1 = keyring.v1 as SnapKeyringV1;
+
+        await v1.handleKeyringSnapMessage({
+          method: KeyringEvent.AccountCreated,
+          params: { account: account1 },
+        });
+
+        expect(await keyring.getAccounts()).toStrictEqual([account1]);
       });
     });
   });

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -7,6 +7,7 @@ import type {
 } from '@metamask/keyring-api/v2';
 import { KeyringType } from '@metamask/keyring-api/v2';
 import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client/v2';
+import { KeyringAccountRegistry } from '@metamask/keyring-sdk';
 import type { AccountId } from '@metamask/keyring-utils';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { Infer } from '@metamask/superstruct';
@@ -17,6 +18,7 @@ import { Mutex } from 'async-mutex';
 import {
   KeyringAccountV1Struct,
   normalizeAccount,
+  normalizeAccountAddress,
   transformAccount,
 } from '../account';
 import { isAccountV1, migrateAccountV1 } from '../migrations';
@@ -24,8 +26,8 @@ import { SnapKeyringV1 } from '../SnapKeyringV1';
 import type {
   AccountMethod,
   SnapKeyringV1Callbacks,
-  SnapKeyringV1Options,
 } from '../SnapKeyringV1';
+import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
 import { equalsIgnoreCase } from '../util';
 
 /**
@@ -79,8 +81,10 @@ export type SnapKeyringCallbacks = SnapKeyringV1Callbacks & {
   withLock?: <Result>(callback: () => Promise<Result>) => Promise<Result>;
 };
 
-type SnapKeyringOptions = Omit<SnapKeyringV1Options, 'callbacks'> & {
+type SnapKeyringOptions = {
+  messenger: SnapKeyringMessenger;
   callbacks: SnapKeyringCallbacks;
+  isAnyAccountTypeAllowed?: boolean;
 };
 
 /**
@@ -103,23 +107,24 @@ export function isSnapKeyring(keyring: Keyring): keyring is SnapKeyring {
 }
 
 /**
- * Per-snap keyring wrapper that implements `Keyring`.
+ * Per-snap keyring that implements `Keyring` (v2).
  *
- * Extends `SnapKeyringV1` — the v1 event-driven flow (account lifecycle,
- * request handling, asset events) is inherited. This class adds the
- * `KeyringV2` batch interface (`createAccounts`, `deleteAccount`, etc.) and
- * owns the `capabilities` property.
- *
- * The `KeyringAccountRegistry`, snap client, and messenger are all inherited
- * from `SnapKeyringV1` so there is no duplicated state.
+ * Owns the account registry and messenger. For v1 snaps (those that do not
+ * declare `endowment:keyring` capabilities in their manifest), a
+ * {@link SnapKeyringV1} instance is created on `deserialize` and held under
+ * {@link SnapKeyring.v1}. V2 snaps have `v1 === undefined` and communicate
+ * directly through the v2 client without the `{ pending, result }` envelope.
  */
-export class SnapKeyring extends SnapKeyringV1 implements Keyring {
-  /**
-   * V2-typed view of the callbacks. Stored separately from the V1 private
-   * field so that V2-specific callbacks are accessible without casting.
-   * Both fields hold the same object reference.
-   */
+export class SnapKeyring implements Keyring {
+  /** Account registry — shared by reference with the v1 instance when present. */
+  readonly #registry: KeyringAccountRegistry;
+
+  /** Messenger for snap controller calls and event publishing. */
+  readonly #messenger: SnapKeyringMessenger;
+
   readonly #callbacks: SnapKeyringCallbacks;
+
+  readonly #isAnyAccountTypeAllowed: boolean;
 
   /**
    * Mutex that serializes `createAccounts` calls on this snap instance.
@@ -129,6 +134,12 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
 
   /** V2 snap client. Set via {@link bindSnapId}. */
   #context: SnapKeyringContext | undefined;
+
+  /**
+   * V1 instance, present only when the snap does not declare v2 capabilities.
+   * Created on `deserialize()` after reading the snap manifest.
+   */
+  #v1: SnapKeyringV1 | undefined;
 
   // ──────────────────────────────────────────────
   // Keyring properties
@@ -144,9 +155,15 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    */
   capabilities: KeyringCapabilities;
 
-  constructor(options: SnapKeyringOptions) {
-    super(options);
-    this.#callbacks = options.callbacks;
+  constructor({
+    messenger,
+    callbacks,
+    isAnyAccountTypeAllowed = false,
+  }: SnapKeyringOptions) {
+    this.#registry = new KeyringAccountRegistry();
+    this.#messenger = messenger;
+    this.#callbacks = callbacks;
+    this.#isAnyAccountTypeAllowed = isAnyAccountTypeAllowed;
     this.#lock = new Mutex();
 
     // Default capabilities; replaced from the snap manifest on `deserialize`.
@@ -154,20 +171,51 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
   }
 
   /**
-   * Bind this keyring to a snap ID and initialize both the v1 and v2 clients.
+   * The v1 instance for this snap, or `undefined` if the snap is v2-only.
    *
-   * Calls `super.bindSnapId` first so the inherited v1 request lifecycle (pending
-   * map, async redirect) is fully set up, then creates the v2-specific context.
+   * Use this to make v1 calls explicit:
+   * ```ts
+   * keyring.v1?.signTransaction(account, tx);
+   * ```
+   */
+  get v1(): SnapKeyringV1 | undefined {
+    return this.#v1;
+  }
+
+  /**
+   * The snap ID this instance is scoped to.
+   *
+   * @throws If the keyring has not been initialized yet.
+   */
+  get snapId(): SnapId {
+    /* istanbul ignore next */
+    if (this.#context === undefined) {
+      throw new Error(
+        'SnapKeyring has not been initialized: call deserialize() first',
+      );
+    }
+    return this.#context.snapId;
+  }
+
+  /**
+   * Bind this keyring to a snap ID and initialize the v2 client.
+   *
+   * Idempotent for the same `snapId`; throws if called again with a different
+   * one to prevent accidentally swapping a keyring's identity.
    *
    * @param snapId - The snap ID to bind to.
    */
-  protected override bindSnapId(snapId: SnapId): void {
-    super.bindSnapId(snapId);
+  protected bindSnapId(snapId: SnapId): void {
+    if (this.#context !== undefined && this.#context.snapId !== snapId) {
+      throw new Error(
+        `SnapKeyring bound to '${this.#context.snapId}' cannot be rebound to '${snapId}'`,
+      );
+    }
     if (this.#context === undefined) {
       this.#context = {
         snapId,
         client: new KeyringInternalSnapClient({
-          messenger: this.messenger,
+          messenger: this.#messenger,
           snapId,
         }),
       };
@@ -184,13 +232,11 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
   }
 
   /**
-   * Destroy this keyring.
-   *
-   * Delegates to the parent `SnapKeyringV1.destroy()` to reject any pending
-   * requests inherited from the v1 flow.
+   * Destroy this keyring, rejecting any pending v1 requests.
    */
-  override async destroy(): Promise<void> {
-    await super.destroy();
+  async destroy(): Promise<void> {
+    await this.#v1?.destroy();
+    this.#v1 = undefined;
   }
 
   /**
@@ -199,7 +245,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * Prefers the injected `withLock` callback (global lock provided by
    * `SnapKeyring`) so that `createAccounts` calls across different snaps
    * are serialized. Falls back to the per-instance `#lock` when no global
-   * lock is provided.g. standalone use in tests).
+   * lock is provided (e.g. standalone use in tests).
    *
    * @param callback - Operation to run under the lock.
    * @returns The result of the callback.
@@ -277,7 +323,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
           const { address } = account;
 
           // Check for idempotency.
-          const existingAccount = this.getExistingAccount(account);
+          const existingAccount = this.#getExistingAccount(account);
           if (existingAccount) {
             // NOTE: We re-use the account from the internal state to avoid having the Snap
             // mutating the account object without updating the map.
@@ -320,7 +366,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
         // Rollback Snap state.
         for (const snapAccount of snapAccounts) {
           // Make sure to only delete accounts that were not part of the keyring state.
-          if (!this.getExistingAccount(snapAccount)) {
+          if (!this.#getExistingAccount(snapAccount)) {
             try {
               await this.#client.deleteAccount(snapAccount.id);
             } catch (rollbackError) {
@@ -368,12 +414,13 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
   /**
    * Submits a request to the keyring.
    *
-   * Validates that the account belongs to this wrapper, then delegates
-   * to the inherited `submitSnapRequest` for the full request lifecycle
-   * (sync / async / redirect).
+   * For v1 snaps (those without declared capabilities), delegates to the v1
+   * event-driven flow that handles the `{ pending, result }` envelope.
+   * For v2 snaps, calls the snap directly via the v2 client which returns
+   * `Json` with no envelope.
    *
    * @param request - The keyring request to submit.
-   * @param request.id - The request ID (unused — a fresh ID is generated internally).
+   * @param request.id - The request ID.
    * @param request.origin - The sender origin.
    * @param request.scope - The CAIP-2 chain ID.
    * @param request.account - The account ID.
@@ -399,13 +446,24 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
         `Account '${request.account}' not found in snap '${this.snapId}'`,
       );
     }
-    return this.submitSnapRequest({
+    if (this.#v1) {
+      // v1 snap: use event-driven flow with { pending, result } envelope handling.
+      return this.#v1.submitSnapRequest({
+        origin: request.origin,
+        account,
+        method: request.request.method as AccountMethod,
+        params: request.request.params,
+        scope: request.scope,
+        noPending: false,
+      });
+    }
+    // v2 snap: call snap directly, returns Json (no envelope).
+    return this.#client.submitRequest({
+      id: request.id,
       origin: request.origin,
-      account,
-      method: request.request.method as AccountMethod,
-      params: request.request.params,
       scope: request.scope,
-      noPending: false,
+      account: request.account,
+      request: request.request,
     });
   }
 
@@ -423,8 +481,8 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @param account - The account to add or update.
    */
   setAccount(account: KeyringAccount): void {
-    const isNew = !this.registry.has(account.id);
-    this.registry.set(account);
+    const isNew = !this.#registry.has(account.id);
+    this.#registry.set(account);
     if (isNew) {
       this.#callbacks.onRegister?.(account.id);
     }
@@ -439,10 +497,10 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @returns `true` if the account was removed, `false` if it was not found.
    */
   removeAccount(id: AccountId): boolean {
-    if (!this.registry.has(id)) {
+    if (!this.#registry.has(id)) {
       return false;
     }
-    this.registry.delete(id);
+    this.#registry.delete(id);
     this.#callbacks.onUnregister?.(id);
     return true;
   }
@@ -454,7 +512,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @returns `true` if the account exists.
    */
   hasAccount(id: AccountId): boolean {
-    return this.registry.has(id);
+    return this.#registry.has(id);
   }
 
   /**
@@ -464,7 +522,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @returns The account, or `undefined` if not found.
    */
   lookupAccount(id: AccountId): KeyringAccount | undefined {
-    return this.registry.get(id);
+    return this.#registry.get(id);
   }
 
   /**
@@ -477,15 +535,15 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @returns The account, or `undefined` if not found.
    */
   lookupByAddress(address: string): KeyringAccount | undefined {
-    const id = this.registry.getAccountId(address);
+    const id = this.#registry.getAccountId(address);
     if (id !== undefined) {
-      return this.registry.get(id);
+      return this.#registry.get(id);
     }
     // The fallback only runs when the exact-match branch above misses,
     // which in practice only happens for EVM addresses with casing
     // differences (checksummed vs lowercase). Non-EVM addresses are
     // case-sensitive and always resolve on the exact branch.
-    return this.registry
+    return this.#registry
       .values()
       .find((account) => equalsIgnoreCase(account.address, address));
   }
@@ -500,7 +558,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @returns An array of all accounts.
    */
   accounts(): KeyringAccount[] {
-    return this.registry.values();
+    return this.#registry.values();
   }
 
   /**
@@ -514,7 +572,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    */
   async serialize(): Promise<SnapKeyringState> {
     const accounts: SnapKeyringState['accounts'] = {};
-    for (const account of this.registry.values()) {
+    for (const account of this.#registry.values()) {
       accounts[account.id] = account;
     }
     const state: SnapKeyringState = {
@@ -527,9 +585,11 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
   /**
    * Restore this keyring from a serialized state.
    *
-   * Validates the payload (accepting both v1 and v2 accounts), migrates any
-   * v1 accounts to v2, then replaces the registry. If validation fails, the
-   * existing registry is left untouched.
+   * Validates the payload (accepting both v1 and v2 account shapes), migrates
+   * any v1 accounts to v2, then replaces the registry. Also determines whether
+   * the snap is v1 or v2 by reading its manifest capabilities: if no
+   * capabilities are declared, a {@link SnapKeyringV1} instance is created and
+   * held under {@link SnapKeyring.v1}.
    *
    * @param state - The state to deserialize.
    * @returns A promise that resolves when deserialization is complete.
@@ -548,6 +608,25 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     this.capabilities =
       this.#resolveKeyringCapabilities() ?? EMPTY_CAPABILITIES;
 
+    // Determine snap version and create a v1 instance if needed.
+    if (this.capabilities.scopes.length === 0) {
+      // v1 snap: no declared capabilities. Create a SnapKeyringV1 instance
+      // that shares the registry and messenger owned by this class.
+      if (this.#v1 === undefined) {
+        this.#v1 = new SnapKeyringV1({
+          messenger: this.#messenger,
+          callbacks: this.#callbacks,
+          registry: this.#registry,
+          isAnyAccountTypeAllowed: this.#isAnyAccountTypeAllowed,
+        });
+        this.#v1.bindSnapId(state.snapId as SnapId);
+      }
+    } else {
+      // v2 snap: tear down any stale v1 instance (e.g. after a manifest update).
+      await this.#v1?.destroy();
+      this.#v1 = undefined;
+    }
+
     // Migrate v1 accounts to v2.
     const migratedAccounts: Record<string, KeyringAccount> = {};
     for (const [id, rawAccount] of Object.entries(state.accounts)) {
@@ -562,14 +641,13 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     }
 
     // Apply the migrated state to the registry.
-    for (const id of [...this.registry.keys()]) {
+    for (const id of [...this.#registry.keys()]) {
       this.removeAccount(id);
     }
 
     for (const account of Object.values(migratedAccounts)) {
       this.setAccount(account);
     }
-
   }
 
   // ──────────────────────────────────────────────
@@ -595,7 +673,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @returns The keyring capabilities, or `undefined` if the snap manifest does not declare any capabilities.
    */
   #resolveKeyringCapabilities(): KeyringCapabilities | undefined {
-    const snap = this.messenger.call('SnapController:getSnap', this.snapId);
+    const snap = this.#messenger.call('SnapController:getSnap', this.snapId);
     // READ THIS CAREFULLY:
     // We are not validating the shape of the capabilities here, because there is
     // manifest validation done already on the snaps side, the snaps repo maintains
@@ -604,5 +682,21 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     // could cause runtime issues!
     return snap?.manifest.initialPermissions['endowment:keyring']
       ?.capabilities as KeyringCapabilities | undefined;
+  }
+
+  /**
+   * Check whether an account with the same ID and address already exists in
+   * the registry. Used for idempotent account creation.
+   *
+   * @param account - The account to check against the registry.
+   * @returns The existing account if found, `undefined` otherwise.
+   */
+  #getExistingAccount(account: KeyringAccount): KeyringAccount | undefined {
+    const address = normalizeAccountAddress(account);
+    const existing = this.#registry.get(account.id);
+    if (existing && normalizeAccountAddress(existing) === address) {
+      return existing;
+    }
+    return undefined;
   }
 }

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -127,12 +127,6 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    */
   readonly #lock: Mutex;
 
-  /**
-   * Whether `deserialize` has completed. Keyring operations are guarded against
-   * use before the keyring has been bound to a snap and its state loaded.
-   */
-  #initialized = false;
-
   /** V2 snap client. Set via {@link bindSnapId}. */
   #context: SnapKeyringContext | undefined;
 
@@ -576,7 +570,6 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
       this.setAccount(account);
     }
 
-    this.#initialized = true;
   }
 
   // ──────────────────────────────────────────────
@@ -589,7 +582,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    * @throws An error if the keyring has not been initialized.
    */
   #assertInitialized(): void {
-    if (!this.#initialized) {
+    if (this.#context === undefined) {
       throw new Error(
         'SnapKeyring has not been initialized: call deserialize() first',
       );

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -269,7 +269,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
 
       const accounts: KeyringAccount[] = [];
       const newAccounts: KeyringAccount[] = [];
-      const snapAccounts = await this.client.createAccounts(options);
+      const snapAccounts = await this.#client.createAccounts(options);
 
       try {
         for (const snapAccount of snapAccounts) {
@@ -322,7 +322,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
           // Make sure to only delete accounts that were not part of the keyring state.
           if (!this.getExistingAccount(snapAccount)) {
             try {
-              await this.client.deleteAccount(snapAccount.id);
+              await this.#client.deleteAccount(snapAccount.id);
             } catch (rollbackError) {
               // Best-effort rollback; log snap-side failures for observability.
               console.error(
@@ -353,7 +353,7 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
     this.removeAccount(accountId);
 
     try {
-      await this.client.deleteAccount(accountId);
+      await this.#client.deleteAccount(accountId);
     } catch (error) {
       // If the Snap failed to delete the account, log the error and continue
       // with the account deletion, otherwise the account will be stuck in the

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -22,12 +22,9 @@ import {
   transformAccount,
 } from '../account';
 import { isAccountV1, migrateAccountV1 } from '../migrations';
-import { SnapKeyringV1 } from '../SnapKeyringV1';
-import type {
-  AccountMethod,
-  SnapKeyringV1Callbacks,
-} from '../SnapKeyringV1';
 import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
+import { SnapKeyringV1 } from '../SnapKeyringV1';
+import type { AccountMethod, SnapKeyringV1Callbacks } from '../SnapKeyringV1';
 import { equalsIgnoreCase } from '../util';
 
 /**
@@ -171,7 +168,9 @@ export class SnapKeyring implements Keyring {
   }
 
   /**
-   * The v1 instance for this snap, or `undefined` if the snap is v2-only.
+   * Gets the v1 instance for this snap, or `undefined` if the snap is v2-only.
+   *
+   * @returns The v1 instance, or `undefined` if the snap is v2-only.
    *
    * Use this to make v1 calls explicit:
    * ```ts
@@ -185,6 +184,7 @@ export class SnapKeyring implements Keyring {
   /**
    * The snap ID this instance is scoped to.
    *
+   * @returns The snap ID.
    * @throws If the keyring has not been initialized yet.
    */
   get snapId(): SnapId {
@@ -222,7 +222,12 @@ export class SnapKeyring implements Keyring {
     }
   }
 
-  /** Returns the v2 snap client. Throws if the keyring is not yet initialized. */
+  /**
+   * Returns the v2 snap client.
+   *
+   * @returns The v2 snap client.
+   * @throws If the keyring is not yet initialized.
+   */
   get #client(): KeyringInternalSnapClient {
     /* istanbul ignore next */
     if (this.#context === undefined) {
@@ -233,6 +238,8 @@ export class SnapKeyring implements Keyring {
 
   /**
    * Destroy this keyring, rejecting any pending v1 requests.
+   *
+   * @returns A promise that resolves when the keyring is destroyed.
    */
   async destroy(): Promise<void> {
     await this.#v1?.destroy();

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -6,6 +6,7 @@ import type {
   KeyringCapabilities,
 } from '@metamask/keyring-api/v2';
 import { KeyringType } from '@metamask/keyring-api/v2';
+import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client/v2';
 import type { AccountId } from '@metamask/keyring-utils';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { Infer } from '@metamask/superstruct';
@@ -83,6 +84,15 @@ type SnapKeyringOptions = Omit<SnapKeyringV1Options, 'callbacks'> & {
 };
 
 /**
+ * Holds the v2 snap client once a {@link SnapKeyring} instance has been bound
+ * via {@link SnapKeyring.bindSnapId}.
+ */
+type SnapKeyringContext = {
+  snapId: SnapId;
+  client: KeyringInternalSnapClient;
+};
+
+/**
  * Checks if a given keyring is a Snap keyring (v2).
  *
  * @param keyring - The keyring to check.
@@ -123,6 +133,9 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
    */
   #initialized = false;
 
+  /** V2 snap client. Set via {@link bindSnapId}. */
+  #context: SnapKeyringContext | undefined;
+
   // ──────────────────────────────────────────────
   // Keyring properties
   // ──────────────────────────────────────────────
@@ -144,6 +157,36 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
 
     // Default capabilities; replaced from the snap manifest on `deserialize`.
     this.capabilities = EMPTY_CAPABILITIES;
+  }
+
+  /**
+   * Bind this keyring to a snap ID and initialize both the v1 and v2 clients.
+   *
+   * Calls `super.bindSnapId` first so the inherited v1 request lifecycle (pending
+   * map, async redirect) is fully set up, then creates the v2-specific context.
+   *
+   * @param snapId - The snap ID to bind to.
+   */
+  protected override bindSnapId(snapId: SnapId): void {
+    super.bindSnapId(snapId);
+    if (this.#context === undefined) {
+      this.#context = {
+        snapId,
+        client: new KeyringInternalSnapClient({
+          messenger: this.messenger,
+          snapId,
+        }),
+      };
+    }
+  }
+
+  /** Returns the v2 snap client. Throws if the keyring is not yet initialized. */
+  get #client(): KeyringInternalSnapClient {
+    /* istanbul ignore next */
+    if (this.#context === undefined) {
+      throw new Error('SnapKeyring is not bound to a snap ID');
+    }
+    return this.#context.client;
   }
 
   /**

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -322,7 +322,16 @@ export class SnapKeyring implements Keyring {
 
       const accounts: KeyringAccount[] = [];
       const newAccounts: KeyringAccount[] = [];
-      const snapAccounts = await this.#client.createAccounts(options);
+      let snapAccounts: KeyringAccount[];
+      if (this.#v1) {
+        // v1 snap: the v1 client wraps options in `{ options }` before sending
+        // `keyring_createAccounts`, while the v2 client sends flat options.
+        // Route through v1 so v1 snaps receive the format they expect.
+        snapAccounts = await this.#v1.createAccounts(options);
+      } else {
+        // v2 snap: call snap directly with flat options.
+        snapAccounts = await this.#client.createAccounts(options);
+      }
 
       try {
         for (const snapAccount of snapAccounts) {

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -621,11 +621,12 @@ export class SnapKeyring implements Keyring {
     // Refresh capabilities from the snap manifest on every deserialize, falling
     // back to the empty default so a re-hydrate clears any previously-loaded
     // capabilities when the snap no longer declares them.
-    this.capabilities =
-      this.#resolveKeyringCapabilities() ?? EMPTY_CAPABILITIES;
+    const capabilities = this.#resolveKeyringCapabilities();
+    this.capabilities = capabilities ?? EMPTY_CAPABILITIES;
 
     // Determine snap version and create a v1 instance if needed.
-    if (this.capabilities.scopes.length === 0) {
+    const v1 = capabilities === undefined;
+    if (v1) {
       // v1 snap: no declared capabilities. Create a SnapKeyringV1 instance
       // that shares the registry and messenger owned by this class.
       if (this.#v1 === undefined) {


### PR DESCRIPTION
Removing inheritance so we the remaining v1 usage are explicit, since `SnapKeyring` (v2) was implicitly exposing v1 methods, it made it pretty difficult to sunset v1 completely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking public API and behavior split across account creation, signing, and snap messages in security-sensitive keyring code; incorrect v1/v2 routing could break snaps or block v2-only accounts.
> 
> **Overview**
> **Breaking:** v2 `SnapKeyring` no longer extends `SnapKeyringV1`. V1 behavior is exposed only via an optional `.v1` getter (set when the snap manifest has no `endowment:keyring` capabilities; `undefined` for v2-only snaps).
> 
> The per-snap v2 class now owns its registry and v2 `KeyringInternalSnapClient`, and on `deserialize` may compose a `SnapKeyringV1` that shares the same registry. `createAccounts` / `submitRequest` route to v1 or the v2 client depending on snap version (including the v1 `{ options }` wrapper vs flat v2 options).
> 
> The top-level `SnapKeyring` coordinator routes legacy v1 entry points (messages, signing, user ops, etc.) through `getKeyringV1For` and throws clear errors when the target snap is v2-only. `setSelectedAccounts` uses `keyring.v1?.` so v2 snaps are skipped.
> 
> `SnapKeyringV1` gains optional shared `registry`, public `bindSnapId`, and `createAccounts` for v1 RPC. Changelog and tests document the API shift and v1/v2 routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 693e6f33923b2eb38e86257fbcd7042e19d8544b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->