### PR TITLE
feat(keyring-eth-hd)!: add `legacyEntropySource`

### DIFF
--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Rename (v2) `HdKeyring.entropySource` to `HdKeyring.legacyEntropySource` ([#602](https://github.com/MetaMask/accounts/pull/602))
+  - The (v2) `HdKeyring.entropySource` readonly property is now using the new `EntropyId` type.
+- Make (v2) `HdKeyring.legacyEntropySource` public ([#602](https://github.com/MetaMask/accounts/pull/602))
+  - The old (v2) `HdKeyring.entropySource` has now been moved into `HdKeyring.legacyEntropySource`.
+
 ## [14.1.2]
 
 ### Changed

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.test.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.test.ts
@@ -10,7 +10,8 @@ import { HdKeyring } from './hd-keyring';
 
 const TEST_MNEMONIC =
   'test test test test test test test test test test test junk';
-const TEST_ENTROPY_SOURCE_ID = 'test-entropy-source-id';
+const TEST_ENTROPY_SOURCE_ID =
+  'entropy:bip44:mnemonic:25bbc7e9-95f1-4198-95da-c6d1143da596';
 
 /**
  * Helper function to create a minimal KeyringRequest for testing.
@@ -90,6 +91,19 @@ describe('HdKeyring (v2 wrapper)', () => {
     it('exposes hdPath from the inner keyring', () => {
       expect(wrapper.hdPath).toBe(inner.hdPath);
       expect(wrapper.hdPath).toBe("m/44'/60'/0'/0");
+    });
+
+    it('returns undefined for legacyEntropySource when not provided', () => {
+      expect(wrapper.legacyEntropySource).toBeUndefined();
+    });
+
+    it('exposes legacyEntropySource when provided', () => {
+      const legacy = new HdKeyring({
+        legacyKeyring: inner,
+        entropySource: TEST_ENTROPY_SOURCE_ID,
+        legacyEntropySource: 'old-keyring-id',
+      });
+      expect(legacy.legacyEntropySource).toBe('old-keyring-id');
     });
 
     it('returns null for mnemonic/seed/root before deserialization', () => {

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.ts
@@ -5,7 +5,7 @@ import {
   EthScope,
   KeyringAccountEntropyTypeOption,
 } from '@metamask/keyring-api';
-import type { EntropyId } from '@metamask/keyring-sdk';
+import type { AsEntropyId } from '@metamask/keyring-sdk';
 import type { KeyringAccount } from '@metamask/keyring-api';
 import { KeyringType, PrivateKeyEncoding } from '@metamask/keyring-api/v2';
 import type {
@@ -53,7 +53,7 @@ const hdKeyringCapabilities: KeyringCapabilities = {
  * Entropy source ID for an HD (BIP-44 mnemonic) keyring, in the canonical
  * `entropy:bip44:mnemonic:<uuid>` format defined by the entropy fingerprint ADR.
  */
-export type HdEntropySourceId = `entropy:bip44:mnemonic:${string}`;
+export type Bip44MnemonicEntropyId = AsEntropyId<`entropy:bip44:mnemonic:${string}`>;
 
 /**
  * Entropy source ID used before fingerprint-based IDs were introduced.
@@ -69,7 +69,7 @@ export type LegacyEntropySourceId = string;
  */
 export type HdKeyringOptions = {
   legacyKeyring: LegacyHdKeyring;
-  entropySource: EntropyId;
+  entropySource: Bip44MnemonicEntropyId;
   /**
    * The keyring ID used before fingerprint-based entropy IDs were introduced.
    * Present only during the migration period; omit for newly created keyrings.
@@ -81,7 +81,7 @@ export class HdKeyring
   extends EthKeyringWrapper<LegacyHdKeyring, Bip44Account<KeyringAccount>>
   implements Keyring
 {
-  readonly entropySource: HdEntropySourceId;
+  readonly entropySource: Bip44MnemonicEntropyId;
 
   readonly legacyEntropySource: LegacyEntropySourceId | undefined;
 

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.ts
@@ -5,7 +5,6 @@ import {
   EthScope,
   KeyringAccountEntropyTypeOption,
 } from '@metamask/keyring-api';
-import type { AsEntropyId } from '@metamask/keyring-sdk';
 import type { KeyringAccount } from '@metamask/keyring-api';
 import { KeyringType, PrivateKeyEncoding } from '@metamask/keyring-api/v2';
 import type {
@@ -15,6 +14,7 @@ import type {
   KeyringCapabilities,
   Keyring,
 } from '@metamask/keyring-api/v2';
+import type { AsEntropyId } from '@metamask/keyring-sdk';
 import { EthKeyringMethod, EthKeyringWrapper } from '@metamask/keyring-sdk/v2';
 import type { AccountId } from '@metamask/keyring-utils';
 import { add0x } from '@metamask/utils';
@@ -53,7 +53,8 @@ const hdKeyringCapabilities: KeyringCapabilities = {
  * Entropy source ID for an HD (BIP-44 mnemonic) keyring, in the canonical
  * `entropy:bip44:mnemonic:<uuid>` format defined by the entropy fingerprint ADR.
  */
-export type Bip44MnemonicEntropyId = AsEntropyId<`entropy:bip44:mnemonic:${string}`>;
+export type Bip44MnemonicEntropyId =
+  AsEntropyId<`entropy:bip44:mnemonic:${string}`>;
 
 /**
  * Entropy source ID used before fingerprint-based IDs were introduced.

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.ts
@@ -5,7 +5,8 @@ import {
   EthScope,
   KeyringAccountEntropyTypeOption,
 } from '@metamask/keyring-api';
-import type { KeyringAccount, EntropySourceId } from '@metamask/keyring-api';
+import type { EntropyId } from '@metamask/keyring-sdk';
+import type { KeyringAccount } from '@metamask/keyring-api';
 import { KeyringType, PrivateKeyEncoding } from '@metamask/keyring-api/v2';
 import type {
   CreateAccountOptions,
@@ -49,6 +50,18 @@ const hdKeyringCapabilities: KeyringCapabilities = {
 };
 
 /**
+ * Entropy source ID for an HD (BIP-44 mnemonic) keyring, in the canonical
+ * `entropy:bip44:mnemonic:<uuid>` format defined by the entropy fingerprint ADR.
+ */
+export type HdEntropySourceId = `entropy:bip44:mnemonic:${string}`;
+
+/**
+ * Entropy source ID used before fingerprint-based IDs were introduced.
+ * Corresponds to the legacy keyring ID stored by `KeyringController`.
+ */
+export type LegacyEntropySourceId = string;
+
+/**
  * Concrete {@link Keyring} adapter for {@link HdKeyring}.
  *
  * This wrapper exposes the accounts and signing capabilities of the legacy
@@ -56,14 +69,21 @@ const hdKeyringCapabilities: KeyringCapabilities = {
  */
 export type HdKeyringOptions = {
   legacyKeyring: LegacyHdKeyring;
-  entropySource: EntropySourceId;
+  entropySource: EntropyId;
+  /**
+   * The keyring ID used before fingerprint-based entropy IDs were introduced.
+   * Present only during the migration period; omit for newly created keyrings.
+   */
+  legacyEntropySource?: LegacyEntropySourceId;
 };
 
 export class HdKeyring
   extends EthKeyringWrapper<LegacyHdKeyring, Bip44Account<KeyringAccount>>
   implements Keyring
 {
-  protected readonly entropySource: EntropySourceId;
+  readonly entropySource: HdEntropySourceId;
+
+  readonly legacyEntropySource: LegacyEntropySourceId | undefined;
 
   constructor(options: HdKeyringOptions) {
     super({
@@ -72,6 +92,7 @@ export class HdKeyring
       capabilities: hdKeyringCapabilities,
     });
     this.entropySource = options.entropySource;
+    this.legacyEntropySource = options.legacyEntropySource;
   }
 
   /**

--- a/packages/keyring-eth-hd/src/v2/index.ts
+++ b/packages/keyring-eth-hd/src/v2/index.ts
@@ -1,1 +1,6 @@
-export { HdKeyring, type HdKeyringOptions } from './hd-keyring';
+export {
+  HdKeyring,
+  type HdKeyringOptions,
+  type HdEntropySourceId,
+  type LegacyEntropySourceId,
+} from './hd-keyring';

--- a/packages/keyring-eth-hd/src/v2/index.ts
+++ b/packages/keyring-eth-hd/src/v2/index.ts
@@ -1,6 +1,4 @@
 export {
   HdKeyring,
   type HdKeyringOptions,
-  type HdEntropySourceId,
-  type LegacyEntropySourceId,
 } from './hd-keyring';

--- a/packages/keyring-eth-hd/src/v2/index.ts
+++ b/packages/keyring-eth-hd/src/v2/index.ts
@@ -1,4 +1,1 @@
-export {
-  HdKeyring,
-  type HdKeyringOptions,
-} from './hd-keyring';
+export { HdKeyring, type HdKeyringOptions } from './hd-keyring';

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new entropy support ([#603](https://github.com/MetaMask/accounts/pull/603))
+
 ## [2.3.0]
 
 ### Added

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add new entropy support ([#603](https://github.com/MetaMask/accounts/pull/603))
+- Add `AsEntropyId` type helper ([#602](https://github.com/MetaMask/accounts/pull/602))
 
 ## [2.3.0]
 

--- a/packages/keyring-sdk/package.json
+++ b/packages/keyring-sdk/package.json
@@ -73,6 +73,7 @@
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",
+    "@noble/hashes": "^1.8.0",
     "async-mutex": "^0.5.0",
     "ethereum-cryptography": "^2.2.1",
     "uuid": "^9.0.1"

--- a/packages/keyring-sdk/src/entropy.test.ts
+++ b/packages/keyring-sdk/src/entropy.test.ts
@@ -1,0 +1,100 @@
+import { fingerprint, toEntropyFingerprint, toEntropyId } from './entropy';
+
+const SECRET = new Uint8Array(32).fill(1);
+
+describe('fingerprint', () => {
+  it('returns a valid UUID v4 string', async () => {
+    const fp = await fingerprint(SECRET);
+    expect(fp).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+  });
+
+  it('is deterministic — same input always produces the same fingerprint', async () => {
+    const first = await fingerprint(SECRET);
+    const second = await fingerprint(SECRET);
+    expect(first).toBe(second);
+  });
+
+  it('produces different fingerprints for different secrets', async () => {
+    const otherSecret = new Uint8Array(32).fill(2);
+    const first = await fingerprint(SECRET);
+    const second = await fingerprint(otherSecret);
+    expect(first).not.toBe(second);
+  });
+
+  it('matches a known value to guard against accidental algorithm changes', async () => {
+    // uuid({ random: HMAC-SHA256( key=Uint8Array(32).fill(1), msg='metamask:fingerprint' ).slice(0, 16) })
+    const fp = await fingerprint(SECRET);
+    expect(fp).toBe('29b22736-01c7-4096-9ae5-9f735d55b5a2');
+  });
+});
+
+describe('toEntropyFingerprint', () => {
+  it('returns a 64-character lowercase hex string', async () => {
+    const fp = await toEntropyFingerprint(SECRET);
+    expect(fp).toHaveLength(64);
+    expect(fp).toMatch(/^[0-9a-f]+$/u);
+  });
+
+  it('is deterministic — same input always produces the same fingerprint', async () => {
+    const first = await toEntropyFingerprint(SECRET);
+    const second = await toEntropyFingerprint(SECRET);
+    expect(first).toBe(second);
+  });
+
+  it('produces different fingerprints for different secrets', async () => {
+    const otherSecret = new Uint8Array(32).fill(2);
+    const first = await toEntropyFingerprint(SECRET);
+    const second = await toEntropyFingerprint(otherSecret);
+    expect(first).not.toBe(second);
+  });
+
+  it('matches a known value to guard against accidental algorithm changes', async () => {
+    // hex( HMAC-SHA256( key=Uint8Array(32).fill(1), msg='metamask:fingerprint' ) )
+    const fp = await toEntropyFingerprint(SECRET);
+    expect(fp).toBe(
+      '29b2273601c75096dae59f735d55b5a24384e06ff17496130d059b1bd5915560',
+    );
+  });
+});
+
+describe('toEntropyId', () => {
+  it('returns the full entropy:category:implementation:uuid format', async () => {
+    const id = await toEntropyId('bip44', 'mnemonic', SECRET);
+    expect(id).toMatch(
+      /^entropy:bip44:mnemonic:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+  });
+
+  it('is deterministic — same inputs always produce the same ID', async () => {
+    const first = await toEntropyId('bip44', 'mnemonic', SECRET);
+    const second = await toEntropyId('bip44', 'mnemonic', SECRET);
+    expect(first).toBe(second);
+  });
+
+  it('produces different IDs for different secrets', async () => {
+    const otherSecret = new Uint8Array(32).fill(2);
+    const first = await toEntropyId('bip44', 'mnemonic', SECRET);
+    const second = await toEntropyId('bip44', 'mnemonic', otherSecret);
+    expect(first).not.toBe(second);
+  });
+
+  it('produces different IDs for different category:implementation combinations', async () => {
+    const mnemonicId = await toEntropyId('bip44', 'mnemonic', SECRET);
+    const privateKeyId = await toEntropyId('raw', 'private-key', SECRET);
+    expect(mnemonicId).not.toBe(privateKeyId);
+  });
+
+  it("uses '_' as the UUID segment when no material is provided (hardware wallets)", async () => {
+    const id = await toEntropyId('bip44', 'ledger');
+    expect(id).toBe('entropy:bip44:ledger:_');
+  });
+
+  it('matches a known value to guard against accidental algorithm changes', async () => {
+    const id = await toEntropyId('bip44', 'mnemonic', SECRET);
+    expect(id).toBe(
+      'entropy:bip44:mnemonic:29b22736-01c7-4096-9ae5-9f735d55b5a2',
+    );
+  });
+});

--- a/packages/keyring-sdk/src/entropy.ts
+++ b/packages/keyring-sdk/src/entropy.ts
@@ -1,0 +1,115 @@
+import { hmac } from '@noble/hashes/hmac';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+import { v4 as uuid } from 'uuid';
+
+/**
+ * The category of an entropy source.
+ *
+ * - `'bip44'` — Entropy that uses BIP-44 to derive signers (e.g. SRP, hardware
+ *   wallets).
+ * - `'raw'` — Entropy that exposes a single key directly, without derivation
+ *   (e.g. imported private keys, MPC).
+ */
+export type EntropyCategory = 'bip44' | 'raw';
+
+/**
+ * The implementation of an entropy source within its category.
+ */
+export type EntropyImplementation =
+  | 'mnemonic'
+  | 'ledger'
+  | 'trezor'
+  | 'private-key'
+  | 'mpc';
+
+/**
+ * The type of an entropy source, expressed as `category:implementation`.
+ *
+ * @example `'bip44:mnemonic'`, `'bip44:ledger'`, `'raw:private-key'`, `'raw:mpc'`
+ */
+export type EntropyType = `${EntropyCategory}:${EntropyImplementation}`;
+
+/**
+ * Unique identifier for an entropy source.
+ *
+ * Format: `entropy:{category}:{implementation}:{uuid}` where the UUID is a
+ * deterministic fingerprint of the underlying secret, or `'_'` for hardware
+ * wallets whose secret never leaves the device.
+ */
+export type EntropyId =
+  `entropy:${EntropyCategory}:${EntropyImplementation}:${string}`;
+
+/**
+ * Represents a source of entropy.
+ */
+export type Entropy = {
+  /**
+   * The unique identifier for this entropy source.
+   */
+  id: EntropyId;
+
+  /**
+   * The type of this entropy source.
+   */
+  type: EntropyType;
+};
+
+/**
+ * Computes a deterministic, non-reversible fingerprint for a piece of entropy.
+ *
+ * The fingerprint is a UUID v4 seeded from the first 16 bytes of
+ * `HMAC-SHA256(key=material, msg='metamask:fingerprint')`.
+ *
+ * `@noble/hashes` is synchronous today, but the async signature is kept as a
+ * forward-compatible seam: a future migration to the Web Crypto API (or any
+ * other async primitive) won't require changes at every call site.
+ *
+ * @param material - The raw entropy bytes (e.g. BIP-39 mnemonic bytes).
+ * @returns A deterministic UUID v4 string that uniquely identifies the entropy
+ * without exposing it.
+ */
+export async function fingerprint(material: Uint8Array): Promise<string> {
+  const message = new TextEncoder().encode('metamask:fingerprint');
+  const digest = hmac(sha256, material, message);
+  return uuid({ random: digest.slice(0, 16) });
+}
+
+/**
+ * Computes a deterministic, non-reversible hex fingerprint for a piece of
+ * entropy. Suitable for comparison and auditing.
+ *
+ * @param material - The raw entropy bytes.
+ * @returns The lowercase hex-encoded 32-byte HMAC-SHA256 digest.
+ */
+export async function toEntropyFingerprint(
+  material: Uint8Array,
+): Promise<string> {
+  const message = new TextEncoder().encode('metamask:fingerprint');
+  const digest = hmac(sha256, material, message);
+  return bytesToHex(digest);
+}
+
+/**
+ * Computes a stable {@link EntropyId} for an entropy source.
+ *
+ * The ID is formatted as `entropy:{category}:{implementation}:{uuid}`, where
+ * the UUID segment is the {@link fingerprint} of `material` when provided, or
+ * `'_'` for entropy sources whose secret never leaves the device (e.g. hardware
+ * wallets).
+ *
+ * @param category - The entropy category (e.g. `'bip44'`, `'raw'`).
+ * @param implementation - The entropy implementation (e.g. `'mnemonic'`,
+ * `'ledger'`, `'private-key'`).
+ * @param material - The raw entropy bytes. Omit for hardware wallets or any
+ * entropy source where the secret is not directly accessible.
+ * @returns A stable {@link EntropyId} string.
+ */
+export async function toEntropyId(
+  category: EntropyCategory,
+  implementation: EntropyImplementation,
+  material?: Uint8Array,
+): Promise<EntropyId> {
+  const uuidSegment = material ? await fingerprint(material) : '_';
+  return `entropy:${category}:${implementation}:${uuidSegment}`;
+}

--- a/packages/keyring-sdk/src/entropy.ts
+++ b/packages/keyring-sdk/src/entropy.ts
@@ -65,7 +65,7 @@ export type Entropy = {
  * @example
  * type Bip44MnemonicEntropyId = AsEntropyId<`entropy:bip44:mnemonic:${string}`>;
  */
-export type AsEntropyId<T extends string> = T & EntropyId;
+export type AsEntropyId<TEntropyId extends string> = TEntropyId & EntropyId;
 
 /**
  * Computes a deterministic, non-reversible fingerprint for a piece of entropy.

--- a/packages/keyring-sdk/src/entropy.ts
+++ b/packages/keyring-sdk/src/entropy.ts
@@ -56,6 +56,18 @@ export type Entropy = {
 };
 
 /**
+ * Narrows a string type to a valid {@link EntropyId}.
+ *
+ * Resolves to `T & EntropyId` when `T` is structurally compatible with
+ * {@link EntropyId}, and collapses to `never` otherwise — surfacing
+ * incompatibilities at compile time.
+ *
+ * @example
+ * type Bip44MnemonicEntropyId = AsEntropyId<`entropy:bip44:mnemonic:${string}`>;
+ */
+export type AsEntropyId<T extends string> = T & EntropyId;
+
+/**
  * Computes a deterministic, non-reversible fingerprint for a piece of entropy.
  *
  * The fingerprint is a UUID v4 seeded from the first 16 bytes of

--- a/packages/keyring-sdk/src/index.ts
+++ b/packages/keyring-sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from './keyring-account-registry';
 export * from './migration';
 export * from './mnemonic';
+export * from './entropy';
 export * from './eth';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2349,6 +2349,7 @@ __metadata:
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
+    "@noble/hashes": "npm:^1.8.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"


### PR DESCRIPTION
Introducing the new entropy source ID to the v2 `HdKeyring`.

This will allow us to use it in combination with `:withKeyringV2` to filter out HD keyrings with their new deterministic entropy source.

This way we can have mapping between both:
```ts
const entropySource = this.messenger.call('KeyringController:withKeyringV2', {
  filter: ({ keyring }) =>
    isHdKeyring(keyring) && keyring.legacyEntropySource === legacyEntropySource,
  ({ keyring }) => keyring.entropySource
);

// OR:
const legacyEntropySource = this.messenger.call('KeyringController:withKeyringV2', {
  filter: ({ keyring }) =>
    isHdKeyring(keyring) && keyring.entropySource === entropySource,
  ({ keyring }) => keyring.legacyEntropySource
);
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking rename/repurpose of `entropySource` affects consumers that assumed the legacy keyring id; migration depends on correctly populating `legacyEntropySource`.
> 
> **Overview**
> **Breaking change** to v2 `HdKeyring` entropy identifiers: public `entropySource` is now the canonical fingerprint `entropy:bip44:mnemonic:<uuid>` (`Bip44MnemonicEntropyId`), and the previous `KeyringController` keyring id moves to optional public **`legacyEntropySource`** on `HdKeyringOptions` for migration-era bidirectional lookup via `withKeyringV2`.
> 
> `@metamask/keyring-sdk` adds **`AsEntropyId`** to narrow string template types to `EntropyId` at compile time; tests use a real canonical entropy id and cover `legacyEntropySource` when set vs omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8504e526797be3ecb6838a14f62a1a3bb1300cd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->