### PR TITLE
fix: send v2 SnapKeyring createAccounts options as flat params

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Send v2 `SnapKeyring.createAccounts` options as flat `params` (via the v2 internal Snap client) instead of the v1 `{ options }` wrapping, so Snaps using the v2 keyring handler accept the request ([#584](https://github.com/MetaMask/accounts/pull/584))
+
 ## [22.4.0]
 
 ### Added

--- a/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/SnapKeyring.test.ts
@@ -2689,7 +2689,7 @@ describe('SnapKeyring', () => {
       const result = await keyring.createAccounts(snapId, options);
 
       expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
       );
 
       // Verify all accounts were returned
@@ -2735,7 +2735,7 @@ describe('SnapKeyring', () => {
       const result = await keyring.createAccounts(snapId, options);
 
       expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
       );
 
       expect(result).toStrictEqual(accountToCreate);
@@ -2771,7 +2771,7 @@ describe('SnapKeyring', () => {
       const result = await keyring.createAccounts(snapId, options);
 
       expect(mockMessenger.handleRequest).toHaveBeenLastCalledWith(
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
       );
 
       expect(result).toStrictEqual(accountsToCreate);
@@ -2899,7 +2899,7 @@ describe('SnapKeyring', () => {
       // We still have sent a Snap request to create accounts
       expect(mockMessenger.handleRequest).toHaveBeenNthCalledWith(
         1,
-        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, { options }),
+        mockKeyringRpcRequest(KeyringRpcMethod.CreateAccounts, options),
       );
 
       // BUT, we should roll back Snap state by deleting the accounts that were created

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.test.ts
@@ -6,6 +6,7 @@ import type {
 import type { Keyring } from '@metamask/keyring-api/v2';
 import { KeyringType } from '@metamask/keyring-api/v2';
 import { KeyringInternalSnapClient } from '@metamask/keyring-internal-snap-client';
+import { KeyringInternalSnapClient as KeyringInternalSnapClientV2 } from '@metamask/keyring-internal-snap-client/v2';
 import type { SnapId } from '@metamask/snaps-sdk';
 
 import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
@@ -473,7 +474,7 @@ describe('SnapKeyring', () => {
       it('creates new accounts and saves state', async () => {
         const { keyring, callbacks, registered } = await makeKeyring();
         jest
-          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .spyOn(KeyringInternalSnapClientV2.prototype, 'createAccounts')
           .mockResolvedValue([account1, account2]);
 
         const result = await keyring.createAccounts(options);
@@ -487,7 +488,7 @@ describe('SnapKeyring', () => {
       it('skips existing accounts (idempotent)', async () => {
         const { keyring, callbacks } = await makeKeyring();
         jest
-          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .spyOn(KeyringInternalSnapClientV2.prototype, 'createAccounts')
           .mockResolvedValue([account1]);
         // Pre-populate the account
         keyring.setAccount(account1);
@@ -509,7 +510,7 @@ describe('SnapKeyring', () => {
             .mockRejectedValueOnce(new Error('duplicate address')),
         });
         jest
-          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .spyOn(KeyringInternalSnapClientV2.prototype, 'createAccounts')
           .mockResolvedValue([account1, account2]);
         const deleteSpy = jest
           .spyOn(KeyringInternalSnapClient.prototype, 'deleteAccount')
@@ -525,7 +526,7 @@ describe('SnapKeyring', () => {
       it('rejects duplicate accounts within a batch', async () => {
         const { keyring } = await makeKeyring();
         jest
-          .spyOn(KeyringInternalSnapClient.prototype, 'createAccounts')
+          .spyOn(KeyringInternalSnapClientV2.prototype, 'createAccounts')
           .mockResolvedValue([account1, account1]);
 
         await expect(keyring.createAccounts(options)).rejects.toThrow(

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyring.ts
@@ -6,6 +6,7 @@ import type {
   KeyringCapabilities,
 } from '@metamask/keyring-api/v2';
 import { KeyringType } from '@metamask/keyring-api/v2';
+import { KeyringInternalSnapClient as KeyringInternalSnapClientV2 } from '@metamask/keyring-internal-snap-client/v2';
 import type { AccountId } from '@metamask/keyring-utils';
 import type { SnapId } from '@metamask/snaps-sdk';
 import type { Infer } from '@metamask/superstruct';
@@ -232,7 +233,17 @@ export class SnapKeyring extends SnapKeyringV1 implements Keyring {
 
       const accounts: KeyringAccount[] = [];
       const newAccounts: KeyringAccount[] = [];
-      const snapAccounts = await this.client.createAccounts(options);
+      // `createAccounts` is a v2-only keyring method: it sends its options as
+      // flat `params`. The inherited v1 `this.client` wraps them as
+      // `{ options }`, which v2 Snaps reject, so we dispatch through the v2
+      // internal client here. `this.client` is kept for the v1-only methods the
+      // bridge still relies on (`submitRequestWithoutOrigin`,
+      // `resolveAccountAddress`, `createAccount`), which the v2 client lacks.
+      const clientV2 = new KeyringInternalSnapClientV2({
+        messenger: this.messenger,
+        snapId: this.snapId,
+      });
+      const snapAccounts = await clientV2.createAccounts(options);
 
       try {
         for (const snapAccount of snapAccounts) {


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->
