### PR TITLE
feat: add DMK error tag mappings and resolver

### DIFF
--- a/packages/hw-wallet-sdk/CHANGELOG.md
+++ b/packages/hw-wallet-sdk/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `DMK_ERROR_TAG_MAPPINGS`, `DMK_MESSAGE_PATTERNS`, and `getDMKErrorFromTag` for parsing Ledger Device Management Kit (DMK) errors by their non-standard `_tag` property ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Add `DMK_ERROR_TAG_MAPPINGS`, `DMK_MESSAGE_PATTERNS`, and `getDMKErrorFromTag` for parsing Ledger Device Management Kit (DMK) errors by their non-standard `_tag` property ([#597](https://github.com/MetaMask/accounts/pull/597))
 
 ## [0.10.0]
 

--- a/packages/hw-wallet-sdk/CHANGELOG.md
+++ b/packages/hw-wallet-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `DMK_ERROR_TAG_MAPPINGS`, `DMK_MESSAGE_PATTERNS`, and `getDMKErrorFromTag` for parsing Ledger Device Management Kit (DMK) errors by their non-standard `_tag` property ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 ## [0.10.0]
 
 ### Added

--- a/packages/hw-wallet-sdk/CHANGELOG.md
+++ b/packages/hw-wallet-sdk/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `DMK_ERROR_TAG_MAPPINGS`, `DMK_MESSAGE_PATTERNS`, and `getDMKErrorFromTag` for parsing Ledger Device Management Kit (DMK) errors by their non-standard `_tag` property ([#597](https://github.com/MetaMask/accounts/pull/597))
+- Add `DMK_ERROR_TAG_MAPPINGS`, `DMK_MESSAGE_PATTERNS`, and `getDmkErrorFromTag` for parsing Ledger Device Management Kit (DMK) errors by their non-standard `_tag` property ([#597](https://github.com/MetaMask/accounts/pull/597))
   - Add `DMK_ERROR_MAPPINGS` providing full `ErrorMapping` details (severity, category, userMessage) for each DMK `_tag`
 
 ## [0.10.0]

--- a/packages/hw-wallet-sdk/CHANGELOG.md
+++ b/packages/hw-wallet-sdk/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `DMK_ERROR_TAG_MAPPINGS`, `DMK_MESSAGE_PATTERNS`, and `getDMKErrorFromTag` for parsing Ledger Device Management Kit (DMK) errors by their non-standard `_tag` property ([#597](https://github.com/MetaMask/accounts/pull/597))
+  - Add `DMK_ERROR_MAPPINGS` providing full `ErrorMapping` details (severity, category, userMessage) for each DMK `_tag`
 
 ## [0.10.0]
 

--- a/packages/hw-wallet-sdk/src/dmk-error-mappings.test.ts
+++ b/packages/hw-wallet-sdk/src/dmk-error-mappings.test.ts
@@ -1,9 +1,74 @@
 import {
+  DMK_ERROR_MAPPINGS,
   DMK_ERROR_TAG_MAPPINGS,
   DMK_MESSAGE_PATTERNS,
   getDMKErrorFromTag,
 } from './dmk-error-mappings';
-import { ErrorCode } from './hardware-errors-enums';
+import type { ErrorMapping } from './hardware-error-mappings';
+import { Category, ErrorCode, Severity } from './hardware-errors-enums';
+
+describe('DMK_ERROR_MAPPINGS', () => {
+  it('maps DeviceSessionNotFound to DeviceDisconnected with full details', () => {
+    expect(DMK_ERROR_MAPPINGS.DeviceSessionNotFound).toStrictEqual({
+      code: ErrorCode.DeviceDisconnected,
+      message: 'DMK device session not found',
+      severity: Severity.Err,
+      category: Category.Connection,
+      userMessage:
+        'Your Ledger device was disconnected. Please reconnect and try again.',
+    });
+  });
+
+  it('maps ConnectionOpeningError to BluetoothConnectionFailed', () => {
+    expect(DMK_ERROR_MAPPINGS.ConnectionOpeningError?.code).toBe(
+      ErrorCode.BluetoothConnectionFailed,
+    );
+  });
+
+  it('maps DeviceLockedError to AuthenticationDeviceLocked', () => {
+    expect(DMK_ERROR_MAPPINGS.DeviceLockedError?.code).toBe(
+      ErrorCode.AuthenticationDeviceLocked,
+    );
+    expect(DMK_ERROR_MAPPINGS.DeviceLockedError?.category).toBe(
+      Category.Authentication,
+    );
+  });
+
+  it('maps SessionRefresherError to DeviceDisconnected', () => {
+    expect(DMK_ERROR_MAPPINGS.SessionRefresherError?.code).toBe(
+      ErrorCode.DeviceDisconnected,
+    );
+  });
+
+  it('has exactly 7 DMK error mappings', () => {
+    expect(Object.keys(DMK_ERROR_MAPPINGS)).toHaveLength(7);
+  });
+
+  it('every mapping has all required ErrorMapping fields', () => {
+    Object.values(DMK_ERROR_MAPPINGS).forEach((mapping) => {
+      expect(mapping).toHaveProperty('code');
+      expect(mapping).toHaveProperty('message');
+      expect(mapping).toHaveProperty('severity');
+      expect(mapping).toHaveProperty('category');
+      expect(mapping).toHaveProperty('userMessage');
+    });
+  });
+
+  it('every mapping code matches the code in DMK_ERROR_TAG_MAPPINGS', () => {
+    Object.entries(DMK_ERROR_MAPPINGS).forEach(([tag, mapping]) => {
+      expect(DMK_ERROR_TAG_MAPPINGS[tag]).toBe(mapping.code);
+    });
+  });
+
+  it('every mapping maps to a valid ErrorCode', () => {
+    const validCodes = Object.values(ErrorCode).filter(
+      (value): value is number => typeof value === 'number',
+    );
+    Object.values(DMK_ERROR_MAPPINGS).forEach((mapping: ErrorMapping) => {
+      expect(validCodes).toContain(mapping.code);
+    });
+  });
+});
 
 describe('DMK_ERROR_TAG_MAPPINGS', () => {
   it('maps DeviceSessionNotFound to DeviceDisconnected', () => {

--- a/packages/hw-wallet-sdk/src/dmk-error-mappings.test.ts
+++ b/packages/hw-wallet-sdk/src/dmk-error-mappings.test.ts
@@ -2,7 +2,7 @@ import {
   DMK_ERROR_MAPPINGS,
   DMK_ERROR_TAG_MAPPINGS,
   DMK_MESSAGE_PATTERNS,
-  getDMKErrorFromTag,
+  getDmkErrorFromTag,
 } from './dmk-error-mappings';
 import type { ErrorMapping } from './hardware-error-mappings';
 import { Category, ErrorCode, Severity } from './hardware-errors-enums';
@@ -164,13 +164,13 @@ describe('DMK_MESSAGE_PATTERNS', () => {
   });
 });
 
-describe('getDMKErrorFromTag', () => {
+describe('getDmkErrorFromTag', () => {
   it('returns DeviceDisconnected for DeviceSessionNotFound tag', () => {
     const error = {
       _tag: 'DeviceSessionNotFound',
       message: 'Session not found',
     };
-    expect(getDMKErrorFromTag(error)).toStrictEqual({
+    expect(getDmkErrorFromTag(error)).toStrictEqual({
       code: ErrorCode.DeviceDisconnected,
       tag: 'DeviceSessionNotFound',
     });
@@ -181,7 +181,7 @@ describe('getDMKErrorFromTag', () => {
       _tag: 'ConnectionOpeningError',
       message: 'Failed to open connection',
     };
-    expect(getDMKErrorFromTag(error)).toStrictEqual({
+    expect(getDmkErrorFromTag(error)).toStrictEqual({
       code: ErrorCode.BluetoothConnectionFailed,
       tag: 'ConnectionOpeningError',
     });
@@ -192,7 +192,7 @@ describe('getDMKErrorFromTag', () => {
       _tag: 'DeviceDisconnectedWhileSendingError',
       message: 'Disconnected',
     };
-    expect(getDMKErrorFromTag(error)).toStrictEqual({
+    expect(getDmkErrorFromTag(error)).toStrictEqual({
       code: ErrorCode.DeviceDisconnected,
       tag: 'DeviceDisconnectedWhileSendingError',
     });
@@ -203,7 +203,7 @@ describe('getDMKErrorFromTag', () => {
       _tag: 'DeviceLockedError',
       message: 'Device is locked',
     };
-    expect(getDMKErrorFromTag(error)).toStrictEqual({
+    expect(getDmkErrorFromTag(error)).toStrictEqual({
       code: ErrorCode.AuthenticationDeviceLocked,
       tag: 'DeviceLockedError',
     });
@@ -214,7 +214,7 @@ describe('getDMKErrorFromTag', () => {
       _tag: 'SessionRefresherError',
       message: 'Session refresh failed',
     };
-    expect(getDMKErrorFromTag(error)).toStrictEqual({
+    expect(getDmkErrorFromTag(error)).toStrictEqual({
       code: ErrorCode.DeviceDisconnected,
       tag: 'SessionRefresherError',
     });
@@ -222,35 +222,35 @@ describe('getDMKErrorFromTag', () => {
 
   it('returns null when _tag is not a recognised DMK tag', () => {
     const error = { _tag: 'SomeUnknownTag', message: 'Unknown' };
-    expect(getDMKErrorFromTag(error)).toBeNull();
+    expect(getDmkErrorFromTag(error)).toBeNull();
   });
 
   it('returns null when _tag is missing', () => {
     const error = { message: 'No tag here' };
-    expect(getDMKErrorFromTag(error)).toBeNull();
+    expect(getDmkErrorFromTag(error)).toBeNull();
   });
 
   it('returns null when _tag is not a string', () => {
     const error = { _tag: 42, message: 'Numeric tag' };
-    expect(getDMKErrorFromTag(error)).toBeNull();
+    expect(getDmkErrorFromTag(error)).toBeNull();
   });
 
   it('returns null for null input', () => {
-    expect(getDMKErrorFromTag(null)).toBeNull();
+    expect(getDmkErrorFromTag(null)).toBeNull();
   });
 
   it('returns null for undefined input', () => {
-    expect(getDMKErrorFromTag(undefined)).toBeNull();
+    expect(getDmkErrorFromTag(undefined)).toBeNull();
   });
 
   it('returns null for primitive input', () => {
-    expect(getDMKErrorFromTag('string error')).toBeNull();
-    expect(getDMKErrorFromTag(42)).toBeNull();
+    expect(getDmkErrorFromTag('string error')).toBeNull();
+    expect(getDmkErrorFromTag(42)).toBeNull();
   });
 
   it('returns null for empty string _tag', () => {
     const error = { _tag: '', message: 'Empty tag' };
-    expect(getDMKErrorFromTag(error)).toBeNull();
+    expect(getDmkErrorFromTag(error)).toBeNull();
   });
 
   it('handles errors with additional properties beyond _tag', () => {
@@ -260,7 +260,7 @@ describe('getDMKErrorFromTag', () => {
       name: 'SomeError',
       stack: 'trace...',
     };
-    expect(getDMKErrorFromTag(error)).toStrictEqual({
+    expect(getDmkErrorFromTag(error)).toStrictEqual({
       code: ErrorCode.AuthenticationDeviceLocked,
       tag: 'DeviceLockedError',
     });

--- a/packages/hw-wallet-sdk/src/dmk-error-mappings.test.ts
+++ b/packages/hw-wallet-sdk/src/dmk-error-mappings.test.ts
@@ -1,0 +1,203 @@
+import {
+  DMK_ERROR_TAG_MAPPINGS,
+  DMK_MESSAGE_PATTERNS,
+  getDMKErrorFromTag,
+} from './dmk-error-mappings';
+import { ErrorCode } from './hardware-errors-enums';
+
+describe('DMK_ERROR_TAG_MAPPINGS', () => {
+  it('maps DeviceSessionNotFound to DeviceDisconnected', () => {
+    expect(DMK_ERROR_TAG_MAPPINGS.DeviceSessionNotFound).toBe(
+      ErrorCode.DeviceDisconnected,
+    );
+  });
+
+  it('maps ConnectionOpeningError to BluetoothConnectionFailed', () => {
+    expect(DMK_ERROR_TAG_MAPPINGS.ConnectionOpeningError).toBe(
+      ErrorCode.BluetoothConnectionFailed,
+    );
+  });
+
+  it('maps DeviceDisconnectedWhileSendingError to DeviceDisconnected', () => {
+    expect(DMK_ERROR_TAG_MAPPINGS.DeviceDisconnectedWhileSendingError).toBe(
+      ErrorCode.DeviceDisconnected,
+    );
+  });
+
+  it('maps DeviceDisconnectedBeforeSendingApdu to DeviceDisconnected', () => {
+    expect(DMK_ERROR_TAG_MAPPINGS.DeviceDisconnectedBeforeSendingApdu).toBe(
+      ErrorCode.DeviceDisconnected,
+    );
+  });
+
+  it('maps DeviceLockedError to AuthenticationDeviceLocked', () => {
+    expect(DMK_ERROR_TAG_MAPPINGS.DeviceLockedError).toBe(
+      ErrorCode.AuthenticationDeviceLocked,
+    );
+  });
+
+  it('maps DeviceNotConnectedError to DeviceDisconnected', () => {
+    expect(DMK_ERROR_TAG_MAPPINGS.DeviceNotConnectedError).toBe(
+      ErrorCode.DeviceDisconnected,
+    );
+  });
+
+  it('maps SessionRefresherError to DeviceDisconnected', () => {
+    expect(DMK_ERROR_TAG_MAPPINGS.SessionRefresherError).toBe(
+      ErrorCode.DeviceDisconnected,
+    );
+  });
+
+  it('has exactly 7 DMK tag mappings', () => {
+    expect(Object.keys(DMK_ERROR_TAG_MAPPINGS)).toHaveLength(7);
+  });
+
+  it('maps every tag to a valid ErrorCode', () => {
+    const validCodes = Object.values(ErrorCode).filter(
+      (value): value is number => typeof value === 'number',
+    );
+    Object.values(DMK_ERROR_TAG_MAPPINGS).forEach((code) => {
+      expect(validCodes).toContain(code);
+    });
+  });
+});
+
+describe('DMK_MESSAGE_PATTERNS', () => {
+  it('has patterns for device disconnected', () => {
+    const entry = DMK_MESSAGE_PATTERNS.find(
+      ({ code }) => code === ErrorCode.DeviceDisconnected,
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.patterns).toContain('session not found');
+    expect(entry?.patterns).toContain('sessionid is not initialized');
+    expect(entry?.patterns).toContain('invalid session');
+  });
+
+  it('has patterns for device unresponsive', () => {
+    const entry = DMK_MESSAGE_PATTERNS.find(
+      ({ code }) => code === ErrorCode.DeviceUnresponsive,
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.patterns).toContain('device action ended without completion');
+  });
+
+  it('has patterns for device not ready', () => {
+    const entry = DMK_MESSAGE_PATTERNS.find(
+      ({ code }) => code === ErrorCode.DeviceNotReady,
+    );
+    expect(entry).toBeDefined();
+    expect(entry?.patterns).toContain('ledger command failed');
+  });
+
+  it('every pattern maps to a valid ErrorCode', () => {
+    const validCodes = Object.values(ErrorCode).filter(
+      (value): value is number => typeof value === 'number',
+    );
+    DMK_MESSAGE_PATTERNS.forEach(({ code }) => {
+      expect(validCodes).toContain(code);
+    });
+  });
+});
+
+describe('getDMKErrorFromTag', () => {
+  it('returns DeviceDisconnected for DeviceSessionNotFound tag', () => {
+    const error = {
+      _tag: 'DeviceSessionNotFound',
+      message: 'Session not found',
+    };
+    expect(getDMKErrorFromTag(error)).toStrictEqual({
+      code: ErrorCode.DeviceDisconnected,
+      tag: 'DeviceSessionNotFound',
+    });
+  });
+
+  it('returns BluetoothConnectionFailed for ConnectionOpeningError tag', () => {
+    const error = {
+      _tag: 'ConnectionOpeningError',
+      message: 'Failed to open connection',
+    };
+    expect(getDMKErrorFromTag(error)).toStrictEqual({
+      code: ErrorCode.BluetoothConnectionFailed,
+      tag: 'ConnectionOpeningError',
+    });
+  });
+
+  it('returns DeviceDisconnected for DeviceDisconnectedWhileSendingError tag', () => {
+    const error = {
+      _tag: 'DeviceDisconnectedWhileSendingError',
+      message: 'Disconnected',
+    };
+    expect(getDMKErrorFromTag(error)).toStrictEqual({
+      code: ErrorCode.DeviceDisconnected,
+      tag: 'DeviceDisconnectedWhileSendingError',
+    });
+  });
+
+  it('returns AuthenticationDeviceLocked for DeviceLockedError tag', () => {
+    const error = {
+      _tag: 'DeviceLockedError',
+      message: 'Device is locked',
+    };
+    expect(getDMKErrorFromTag(error)).toStrictEqual({
+      code: ErrorCode.AuthenticationDeviceLocked,
+      tag: 'DeviceLockedError',
+    });
+  });
+
+  it('returns DeviceDisconnected for SessionRefresherError tag', () => {
+    const error = {
+      _tag: 'SessionRefresherError',
+      message: 'Session refresh failed',
+    };
+    expect(getDMKErrorFromTag(error)).toStrictEqual({
+      code: ErrorCode.DeviceDisconnected,
+      tag: 'SessionRefresherError',
+    });
+  });
+
+  it('returns null when _tag is not a recognised DMK tag', () => {
+    const error = { _tag: 'SomeUnknownTag', message: 'Unknown' };
+    expect(getDMKErrorFromTag(error)).toBeNull();
+  });
+
+  it('returns null when _tag is missing', () => {
+    const error = { message: 'No tag here' };
+    expect(getDMKErrorFromTag(error)).toBeNull();
+  });
+
+  it('returns null when _tag is not a string', () => {
+    const error = { _tag: 42, message: 'Numeric tag' };
+    expect(getDMKErrorFromTag(error)).toBeNull();
+  });
+
+  it('returns null for null input', () => {
+    expect(getDMKErrorFromTag(null)).toBeNull();
+  });
+
+  it('returns null for undefined input', () => {
+    expect(getDMKErrorFromTag(undefined)).toBeNull();
+  });
+
+  it('returns null for primitive input', () => {
+    expect(getDMKErrorFromTag('string error')).toBeNull();
+    expect(getDMKErrorFromTag(42)).toBeNull();
+  });
+
+  it('returns null for empty string _tag', () => {
+    const error = { _tag: '', message: 'Empty tag' };
+    expect(getDMKErrorFromTag(error)).toBeNull();
+  });
+
+  it('handles errors with additional properties beyond _tag', () => {
+    const error = {
+      _tag: 'DeviceLockedError',
+      message: 'Device is locked',
+      name: 'SomeError',
+      stack: 'trace...',
+    };
+    expect(getDMKErrorFromTag(error)).toStrictEqual({
+      code: ErrorCode.AuthenticationDeviceLocked,
+      tag: 'DeviceLockedError',
+    });
+  });
+});

--- a/packages/hw-wallet-sdk/src/dmk-error-mappings.ts
+++ b/packages/hw-wallet-sdk/src/dmk-error-mappings.ts
@@ -1,26 +1,93 @@
-import { ErrorCode } from './hardware-errors-enums';
+import type { ErrorMapping } from './hardware-error-mappings';
+import { Category, ErrorCode, Severity } from './hardware-errors-enums';
 
 /**
- * DMK (Device Management Kit) `_tag`-based error name mappings.
+ * Full DMK (Device Management Kit) `_tag`-based error mappings.
  *
  * DMK is Ledger's newer SDK. Unlike legacy `@ledgerhq/errors`, which identify
  * errors via the standard `error.name` property, DMK errors carry a
  * non-standard `_tag` string (e.g. `'DeviceSessionNotFound'`,
  * `'DeviceLockedError'`). Tag values are looked up in this mapping to resolve
- * the corresponding `ErrorCode`.
+ * the full {@link ErrorMapping} (code, message, severity, category,
+ * userMessage).
+ *
+ * This is the single source of truth for DMK tag → error details. The
+ * code-only {@link DMK_ERROR_TAG_MAPPINGS} is derived from this object so
+ * consumers that only need the `ErrorCode` (e.g. MetaMask Mobile) can use the
+ * simpler mapping without duplicating data.
  *
  * These mappings are shared with legacy error names in consumers (e.g.
  * MetaMask Mobile) since both map to the same `ErrorCode` values.
  */
-export const DMK_ERROR_TAG_MAPPINGS: Record<string, ErrorCode> = {
-  DeviceSessionNotFound: ErrorCode.DeviceDisconnected,
-  ConnectionOpeningError: ErrorCode.BluetoothConnectionFailed,
-  DeviceDisconnectedWhileSendingError: ErrorCode.DeviceDisconnected,
-  DeviceDisconnectedBeforeSendingApdu: ErrorCode.DeviceDisconnected,
-  DeviceLockedError: ErrorCode.AuthenticationDeviceLocked,
-  DeviceNotConnectedError: ErrorCode.DeviceDisconnected,
-  SessionRefresherError: ErrorCode.DeviceDisconnected,
+export const DMK_ERROR_MAPPINGS: Record<string, ErrorMapping> = {
+  DeviceSessionNotFound: {
+    code: ErrorCode.DeviceDisconnected,
+    message: 'DMK device session not found',
+    severity: Severity.Err,
+    category: Category.Connection,
+    userMessage:
+      'Your Ledger device was disconnected. Please reconnect and try again.',
+  },
+  ConnectionOpeningError: {
+    code: ErrorCode.BluetoothConnectionFailed,
+    message: 'DMK connection failed to open',
+    severity: Severity.Err,
+    category: Category.Connection,
+    userMessage:
+      'Failed to connect to your Ledger device. Please make sure it is nearby and try again.',
+  },
+  DeviceDisconnectedWhileSendingError: {
+    code: ErrorCode.DeviceDisconnected,
+    message: 'DMK device disconnected while sending',
+    severity: Severity.Err,
+    category: Category.Connection,
+    userMessage:
+      'Your Ledger device was disconnected. Please reconnect and try again.',
+  },
+  DeviceDisconnectedBeforeSendingApdu: {
+    code: ErrorCode.DeviceDisconnected,
+    message: 'DMK device disconnected before sending',
+    severity: Severity.Err,
+    category: Category.Connection,
+    userMessage:
+      'Your Ledger device was disconnected. Please reconnect and try again.',
+  },
+  DeviceLockedError: {
+    code: ErrorCode.AuthenticationDeviceLocked,
+    message: 'DMK device locked',
+    severity: Severity.Err,
+    category: Category.Authentication,
+    userMessage: 'Please unlock your Ledger device to continue.',
+  },
+  DeviceNotConnectedError: {
+    code: ErrorCode.DeviceDisconnected,
+    message: 'DMK device not connected',
+    severity: Severity.Err,
+    category: Category.Connection,
+    userMessage:
+      'Your Ledger device is not connected. Please connect and try again.',
+  },
+  SessionRefresherError: {
+    code: ErrorCode.DeviceDisconnected,
+    message: 'DMK session refresh failed',
+    severity: Severity.Err,
+    category: Category.Connection,
+    userMessage:
+      'Your Ledger device session has expired. Please reconnect and try again.',
+  },
 };
+
+/**
+ * DMK `_tag`-to-`ErrorCode` mappings.
+ *
+ * Derived from {@link DMK_ERROR_MAPPINGS} so there is a single source of truth
+ * for tag → code resolution. Consumers that only need the numeric `ErrorCode`
+ * (e.g. MetaMask Mobile) can use this lightweight mapping directly.
+ */
+export const DMK_ERROR_TAG_MAPPINGS: Record<string, ErrorCode> =
+  Object.fromEntries(
+    Object.entries(DMK_ERROR_MAPPINGS).map(([tag, { code }]) => [tag, code]),
+  );
 
 /**
  * DMK-specific message patterns for error parsing.

--- a/packages/hw-wallet-sdk/src/dmk-error-mappings.ts
+++ b/packages/hw-wallet-sdk/src/dmk-error-mappings.ts
@@ -137,7 +137,7 @@ export type DMKTagResolution = {
  * @returns The resolved `ErrorCode` and the original tag string, or `null`
  * if no `_tag` is present or the tag is not recognised.
  */
-export function getDMKErrorFromTag(error: unknown): DMKTagResolution | null {
+export function getDmkErrorFromTag(error: unknown): DMKTagResolution | null {
   if (error === null || typeof error !== 'object') {
     return null;
   }

--- a/packages/hw-wallet-sdk/src/dmk-error-mappings.ts
+++ b/packages/hw-wallet-sdk/src/dmk-error-mappings.ts
@@ -1,0 +1,94 @@
+import { ErrorCode } from './hardware-errors-enums';
+
+/**
+ * DMK (Device Management Kit) `_tag`-based error name mappings.
+ *
+ * DMK is Ledger's newer SDK. Unlike legacy `@ledgerhq/errors`, which identify
+ * errors via the standard `error.name` property, DMK errors carry a
+ * non-standard `_tag` string (e.g. `'DeviceSessionNotFound'`,
+ * `'DeviceLockedError'`). Tag values are looked up in this mapping to resolve
+ * the corresponding `ErrorCode`.
+ *
+ * These mappings are shared with legacy error names in consumers (e.g.
+ * MetaMask Mobile) since both map to the same `ErrorCode` values.
+ */
+export const DMK_ERROR_TAG_MAPPINGS: Record<string, ErrorCode> = {
+  DeviceSessionNotFound: ErrorCode.DeviceDisconnected,
+  ConnectionOpeningError: ErrorCode.BluetoothConnectionFailed,
+  DeviceDisconnectedWhileSendingError: ErrorCode.DeviceDisconnected,
+  DeviceDisconnectedBeforeSendingApdu: ErrorCode.DeviceDisconnected,
+  DeviceLockedError: ErrorCode.AuthenticationDeviceLocked,
+  DeviceNotConnectedError: ErrorCode.DeviceDisconnected,
+  SessionRefresherError: ErrorCode.DeviceDisconnected,
+};
+
+/**
+ * DMK-specific message patterns for error parsing.
+ *
+ * Each entry maps one or more case-insensitive message substrings to an
+ * `ErrorCode`. Used as a fallback when neither `error.name` nor `_tag` is
+ * recognised, but the error message contains DMK-specific phrasing.
+ */
+export const DMK_MESSAGE_PATTERNS: readonly {
+  patterns: string[];
+  code: ErrorCode;
+}[] = [
+  {
+    patterns: [
+      'session not found',
+      'sessionid is not initialized',
+      'invalid session',
+    ],
+    code: ErrorCode.DeviceDisconnected,
+  },
+  {
+    patterns: ['device action ended without completion'],
+    code: ErrorCode.DeviceUnresponsive,
+  },
+  {
+    patterns: ['ledger command failed'],
+    code: ErrorCode.DeviceNotReady,
+  },
+];
+
+/**
+ * Result of resolving a DMK error from its `_tag` property.
+ */
+export type DMKTagResolution = {
+  code: ErrorCode;
+  tag: string;
+};
+
+/**
+ * Parse a DMK (Device Management Kit) error by its `_tag` property.
+ *
+ * DMK errors carry a non-standard `_tag` string. This function extracts the
+ * tag and looks it up in {@link DMK_ERROR_TAG_MAPPINGS} to resolve the
+ * corresponding `ErrorCode`.
+ *
+ * @param error - The error object to parse.
+ * @returns The resolved `ErrorCode` and the original tag string, or `null`
+ * if no `_tag` is present or the tag is not recognised.
+ */
+export function getDMKErrorFromTag(error: unknown): DMKTagResolution | null {
+  if (error === null || typeof error !== 'object') {
+    return null;
+  }
+
+  const errorObj = error as Record<string, unknown>;
+  const tag =
+    '_tag' in errorObj && typeof errorObj._tag === 'string'
+      ? errorObj._tag
+      : null;
+
+  if (!tag) {
+    return null;
+  }
+
+  const code = DMK_ERROR_TAG_MAPPINGS[tag];
+  if (code === undefined) {
+    return null;
+  }
+
+  return { code, tag };
+}

--- a/packages/hw-wallet-sdk/src/index.ts
+++ b/packages/hw-wallet-sdk/src/index.ts
@@ -1,5 +1,6 @@
 export * from './hardware-errors-enums';
 export * from './hardware-error-mappings';
 export * from './hardware-error';
+export * from './dmk-error-mappings';
 export * from './types';
 export * from './user-rejection';

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `createDMKError` factory function and wire DMK `_tag` resolution into the Ledger DMK bridge ([#597](https://github.com/MetaMask/accounts/pull/597))
-  - `createDMKError` constructs `HardwareWalletError` instances from DMK `_tag` strings.
+- Add `createDmkError` factory function and wire DMK `_tag` resolution into the Ledger DMK bridge ([#597](https://github.com/MetaMask/accounts/pull/597))
+  - `createDmkError` constructs `HardwareWalletError` instances from DMK `_tag` strings.
   - `translateDmkError` now resolves DMK connection/session errors (e.g. `DeviceSessionNotFound`, `DeviceLockedError`) by their `_tag` before falling back to hex APDU status codes.
   - `LedgerDmkBridge.#toError` also resolves DMK `_tag` errors so `sendCommand` failures are correctly classified.
 

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `createDMKError` factory function for constructing `HardwareWalletError` instances from DMK `_tag` strings
+  - `translateDmkError` now resolves DMK connection/session errors (e.g. `DeviceSessionNotFound`, `DeviceLockedError`) by their `_tag` before falling back to hex APDU status codes
+  - `LedgerDmkBridge.#toError` also resolves DMK `_tag` errors so `sendCommand` failures are correctly classified
+  - Bump `@metamask/hw-wallet-sdk` from `^0.10.0` to `^0.11.0` ([#597](https://github.com/MetaMask/accounts/pull/597))
+
 ## [12.3.0]
 
 ### Changed

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -9,10 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `createDMKError` factory function for constructing `HardwareWalletError` instances from DMK `_tag` strings
-  - `translateDmkError` now resolves DMK connection/session errors (e.g. `DeviceSessionNotFound`, `DeviceLockedError`) by their `_tag` before falling back to hex APDU status codes
-  - `LedgerDmkBridge.#toError` also resolves DMK `_tag` errors so `sendCommand` failures are correctly classified
-  - Bump `@metamask/hw-wallet-sdk` from `^0.10.0` to `^0.11.0` ([#597](https://github.com/MetaMask/accounts/pull/597))
+- Add `createDMKError` factory function and wire DMK `_tag` resolution into the Ledger DMK bridge ([#597](https://github.com/MetaMask/accounts/pull/597))
+  - `createDMKError` constructs `HardwareWalletError` instances from DMK `_tag` strings.
+  - `translateDmkError` now resolves DMK connection/session errors (e.g. `DeviceSessionNotFound`, `DeviceLockedError`) by their `_tag` before falling back to hex APDU status codes.
+  - `LedgerDmkBridge.#toError` also resolves DMK `_tag` errors so `sendCommand` failures are correctly classified.
+
+### Changed
+
+- Bump `@metamask/hw-wallet-sdk` from `^0.10.0` to `^0.11.0` ([#597](https://github.com/MetaMask/accounts/pull/597))
 
 ## [12.3.0]
 

--- a/packages/keyring-eth-ledger-bridge/src/dmk/dmk-error-translator.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/dmk/dmk-error-translator.test.ts
@@ -1,9 +1,89 @@
 import { TransportStatusError } from '@ledgerhq/hw-transport';
+import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
 
 import { createMockDeviceExchangeError } from './__testhelpers__/mock-error';
 import { translateDmkError } from './dmk-error-translator';
 
 describe('translateDmkError', () => {
+  describe('DMK _tag resolution (connection/session errors)', () => {
+    it('translates DeviceSessionNotFound tag to HardwareWalletError', () => {
+      const error = { _tag: 'DeviceSessionNotFound', message: 'Session lost' };
+
+      const result = translateDmkError(error);
+
+      expect(result).toBeInstanceOf(HardwareWalletError);
+      expect((result as HardwareWalletError).code).toBe(
+        ErrorCode.DeviceDisconnected,
+      );
+    });
+
+    it('translates DeviceLockedError tag to HardwareWalletError', () => {
+      const error = { _tag: 'DeviceLockedError', message: 'Device is locked' };
+
+      const result = translateDmkError(error);
+
+      expect(result).toBeInstanceOf(HardwareWalletError);
+      expect((result as HardwareWalletError).code).toBe(
+        ErrorCode.AuthenticationDeviceLocked,
+      );
+    });
+
+    it('translates ConnectionOpeningError tag to HardwareWalletError', () => {
+      const error = {
+        _tag: 'ConnectionOpeningError',
+        message: 'Failed to open',
+      };
+
+      const result = translateDmkError(error);
+
+      expect(result).toBeInstanceOf(HardwareWalletError);
+      expect((result as HardwareWalletError).code).toBe(
+        ErrorCode.BluetoothConnectionFailed,
+      );
+    });
+
+    it('translates DeviceDisconnectedWhileSendingError tag', () => {
+      const error = {
+        _tag: 'DeviceDisconnectedWhileSendingError',
+        message: 'Disconnected',
+      };
+
+      const result = translateDmkError(error);
+
+      expect(result).toBeInstanceOf(HardwareWalletError);
+      expect((result as HardwareWalletError).code).toBe(
+        ErrorCode.DeviceDisconnected,
+      );
+    });
+
+    it('translates SessionRefresherError tag', () => {
+      const error = {
+        _tag: 'SessionRefresherError',
+        message: 'Refresh failed',
+      };
+
+      const result = translateDmkError(error);
+
+      expect(result).toBeInstanceOf(HardwareWalletError);
+      expect((result as HardwareWalletError).code).toBe(
+        ErrorCode.DeviceDisconnected,
+      );
+    });
+
+    it('includes the DMK tag in the error message', () => {
+      const error = {
+        _tag: 'DeviceLockedError',
+        message: 'Device is locked',
+      };
+
+      const result = translateDmkError(error);
+
+      expect((result as HardwareWalletError).message).toContain(
+        'DMK device locked',
+      );
+    });
+  });
+
   describe('EthAppCommandError (DeviceExchangeError with EthErrorCodes)', () => {
     it('translates error code "6985" to TransportStatusError with statusCode 0x6985', () => {
       const dmkError = createMockDeviceExchangeError('6985');
@@ -11,7 +91,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6985);
+      expect((result as TransportStatusError).statusCode).toBe(0x6985);
     });
 
     it('translates error code "6a80" to TransportStatusError with statusCode 0x6a80', () => {
@@ -20,7 +100,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6a80);
+      expect((result as TransportStatusError).statusCode).toBe(0x6a80);
     });
 
     it('translates error code "6a84" to TransportStatusError with statusCode 0x6a84', () => {
@@ -29,7 +109,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6a84);
+      expect((result as TransportStatusError).statusCode).toBe(0x6a84);
     });
 
     it('translates error code "6982" to TransportStatusError with statusCode 0x6982', () => {
@@ -38,7 +118,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6982);
+      expect((result as TransportStatusError).statusCode).toBe(0x6982);
     });
 
     it('translates error code "6b00" to TransportStatusError with statusCode 0x6b00', () => {
@@ -47,7 +127,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6b00);
+      expect((result as TransportStatusError).statusCode).toBe(0x6b00);
     });
 
     it('translates error code "6d00" to TransportStatusError with statusCode 0x6d00', () => {
@@ -56,7 +136,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6d00);
+      expect((result as TransportStatusError).statusCode).toBe(0x6d00);
     });
 
     it('translates error code "6e00" to TransportStatusError with statusCode 0x6e00', () => {
@@ -65,7 +145,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6e00);
+      expect((result as TransportStatusError).statusCode).toBe(0x6e00);
     });
 
     it('translates error code "6f00" to TransportStatusError with statusCode 0x6f00', () => {
@@ -74,7 +154,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6f00);
+      expect((result as TransportStatusError).statusCode).toBe(0x6f00);
     });
 
     it('translates error code "6a00" to TransportStatusError with statusCode 0x6a00', () => {
@@ -83,7 +163,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6a00);
+      expect((result as TransportStatusError).statusCode).toBe(0x6a00);
     });
 
     it('translates error code "6a88" to TransportStatusError with statusCode 0x6a88', () => {
@@ -92,7 +172,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6a88);
+      expect((result as TransportStatusError).statusCode).toBe(0x6a88);
     });
   });
 
@@ -103,7 +183,7 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0xffff);
+      expect((result as TransportStatusError).statusCode).toBe(0xffff);
     });
   });
 
@@ -114,21 +194,21 @@ describe('translateDmkError', () => {
       const result = translateDmkError(error);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6f00);
+      expect((result as TransportStatusError).statusCode).toBe(0x6f00);
     });
 
     it('wraps non-Error values in TransportStatusError with status 0x6f00', () => {
       const result = translateDmkError('string error');
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6f00);
+      expect((result as TransportStatusError).statusCode).toBe(0x6f00);
     });
 
     it('wraps null/undefined in TransportStatusError with status 0x6f00', () => {
       const result = translateDmkError(null);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6f00);
+      expect((result as TransportStatusError).statusCode).toBe(0x6f00);
     });
   });
 
@@ -139,7 +219,26 @@ describe('translateDmkError', () => {
       const result = translateDmkError(dmkError);
 
       expect(result).toBeInstanceOf(TransportStatusError);
-      expect(result.statusCode).toBe(0x6f00);
+      expect((result as TransportStatusError).statusCode).toBe(0x6f00);
+    });
+  });
+
+  describe('_tag takes priority over DeviceExchangeError hex code', () => {
+    it('resolves by _tag when both _tag and unrecognized errorCode are present', () => {
+      // A DMK error that carries both a recognised _tag and a non-hex errorCode.
+      // The _tag should win because it identifies the semantic error type.
+      const error = {
+        _tag: 'DeviceSessionNotFound',
+        errorCode: 'n/a',
+        message: 'Session expired',
+      };
+
+      const result = translateDmkError(error);
+
+      expect(result).toBeInstanceOf(HardwareWalletError);
+      expect((result as HardwareWalletError).code).toBe(
+        ErrorCode.DeviceDisconnected,
+      );
     });
   });
 });

--- a/packages/keyring-eth-ledger-bridge/src/dmk/dmk-error-translator.ts
+++ b/packages/keyring-eth-ledger-bridge/src/dmk/dmk-error-translator.ts
@@ -1,21 +1,50 @@
 import { DeviceExchangeError } from '@ledgerhq/device-management-kit';
 import { TransportStatusError } from '@ledgerhq/hw-transport';
+import {
+  getDMKErrorFromTag,
+  HardwareWalletError,
+} from '@metamask/hw-wallet-sdk';
+
+import { createDMKError } from '../errors';
 
 const GENERIC_ERROR_STATUS_CODE = 0x6f00;
 
 /**
- * Translates a DMK error (DeviceExchangeError with hex error codes) into a
- * TransportStatusError that the Ledger keyring error handler can process.
+ * Translates a DMK error into an error the Ledger keyring error handler can
+ * process.
+ *
+ * Resolution order:
+ * 1. **DMK `_tag`** — connection/session-level DMK errors (e.g.
+ *    `DeviceSessionNotFound`, `DeviceLockedError`) carry a `_tag` but no hex
+ *    APDU status code. These are resolved to a {@link HardwareWalletError}
+ *    via the shared SDK mappings.
+ * 2. **`DeviceExchangeError` hex code** — APDU-level errors that carry a
+ *    4-character hex `errorCode` (e.g. `'6985'`). These are converted to a
+ *    {@link TransportStatusError} so the existing `LEDGER_ERROR_MAPPINGS`
+ *    lookup in the keyring error handler applies.
+ * 3. **Generic fallback** — anything else is wrapped in a
+ *    {@link TransportStatusError} with status `0x6f00`.
  *
  * @param error - The error from a DMK device action or command.
- * @returns A TransportStatusError with the corresponding APDU status code.
+ * @returns A `HardwareWalletError` (for resolved DMK tags) or a
+ * `TransportStatusError` (for hex codes and the generic fallback).
  */
-export function translateDmkError(error: unknown): TransportStatusError {
+export function translateDmkError(
+  error: unknown,
+): TransportStatusError | HardwareWalletError {
+  // 1. DMK connection/session errors identified by _tag
+  const tagResolution = getDMKErrorFromTag(error);
+  if (tagResolution) {
+    return createDMKError(tagResolution.tag);
+  }
+
+  // 2. DeviceExchangeError with hex APDU status code
   if (isDeviceExchangeError(error)) {
     const statusCode = parseHexErrorCode(error.errorCode);
     return new TransportStatusError(statusCode);
   }
 
+  // 3. Generic fallback
   return new TransportStatusError(GENERIC_ERROR_STATUS_CODE);
 }
 

--- a/packages/keyring-eth-ledger-bridge/src/dmk/dmk-error-translator.ts
+++ b/packages/keyring-eth-ledger-bridge/src/dmk/dmk-error-translator.ts
@@ -1,11 +1,11 @@
 import { DeviceExchangeError } from '@ledgerhq/device-management-kit';
 import { TransportStatusError } from '@ledgerhq/hw-transport';
 import {
-  getDMKErrorFromTag,
+  getDmkErrorFromTag,
   HardwareWalletError,
 } from '@metamask/hw-wallet-sdk';
 
-import { createDMKError } from '../errors';
+import { createDmkError } from '../errors';
 
 const GENERIC_ERROR_STATUS_CODE = 0x6f00;
 
@@ -33,9 +33,9 @@ export function translateDmkError(
   error: unknown,
 ): TransportStatusError | HardwareWalletError {
   // 1. DMK connection/session errors identified by _tag
-  const tagResolution = getDMKErrorFromTag(error);
+  const tagResolution = getDmkErrorFromTag(error);
   if (tagResolution) {
-    return createDMKError(tagResolution.tag);
+    return createDmkError(tagResolution.tag);
   }
 
   // 2. DeviceExchangeError with hex APDU status code

--- a/packages/keyring-eth-ledger-bridge/src/dmk/ledger-dmk-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/dmk/ledger-dmk-bridge.test.ts
@@ -10,6 +10,7 @@ import {
 } from '@ledgerhq/device-management-kit';
 import { TransportStatusError } from '@ledgerhq/hw-transport';
 import { EIP712Message } from '@ledgerhq/types-live';
+import { ErrorCode, HardwareWalletError } from '@metamask/hw-wallet-sdk';
 import { BehaviorSubject, of, Subject, throwError } from 'rxjs';
 
 import { createMockDeviceExchangeError } from './__testhelpers__/mock-error';
@@ -833,6 +834,23 @@ describe('LedgerDmkBridge', () => {
 
       await expect(bridge.getAppConfiguration()).rejects.toThrow(
         'Ledger command failed.',
+      );
+    });
+
+    it('resolves DMK connection errors by _tag', async () => {
+      mockSDK.sendCommand.mockResolvedValue({
+        status: 'error',
+        error: {
+          _tag: 'DeviceSessionNotFound',
+          message: 'Session expired',
+        },
+      });
+
+      const promise = bridge.getAppConfiguration();
+      await expect(promise).rejects.toThrow(HardwareWalletError);
+      await expect(promise).rejects.toHaveProperty(
+        'code',
+        ErrorCode.DeviceDisconnected,
       );
     });
   });

--- a/packages/keyring-eth-ledger-bridge/src/dmk/ledger-dmk-bridge.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/dmk/ledger-dmk-bridge.test.ts
@@ -148,8 +148,12 @@ describe('LedgerDmkBridge', () => {
     bridge = new LedgerDmkBridge({ transportFactory: mockTransportFactory });
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
+  afterEach(async () => {
+    // Cancel any pending session-monitoring retry timers before mocks are
+    // reset. With `resetMocks: true`, an orphaned retry would call
+    // `getDeviceSessionState()` after it returns `undefined`, crashing on `.pipe`.
+    await bridge.destroy();
+    jest.useRealTimers();
   });
 
   describe('constructor', () => {

--- a/packages/keyring-eth-ledger-bridge/src/dmk/ledger-dmk-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/dmk/ledger-dmk-bridge.ts
@@ -13,7 +13,7 @@ import type {
 } from '@ledgerhq/device-management-kit';
 import type { Signature } from '@ledgerhq/device-signer-kit-ethereum';
 import type Transport from '@ledgerhq/hw-transport';
-import { getDMKErrorFromTag } from '@metamask/hw-wallet-sdk';
+import { getDmkErrorFromTag } from '@metamask/hw-wallet-sdk';
 import type { Observable } from 'rxjs';
 import {
   concat,
@@ -33,7 +33,7 @@ import {
   switchMap,
 } from 'rxjs/operators';
 
-import { createDMKError } from '../errors';
+import { createDmkError } from '../errors';
 import {
   AppConfigurationResponse,
   GetAppNameAndVersionResponse,
@@ -482,9 +482,9 @@ export class LedgerDmkBridge implements LedgerBridge<LedgerDmkBridgeOptions> {
     // DMK connection/session errors identified by _tag (e.g.
     // DeviceSessionNotFound, DeviceLockedError) carry no hex APDU code.
     // Resolve them to a HardwareWalletError before falling through.
-    const tagResolution = getDMKErrorFromTag(error);
+    const tagResolution = getDmkErrorFromTag(error);
     if (tagResolution) {
-      return createDMKError(tagResolution.tag);
+      return createDmkError(tagResolution.tag);
     }
 
     if (isDeviceExchangeError(error)) {

--- a/packages/keyring-eth-ledger-bridge/src/dmk/ledger-dmk-bridge.ts
+++ b/packages/keyring-eth-ledger-bridge/src/dmk/ledger-dmk-bridge.ts
@@ -13,6 +13,7 @@ import type {
 } from '@ledgerhq/device-management-kit';
 import type { Signature } from '@ledgerhq/device-signer-kit-ethereum';
 import type Transport from '@ledgerhq/hw-transport';
+import { getDMKErrorFromTag } from '@metamask/hw-wallet-sdk';
 import type { Observable } from 'rxjs';
 import {
   concat,
@@ -32,6 +33,7 @@ import {
   switchMap,
 } from 'rxjs/operators';
 
+import { createDMKError } from '../errors';
 import {
   AppConfigurationResponse,
   GetAppNameAndVersionResponse,
@@ -477,6 +479,14 @@ export class LedgerDmkBridge implements LedgerBridge<LedgerDmkBridgeOptions> {
   }
 
   #toError(error: unknown): Error {
+    // DMK connection/session errors identified by _tag (e.g.
+    // DeviceSessionNotFound, DeviceLockedError) carry no hex APDU code.
+    // Resolve them to a HardwareWalletError before falling through.
+    const tagResolution = getDMKErrorFromTag(error);
+    if (tagResolution) {
+      return createDMKError(tagResolution.tag);
+    }
+
     if (isDeviceExchangeError(error)) {
       return translateDmkError(error);
     }

--- a/packages/keyring-eth-ledger-bridge/src/errors.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/errors.test.ts
@@ -4,6 +4,7 @@ import {
 } from '@metamask/hw-wallet-sdk';
 
 import {
+  createDMKError,
   createLedgerError,
   createKeyringStateError,
   isKnownLedgerError,
@@ -119,5 +120,68 @@ describe('createKeyringStateError', () => {
     expect(error).toBeInstanceOf(HardwareWalletError);
     expect(error.code).toBe(ErrorCodeEnum.Unknown);
     expect(error.message).toContain('Unknown Ledger keyring error');
+  });
+});
+
+describe('createDMKError', () => {
+  describe('known DMK tags', () => {
+    it('creates HardwareWalletError for DeviceSessionNotFound', () => {
+      const error = createDMKError('DeviceSessionNotFound');
+
+      expect(error).toBeInstanceOf(HardwareWalletError);
+      expect(error.code).toBe(ErrorCodeEnum.DeviceDisconnected);
+      expect(error.message).toBe('DMK device session not found');
+    });
+
+    it('creates HardwareWalletError for DeviceLockedError', () => {
+      const error = createDMKError('DeviceLockedError');
+
+      expect(error).toBeInstanceOf(HardwareWalletError);
+      expect(error.code).toBe(ErrorCodeEnum.AuthenticationDeviceLocked);
+    });
+
+    it('creates HardwareWalletError for ConnectionOpeningError', () => {
+      const error = createDMKError('ConnectionOpeningError');
+
+      expect(error).toBeInstanceOf(HardwareWalletError);
+      expect(error.code).toBe(ErrorCodeEnum.BluetoothConnectionFailed);
+    });
+
+    it('includes context in message when provided', () => {
+      const error = createDMKError(
+        'DeviceSessionNotFound',
+        'during signTransaction',
+      );
+
+      expect(error.message).toBe(
+        'DMK device session not found (during signTransaction)',
+      );
+    });
+
+    it('uses the mapping userMessage', () => {
+      const error = createDMKError('DeviceLockedError');
+
+      expect(error.userMessage).toBe(
+        'Please unlock your Ledger device to continue.',
+      );
+    });
+  });
+
+  describe('unknown DMK tags', () => {
+    it('creates fallback error for unknown tag without context', () => {
+      const error = createDMKError('SomeUnknownTag');
+
+      expect(error).toBeInstanceOf(HardwareWalletError);
+      expect(error.code).toBe(ErrorCodeEnum.Unknown);
+      expect(error.message).toBe('Unknown DMK error: SomeUnknownTag');
+    });
+
+    it('creates fallback error for unknown tag with context', () => {
+      const error = createDMKError('SomeUnknownTag', 'while connecting');
+
+      expect(error.message).toBe(
+        'Unknown DMK error: SomeUnknownTag (while connecting)',
+      );
+    });
   });
 });

--- a/packages/keyring-eth-ledger-bridge/src/errors.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/errors.test.ts
@@ -4,7 +4,7 @@ import {
 } from '@metamask/hw-wallet-sdk';
 
 import {
-  createDMKError,
+  createDmkError,
   createLedgerError,
   createKeyringStateError,
   isKnownLedgerError,
@@ -123,10 +123,10 @@ describe('createKeyringStateError', () => {
   });
 });
 
-describe('createDMKError', () => {
+describe('createDmkError', () => {
   describe('known DMK tags', () => {
     it('creates HardwareWalletError for DeviceSessionNotFound', () => {
-      const error = createDMKError('DeviceSessionNotFound');
+      const error = createDmkError('DeviceSessionNotFound');
 
       expect(error).toBeInstanceOf(HardwareWalletError);
       expect(error.code).toBe(ErrorCodeEnum.DeviceDisconnected);
@@ -134,21 +134,21 @@ describe('createDMKError', () => {
     });
 
     it('creates HardwareWalletError for DeviceLockedError', () => {
-      const error = createDMKError('DeviceLockedError');
+      const error = createDmkError('DeviceLockedError');
 
       expect(error).toBeInstanceOf(HardwareWalletError);
       expect(error.code).toBe(ErrorCodeEnum.AuthenticationDeviceLocked);
     });
 
     it('creates HardwareWalletError for ConnectionOpeningError', () => {
-      const error = createDMKError('ConnectionOpeningError');
+      const error = createDmkError('ConnectionOpeningError');
 
       expect(error).toBeInstanceOf(HardwareWalletError);
       expect(error.code).toBe(ErrorCodeEnum.BluetoothConnectionFailed);
     });
 
     it('includes context in message when provided', () => {
-      const error = createDMKError(
+      const error = createDmkError(
         'DeviceSessionNotFound',
         'during signTransaction',
       );
@@ -159,7 +159,7 @@ describe('createDMKError', () => {
     });
 
     it('uses the mapping userMessage', () => {
-      const error = createDMKError('DeviceLockedError');
+      const error = createDmkError('DeviceLockedError');
 
       expect(error.userMessage).toBe(
         'Please unlock your Ledger device to continue.',
@@ -169,7 +169,7 @@ describe('createDMKError', () => {
 
   describe('unknown DMK tags', () => {
     it('creates fallback error for unknown tag without context', () => {
-      const error = createDMKError('SomeUnknownTag');
+      const error = createDmkError('SomeUnknownTag');
 
       expect(error).toBeInstanceOf(HardwareWalletError);
       expect(error.code).toBe(ErrorCodeEnum.Unknown);
@@ -177,7 +177,7 @@ describe('createDMKError', () => {
     });
 
     it('creates fallback error for unknown tag with context', () => {
-      const error = createDMKError('SomeUnknownTag', 'while connecting');
+      const error = createDmkError('SomeUnknownTag', 'while connecting');
 
       expect(error.message).toBe(
         'Unknown DMK error: SomeUnknownTag (while connecting)',

--- a/packages/keyring-eth-ledger-bridge/src/errors.ts
+++ b/packages/keyring-eth-ledger-bridge/src/errors.ts
@@ -113,7 +113,7 @@ export function createKeyringStateError(code: ErrorCode): HardwareWalletError {
  * @returns A HardwareWalletError instance with mapped error details, or a
  * fallback error if the tag is not recognised.
  */
-export function createDMKError(
+export function createDmkError(
   tag: string,
   context?: string,
 ): HardwareWalletError {

--- a/packages/keyring-eth-ledger-bridge/src/errors.ts
+++ b/packages/keyring-eth-ledger-bridge/src/errors.ts
@@ -4,6 +4,7 @@ import {
   Severity,
   Category,
   HardwareWalletError,
+  DMK_ERROR_MAPPINGS,
   LEDGER_ERROR_MAPPINGS,
   KEYRING_ERROR_MAPPINGS,
 } from '@metamask/hw-wallet-sdk';
@@ -90,6 +91,51 @@ export function createKeyringStateError(code: ErrorCode): HardwareWalletError {
   }
 
   const fallbackMessage = `Unknown Ledger keyring error: ${code}`;
+
+  return new HardwareWalletError(fallbackMessage, {
+    code: ErrorCode.Unknown,
+    severity: Severity.Err,
+    category: Category.Unknown,
+    userMessage: fallbackMessage,
+  });
+}
+
+/**
+ * Factory function to create a HardwareWalletError from a DMK (Device
+ * Management Kit) error `_tag`.
+ *
+ * Looks up the tag in {@link DMK_ERROR_MAPPINGS} to resolve the full error
+ * details (code, message, severity, category, userMessage).
+ *
+ * @param tag - The DMK `_tag` string (e.g. `'DeviceSessionNotFound'`,
+ * `'DeviceLockedError'`).
+ * @param context - Optional additional context to append to the error message.
+ * @returns A HardwareWalletError instance with mapped error details, or a
+ * fallback error if the tag is not recognised.
+ */
+export function createDMKError(
+  tag: string,
+  context?: string,
+): HardwareWalletError {
+  const errorMapping = DMK_ERROR_MAPPINGS[tag];
+
+  if (errorMapping) {
+    const message = context
+      ? `${errorMapping.message} (${context})`
+      : errorMapping.message;
+
+    return new HardwareWalletError(message, {
+      code: errorMapping.code,
+      severity: errorMapping.severity,
+      category: errorMapping.category,
+      userMessage: errorMapping.userMessage ?? message,
+    });
+  }
+
+  // Fallback for unknown DMK tags
+  const fallbackMessage = context
+    ? `Unknown DMK error: ${tag} (${context})`
+    : `Unknown DMK error: ${tag}`;
 
   return new HardwareWalletError(fallbackMessage, {
     code: ErrorCode.Unknown,


### PR DESCRIPTION
This PR adds new dmk related errors to the @hw-wallet-sdk and used in the ledger keyring. 

<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Error handling on the Ledger DMK path changes for connection/session failures, which affects what users see and how callers branch on error codes; coverage is broad but misclassification could still slip through for unmapped tags.
> 
> **Overview**
> Ledger **Device Management Kit** failures that expose a `_tag` (e.g. `DeviceSessionNotFound`, `DeviceLockedError`) can now be turned into shared `HardwareWalletError` types instead of generic APDU/`TransportStatusError` wrappers.
> 
> **`@metamask/hw-wallet-sdk`** adds `DMK_ERROR_MAPPINGS` (full `ErrorMapping` + user messages), derived `DMK_ERROR_TAG_MAPPINGS`, message fallback patterns `DMK_MESSAGE_PATTERNS`, and `getDmkErrorFromTag`, all re-exported from the package entry.
> 
> **`keyring-eth-ledger-bridge`** adds `createDmkError` and wires tag resolution into `translateDmkError` (**`_tag` first**, then hex `DeviceExchangeError`, then `0x6f00` fallback) and `LedgerDmkBridge.#toError` so `sendCommand` / device-action failures get the right codes. The bridge depends on **`@metamask/hw-wallet-sdk` ^0.11.0**. Bridge tests call `destroy()` in `afterEach` to avoid flaky session-retry timers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c00eeee7574b4bc305028c007388b2137df367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->