### PR TITLE
feat(keyring-api): add `base32` private key encoding

### DIFF
--- a/packages/keyring-api/CHANGELOG.md
+++ b/packages/keyring-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for `base32` private key encoding in `exportAccount` ([#589](https://github.com/MetaMask/accounts/pull/589))
+
 ## [23.5.0]
 
 ### Added

--- a/packages/keyring-api/src/v2/api/create-account/index.test.ts
+++ b/packages/keyring-api/src/v2/api/create-account/index.test.ts
@@ -63,6 +63,19 @@ describe('CreateAccountOptionsStruct', () => {
         assert(validPrivateKey, CreateAccountOptionsStruct),
       ).not.toThrow();
     });
+
+    it('validates PrivateKeyImport type with base32 encoding correctly', () => {
+      const validPrivateKey = {
+        type: AccountCreationType.PrivateKeyImport,
+        privateKey: 'JBSWY3DPEHPK3PXP',
+        encoding: 'base32',
+      };
+
+      expect(is(validPrivateKey, CreateAccountOptionsStruct)).toBe(true);
+      expect(() =>
+        assert(validPrivateKey, CreateAccountOptionsStruct),
+      ).not.toThrow();
+    });
   });
 
   describe('invalid account creation types', () => {

--- a/packages/keyring-api/src/v2/api/keyring.test-d.ts
+++ b/packages/keyring-api/src/v2/api/keyring.test-d.ts
@@ -50,6 +50,15 @@ expectAssignable<ImportPrivateKeyFormat>({
   type: 'eip155:eoa',
 });
 
+expectAssignable<ImportPrivateKeyFormat>({
+  encoding: 'base32',
+});
+
+expectAssignable<ImportPrivateKeyFormat>({
+  encoding: 'base32',
+  type: 'eip155:eoa',
+});
+
 expectNotAssignable<ImportPrivateKeyFormat>({
   encoding: 'invalid',
 });
@@ -133,6 +142,12 @@ expectAssignable<CreateAccountPrivateKeyOptions>({
   accountType: 'bip122:p2wpkh',
 });
 
+expectAssignable<CreateAccountPrivateKeyOptions>({
+  type: AccountCreationType.PrivateKeyImport,
+  privateKey: 'JBSWY3DPEHPK3PXP',
+  encoding: 'base32',
+});
+
 // Test CreateAccountCustomOptions
 expectAssignable<CreateAccountCustomOptions>({
   type: AccountCreationType.Custom,
@@ -172,6 +187,11 @@ expectAssignable<ExportAccountOptions>({
   encoding: 'base58',
 });
 
+expectAssignable<ExportAccountOptions>({
+  type: AccountExportType.PrivateKey,
+  encoding: 'base32',
+});
+
 // Test PrivateKeyExportedAccount
 expectAssignable<PrivateKeyExportedAccount>({
   type: AccountExportType.PrivateKey,
@@ -184,6 +204,12 @@ expectAssignable<ExportedAccount>({
   type: AccountExportType.PrivateKey,
   privateKey: 'L1aW4aubDFB7yfras2S1mN3bqg9nwySY8nkoLmJebSLD5BWv3ENZ',
   encoding: 'base58',
+});
+
+expectAssignable<ExportedAccount>({
+  type: AccountExportType.PrivateKey,
+  privateKey: 'JBSWY3DPEHPK3PXP',
+  encoding: 'base32',
 });
 
 // Test Keyring interface

--- a/packages/keyring-api/src/v2/api/private-key.ts
+++ b/packages/keyring-api/src/v2/api/private-key.ts
@@ -16,6 +16,11 @@ export enum PrivateKeyEncoding {
    * Base58 encoding format.
    */
   Base58 = 'base58',
+
+  /**
+   * Base32 encoding format.
+   */
+  Base32 = 'base32',
 }
 
 /**
@@ -24,6 +29,7 @@ export enum PrivateKeyEncoding {
 export const PrivateKeyEncodingStruct = enums([
   `${PrivateKeyEncoding.Hexadecimal}`,
   `${PrivateKeyEncoding.Base58}`,
+  `${PrivateKeyEncoding.Base32}`,
 ]);
 
 /**


### PR DESCRIPTION
Adding a new encoding for private keys (will be used by Stellar).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive enum/struct extension with tests only; no changes to encoding logic or existing format behavior.
> 
> **Overview**
> Adds **`base32`** as a supported private key string encoding in the v2 keyring API, alongside existing `hexadecimal` and `base58`.
> 
> The change extends `PrivateKeyEncoding` / `PrivateKeyEncodingStruct` in `private-key.ts`, so **`encoding: 'base32'`** is accepted for private-key **import** (`ImportPrivateKeyFormat`, `CreateAccountOptions` private-key import), **export** (`ExportAccountOptions`, `ExportedAccount`), and related capability format declarations. Runtime validation and TypeScript assignability are covered with new struct and `test-d` cases; the unreleased changelog notes **`exportAccount`** support for this encoding (intended for Stellar).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c41a37f0f1270f4912f3ecfd7bfc68330b84032c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->