### PR TITLE
feat(account-api): add `PrivateKeyAccount` type helper

### DIFF
--- a/packages/account-api/CHANGELOG.md
+++ b/packages/account-api/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `PrivateKeyAccount<Account>` type helper ([#590](https://github.com/MetaMask/accounts/pull/590))
+
 ### Changed
 
 - Bump `@metamask/keyring-utils` from `^3.2.0` to `^3.3.1` ([#544](https://github.com/MetaMask/accounts/pull/544), [#546](https://github.com/MetaMask/accounts/pull/546))

--- a/packages/account-api/src/api/bip44.ts
+++ b/packages/account-api/src/api/bip44.ts
@@ -2,6 +2,7 @@ import type {
   KeyringAccount,
   KeyringAccountEntropyMnemonicOptions,
 } from '@metamask/keyring-api';
+import { KeyringAccountEntropyTypeOption } from '@metamask/keyring-api';
 
 /**
  * BIP-44 compatible account type.
@@ -25,7 +26,10 @@ export function isBip44Account<Account extends KeyringAccount>(
 ): account is Bip44Account<Account> {
   // To be BIP-44 compatible, we just check for the entropy type (the
   // the `entropy` shape will be inferred automatically).
-  return account.options.entropy?.type === 'mnemonic';
+  return (
+    account.options.entropy?.type ===
+    `${KeyringAccountEntropyTypeOption.Mnemonic}`
+  );
 }
 
 /**

--- a/packages/account-api/src/api/private-key.test.ts
+++ b/packages/account-api/src/api/private-key.test.ts
@@ -35,7 +35,7 @@ const MOCK_PRIVATE_KEY_ACCOUNT: PrivateKeyAccount<KeyringAccount> = {
 
 describe('private-key', () => {
   describe('isPrivateKeyAccount', () => {
-    it('returns true if the account is private key compatible', () => {
+    it('returns true if the account is a private key account', () => {
       expect(isPrivateKeyAccount(MOCK_PRIVATE_KEY_ACCOUNT)).toBe(true);
       expect(() =>
         assertIsPrivateKeyAccount(MOCK_PRIVATE_KEY_ACCOUNT),
@@ -64,7 +64,7 @@ describe('private-key', () => {
         options: {},
       },
     ])(
-      'returns false if the account is not private key compatible with: $tc',
+      'returns false if the account is not a private key account with: $tc',
       ({ options }) => {
         const account = {
           ...MOCK_HD_ACCOUNT_1,

--- a/packages/account-api/src/api/private-key.test.ts
+++ b/packages/account-api/src/api/private-key.test.ts
@@ -77,7 +77,7 @@ describe('private-key', () => {
 
         expect(isPrivateKeyAccount(account)).toBe(false);
         expect(() => assertIsPrivateKeyAccount(account)).toThrow(
-          'Account is not private key compatible',
+          'Account is not private key account',
         );
       },
     );

--- a/packages/account-api/src/api/private-key.test.ts
+++ b/packages/account-api/src/api/private-key.test.ts
@@ -1,0 +1,85 @@
+import type {
+  KeyringAccount,
+  KeyringAccountEntropyPrivateKeyOptions,
+} from '@metamask/keyring-api';
+import {
+  EthAccountType,
+  EthMethod,
+  EthScope,
+  KeyringAccountEntropyTypeOption,
+} from '@metamask/keyring-api';
+
+import { MOCK_HD_ACCOUNT_1 } from '../mocks';
+import type { PrivateKeyAccount } from './private-key';
+import { isPrivateKeyAccount, assertIsPrivateKeyAccount } from './private-key';
+
+const MOCK_PRIVATE_KEY_ACCOUNT: PrivateKeyAccount<KeyringAccount> = {
+  id: 'mock-pk-id-1',
+  address: '0x123',
+  options: {
+    entropy: {
+      type: KeyringAccountEntropyTypeOption.PrivateKey,
+    },
+  },
+  methods: [
+    EthMethod.PersonalSign,
+    EthMethod.Sign,
+    EthMethod.SignTransaction,
+    EthMethod.SignTypedDataV1,
+    EthMethod.SignTypedDataV3,
+    EthMethod.SignTypedDataV4,
+  ],
+  type: EthAccountType.Eoa,
+  scopes: [EthScope.Eoa],
+};
+
+describe('private-key', () => {
+  describe('isPrivateKeyAccount', () => {
+    it('returns true if the account is private key compatible', () => {
+      expect(isPrivateKeyAccount(MOCK_PRIVATE_KEY_ACCOUNT)).toBe(true);
+      expect(() =>
+        assertIsPrivateKeyAccount(MOCK_PRIVATE_KEY_ACCOUNT),
+      ).not.toThrow();
+    });
+
+    it.each([
+      {
+        tc: 'missing type',
+        options: {
+          entropy: {
+            // Missing type.
+          },
+        },
+      },
+      {
+        tc: 'wrong type',
+        options: {
+          entropy: {
+            type: KeyringAccountEntropyTypeOption.Mnemonic,
+          },
+        },
+      },
+      {
+        tc: 'missing entropy',
+        options: {},
+      },
+    ])(
+      'returns false if the account is not private key compatible with: $tc',
+      ({ options }) => {
+        const account = {
+          ...MOCK_HD_ACCOUNT_1,
+          options: {
+            entropy:
+              // Force the error case here.
+              options as unknown as KeyringAccountEntropyPrivateKeyOptions,
+          },
+        };
+
+        expect(isPrivateKeyAccount(account)).toBe(false);
+        expect(() => assertIsPrivateKeyAccount(account)).toThrow(
+          'Account is not private key compatible',
+        );
+      },
+    );
+  });
+});

--- a/packages/account-api/src/api/private-key.ts
+++ b/packages/account-api/src/api/private-key.ts
@@ -4,7 +4,7 @@ import type {
 } from '@metamask/keyring-api';
 
 /**
- * Private key compatible account type.
+ * Private key account type.
  */
 export type PrivateKeyAccount<Account extends KeyringAccount> = Account & {
   // We force the option type for those accounts. (That's how we identify
@@ -15,10 +15,10 @@ export type PrivateKeyAccount<Account extends KeyringAccount> = Account & {
 };
 
 /**
- * Checks if an account is private key compatible.
+ * Checks if an account is a private key account.
  *
  * @param account - The account to be tested.
- * @returns True if the account is private key compatible.
+ * @returns True if the account is a private key account.
  */
 export function isPrivateKeyAccount<Account extends KeyringAccount>(
   account: Account,
@@ -29,10 +29,10 @@ export function isPrivateKeyAccount<Account extends KeyringAccount>(
 }
 
 /**
- * Asserts a keyring account is private keycompatible.
+ * Asserts a keyring account is a private key account.
  *
  * @param account - Keyring account to check.
- * @throws If the keyring account is not compatible.
+ * @throws If the keyring account is not a private key account.
  */
 export function assertIsPrivateKeyAccount<Account extends KeyringAccount>(
   account: Account,

--- a/packages/account-api/src/api/private-key.ts
+++ b/packages/account-api/src/api/private-key.ts
@@ -1,3 +1,4 @@
+import { KeyringAccountEntropyTypeOption } from '@metamask/keyring-api';
 import type {
   KeyringAccount,
   KeyringAccountEntropyPrivateKeyOptions,
@@ -23,9 +24,12 @@ export type PrivateKeyAccount<Account extends KeyringAccount> = Account & {
 export function isPrivateKeyAccount<Account extends KeyringAccount>(
   account: Account,
 ): account is PrivateKeyAccount<Account> {
-  // To be private key compatible, we just check for the entropy type
-  // (the `entropy` shape will be inferred automatically).
-  return account.options.entropy?.type === 'private-key';
+  // To be private key compatible, we just check for the entropy type (the
+  // the `entropy` shape will be inferred automatically).
+  return (
+    account.options.entropy?.type ===
+    `${KeyringAccountEntropyTypeOption.PrivateKey}`
+  );
 }
 
 /**

--- a/packages/account-api/src/api/private-key.ts
+++ b/packages/account-api/src/api/private-key.ts
@@ -23,8 +23,8 @@ export type PrivateKeyAccount<Account extends KeyringAccount> = Account & {
 export function isPrivateKeyAccount<Account extends KeyringAccount>(
   account: Account,
 ): account is PrivateKeyAccount<Account> {
-  // To be private key compatible, we just check for the entropy type (the
-  // the `entropy` shape will be inferred automatically).
+  // To be private key compatible, we just check for the entropy type
+  // (the `entropy` shape will be inferred automatically).
   return account.options.entropy?.type === 'private-key';
 }
 

--- a/packages/account-api/src/api/private-key.ts
+++ b/packages/account-api/src/api/private-key.ts
@@ -38,6 +38,6 @@ export function assertIsPrivateKeyAccount<Account extends KeyringAccount>(
   account: Account,
 ): asserts account is PrivateKeyAccount<Account> {
   if (!isPrivateKeyAccount(account)) {
-    throw new Error('Account is not private key compatible');
+    throw new Error('Account is not private key account');
   }
 }

--- a/packages/account-api/src/api/private-key.ts
+++ b/packages/account-api/src/api/private-key.ts
@@ -1,0 +1,43 @@
+import type {
+  KeyringAccount,
+  KeyringAccountEntropyPrivateKeyOptions,
+} from '@metamask/keyring-api';
+
+/**
+ * Private key compatible account type.
+ */
+export type PrivateKeyAccount<Account extends KeyringAccount> = Account & {
+  // We force the option type for those accounts. (That's how we identify
+  // if an account is private key compatible).
+  options: {
+    entropy: KeyringAccountEntropyPrivateKeyOptions;
+  };
+};
+
+/**
+ * Checks if an account is private key compatible.
+ *
+ * @param account - The account to be tested.
+ * @returns True if the account is private key compatible.
+ */
+export function isPrivateKeyAccount<Account extends KeyringAccount>(
+  account: Account,
+): account is PrivateKeyAccount<Account> {
+  // To be private key compatible, we just check for the entropy type (the
+  // the `entropy` shape will be inferred automatically).
+  return account.options.entropy?.type === 'private-key';
+}
+
+/**
+ * Asserts a keyring account is private keycompatible.
+ *
+ * @param account - Keyring account to check.
+ * @throws If the keyring account is not compatible.
+ */
+export function assertIsPrivateKeyAccount<Account extends KeyringAccount>(
+  account: Account,
+): asserts account is PrivateKeyAccount<Account> {
+  if (!isPrivateKeyAccount(account)) {
+    throw new Error('Account is not private key compatible');
+  }
+}


### PR DESCRIPTION
Adding a `PrivateKeyAccount<Account>` type helper, similar to `Bip44Account<Account>`. This new one automatically forces the `options.entropy.type` to be `'private-key'`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and a small enum-based change to BIP-44 detection; behavior should be equivalent if enum values match prior string literals.
> 
> **Overview**
> Adds **`PrivateKeyAccount<Account>`** alongside the existing BIP-44 pattern: a typed account shape with `options.entropy` narrowed to private-key entropy, plus **`isPrivateKeyAccount`** and **`assertIsPrivateKeyAccount`** guards keyed off `KeyringAccountEntropyTypeOption.PrivateKey`. Unit tests cover positive and negative entropy/type cases.
> 
> **`isBip44Account`** now compares entropy type using **`KeyringAccountEntropyTypeOption.Mnemonic`** instead of the string literal `'mnemonic'`, matching the new private-key checks and `@metamask/keyring-api` enums.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554b30a8079c1d195b8d1158e013ae3068d5c8c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->