### PR TITLE
feat(keyring-sdk): add new entropy support

### DIFF
--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `HdKeyring.toEntropySourceId` (v2) ([#604](https://github.com/MetaMask/accounts/pull/603))
+  - This can be used to compute a stable/deterministic ID for the keyring's seed.
+
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.6.0` to `^23.7.0` ([#604](https://github.com/MetaMask/accounts/pull/604))

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `HdKeyring.toEntropySourceId` (v2) ([#604](https://github.com/MetaMask/accounts/pull/603))
+- Add `HdKeyring.toEntropySourceId` (v2) ([#603](https://github.com/MetaMask/accounts/pull/603))
   - This can be used to compute a stable/deterministic ID for the keyring's seed.
 
 ### Changed

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.test.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.test.ts
@@ -2,10 +2,9 @@ import type { TypedTxData } from '@ethereumjs/tx';
 import { EthAccountType, EthMethod, EthScope } from '@metamask/keyring-api';
 import type { KeyringAccount, KeyringRequest } from '@metamask/keyring-api';
 import { KeyringType, PrivateKeyEncoding } from '@metamask/keyring-api/v2';
+import { toEntropySourceId } from '@metamask/keyring-sdk';
 import type { AccountId } from '@metamask/keyring-utils';
 import type { Json } from '@metamask/utils';
-
-import { toEntropySourceId } from '@metamask/keyring-sdk';
 
 import { HdKeyring as LegacyHdKeyring } from '../hd-keyring';
 import { HdKeyring } from './hd-keyring';

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.test.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.test.ts
@@ -5,6 +5,8 @@ import { KeyringType, PrivateKeyEncoding } from '@metamask/keyring-api/v2';
 import type { AccountId } from '@metamask/keyring-utils';
 import type { Json } from '@metamask/utils';
 
+import { toEntropySourceId } from '@metamask/keyring-sdk';
+
 import { HdKeyring as LegacyHdKeyring } from '../hd-keyring';
 import { HdKeyring } from './hd-keyring';
 
@@ -1082,6 +1084,67 @@ describe('HdKeyring (v2 wrapper)', () => {
           `Account ${accountId} cannot handle method: eth_sendTransaction`,
         );
       });
+    });
+  });
+
+  describe('toEntropySourceId', () => {
+    it('returns a valid EntropySourceId', async () => {
+      const id = await wrapper.toEntropySourceId();
+      expect(id).toMatch(/^entropy:mnemonic:[0-9a-f-]{36}$/u);
+    });
+
+    it('is deterministic for the same mnemonic', async () => {
+      const inner2 = new LegacyHdKeyring();
+      await inner2.deserialize({
+        mnemonic: Array.from(Buffer.from(TEST_MNEMONIC, 'utf8')),
+        numberOfAccounts: 0,
+        hdPath: "m/44'/60'/0'/0",
+      });
+      const wrapper2 = new HdKeyring({
+        legacyKeyring: inner2,
+        entropySource: TEST_ENTROPY_SOURCE_ID,
+      });
+
+      expect(await wrapper.toEntropySourceId()).toBe(
+        await wrapper2.toEntropySourceId(),
+      );
+    });
+
+    it('produces different IDs for different mnemonics', async () => {
+      const otherMnemonic =
+        'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+      const otherInner = new LegacyHdKeyring();
+      await otherInner.deserialize({
+        mnemonic: Array.from(Buffer.from(otherMnemonic, 'utf8')),
+        numberOfAccounts: 0,
+        hdPath: "m/44'/60'/0'/0",
+      });
+      const otherWrapper = new HdKeyring({
+        legacyKeyring: otherInner,
+        entropySource: TEST_ENTROPY_SOURCE_ID,
+      });
+
+      expect(await wrapper.toEntropySourceId()).not.toBe(
+        await otherWrapper.toEntropySourceId(),
+      );
+    });
+
+    it('matches the result of the keyring-sdk toEntropySourceId helper', async () => {
+      const seed = wrapper.seed as Uint8Array;
+      const expected = await toEntropySourceId('mnemonic', seed);
+      expect(await wrapper.toEntropySourceId()).toBe(expected);
+    });
+
+    it('throws if the keyring is not initialized', async () => {
+      const uninitializedInner = new LegacyHdKeyring();
+      const uninitializedWrapper = new HdKeyring({
+        legacyKeyring: uninitializedInner,
+        entropySource: TEST_ENTROPY_SOURCE_ID,
+      });
+
+      await expect(uninitializedWrapper.toEntropySourceId()).rejects.toThrow(
+        'Cannot compute entropy source ID: keyring is not initialized (seed unavailable).',
+      );
     });
   });
 });

--- a/packages/keyring-eth-hd/src/v2/hd-keyring.ts
+++ b/packages/keyring-eth-hd/src/v2/hd-keyring.ts
@@ -14,6 +14,7 @@ import type {
   KeyringCapabilities,
   Keyring,
 } from '@metamask/keyring-api/v2';
+import { toEntropySourceId as computeEntropySourceId } from '@metamask/keyring-sdk';
 import { EthKeyringMethod, EthKeyringWrapper } from '@metamask/keyring-sdk/v2';
 import type { AccountId } from '@metamask/keyring-utils';
 import { add0x } from '@metamask/utils';
@@ -107,6 +108,22 @@ export class HdKeyring
    */
   get hdPath(): LegacyHdKeyring['hdPath'] {
     return this.inner.hdPath;
+  }
+
+  /**
+   * Computes a stable {@link EntropySourceId} from this keyring's seed.
+   *
+   * @throws If the keyring has not been initialized (seed unavailable).
+   * @returns A deterministic `EntropySourceId` of the form `entropy:mnemonic:{uuid}`.
+   */
+  async toEntropySourceId(): Promise<EntropySourceId> {
+    const { seed } = this;
+    if (!seed) {
+      throw new Error(
+        'Cannot compute entropy source ID: keyring is not initialized (seed unavailable).',
+      );
+    }
+    return computeEntropySourceId('mnemonic', seed);
   }
 
   /**

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new entropy support ([#603](https://github.com/MetaMask/accounts/pull/603))
+
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.6.0` to `^23.7.0` ([#604](https://github.com/MetaMask/accounts/pull/604))

--- a/packages/keyring-sdk/package.json
+++ b/packages/keyring-sdk/package.json
@@ -73,6 +73,7 @@
     "@metamask/scure-bip39": "^2.1.1",
     "@metamask/superstruct": "^3.4.1",
     "@metamask/utils": "^11.11.0",
+    "@noble/hashes": "^1.8.0",
     "async-mutex": "^0.5.0",
     "ethereum-cryptography": "^2.2.1",
     "uuid": "^9.0.1"

--- a/packages/keyring-sdk/src/entropy.test.ts
+++ b/packages/keyring-sdk/src/entropy.test.ts
@@ -1,0 +1,100 @@
+import { fingerprint, toEntropyFingerprint, toEntropyId } from './entropy';
+
+const SECRET = new Uint8Array(32).fill(1);
+
+describe('fingerprint', () => {
+  it('returns a valid UUID v4 string', async () => {
+    const fp = await fingerprint(SECRET);
+    expect(fp).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+  });
+
+  it('is deterministic — same input always produces the same fingerprint', async () => {
+    const first = await fingerprint(SECRET);
+    const second = await fingerprint(SECRET);
+    expect(first).toBe(second);
+  });
+
+  it('produces different fingerprints for different secrets', async () => {
+    const otherSecret = new Uint8Array(32).fill(2);
+    const first = await fingerprint(SECRET);
+    const second = await fingerprint(otherSecret);
+    expect(first).not.toBe(second);
+  });
+
+  it('matches a known value to guard against accidental algorithm changes', async () => {
+    // uuid({ random: HMAC-SHA256( key=Uint8Array(32).fill(1), msg='metamask:fingerprint' ).slice(0, 16) })
+    const fp = await fingerprint(SECRET);
+    expect(fp).toBe('29b22736-01c7-4096-9ae5-9f735d55b5a2');
+  });
+});
+
+describe('toEntropyFingerprint', () => {
+  it('returns a 64-character lowercase hex string', async () => {
+    const fp = await toEntropyFingerprint(SECRET);
+    expect(fp).toHaveLength(64);
+    expect(fp).toMatch(/^[0-9a-f]+$/u);
+  });
+
+  it('is deterministic — same input always produces the same fingerprint', async () => {
+    const first = await toEntropyFingerprint(SECRET);
+    const second = await toEntropyFingerprint(SECRET);
+    expect(first).toBe(second);
+  });
+
+  it('produces different fingerprints for different secrets', async () => {
+    const otherSecret = new Uint8Array(32).fill(2);
+    const first = await toEntropyFingerprint(SECRET);
+    const second = await toEntropyFingerprint(otherSecret);
+    expect(first).not.toBe(second);
+  });
+
+  it('matches a known value to guard against accidental algorithm changes', async () => {
+    // hex( HMAC-SHA256( key=Uint8Array(32).fill(1), msg='metamask:fingerprint' ) )
+    const fp = await toEntropyFingerprint(SECRET);
+    expect(fp).toBe(
+      '29b2273601c75096dae59f735d55b5a24384e06ff17496130d059b1bd5915560',
+    );
+  });
+});
+
+describe('toEntropyId', () => {
+  it('returns the full entropy:category:implementation:uuid format', async () => {
+    const id = await toEntropyId('bip44', 'mnemonic', SECRET);
+    expect(id).toMatch(
+      /^entropy:bip44:mnemonic:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+    );
+  });
+
+  it('is deterministic — same inputs always produce the same ID', async () => {
+    const first = await toEntropyId('bip44', 'mnemonic', SECRET);
+    const second = await toEntropyId('bip44', 'mnemonic', SECRET);
+    expect(first).toBe(second);
+  });
+
+  it('produces different IDs for different secrets', async () => {
+    const otherSecret = new Uint8Array(32).fill(2);
+    const first = await toEntropyId('bip44', 'mnemonic', SECRET);
+    const second = await toEntropyId('bip44', 'mnemonic', otherSecret);
+    expect(first).not.toBe(second);
+  });
+
+  it('produces different IDs for different category:implementation combinations', async () => {
+    const mnemonicId = await toEntropyId('bip44', 'mnemonic', SECRET);
+    const privateKeyId = await toEntropyId('raw', 'private-key', SECRET);
+    expect(mnemonicId).not.toBe(privateKeyId);
+  });
+
+  it("uses '_' as the UUID segment when no material is provided (hardware wallets)", async () => {
+    const id = await toEntropyId('bip44', 'ledger');
+    expect(id).toBe('entropy:bip44:ledger:_');
+  });
+
+  it('matches a known value to guard against accidental algorithm changes', async () => {
+    const id = await toEntropyId('bip44', 'mnemonic', SECRET);
+    expect(id).toBe(
+      'entropy:bip44:mnemonic:29b22736-01c7-4096-9ae5-9f735d55b5a2',
+    );
+  });
+});

--- a/packages/keyring-sdk/src/entropy.test.ts
+++ b/packages/keyring-sdk/src/entropy.test.ts
@@ -1,4 +1,4 @@
-import { fingerprint, toEntropyFingerprint, toEntropyId } from './entropy';
+import { fingerprint, toEntropySourceId } from './entropy';
 
 const SECRET = new Uint8Array(32).fill(1);
 
@@ -30,71 +30,42 @@ describe('fingerprint', () => {
   });
 });
 
-describe('toEntropyFingerprint', () => {
-  it('returns a 64-character lowercase hex string', async () => {
-    const fp = await toEntropyFingerprint(SECRET);
-    expect(fp).toHaveLength(64);
-    expect(fp).toMatch(/^[0-9a-f]+$/u);
-  });
-
-  it('is deterministic — same input always produces the same fingerprint', async () => {
-    const first = await toEntropyFingerprint(SECRET);
-    const second = await toEntropyFingerprint(SECRET);
-    expect(first).toBe(second);
-  });
-
-  it('produces different fingerprints for different secrets', async () => {
-    const otherSecret = new Uint8Array(32).fill(2);
-    const first = await toEntropyFingerprint(SECRET);
-    const second = await toEntropyFingerprint(otherSecret);
-    expect(first).not.toBe(second);
-  });
-
-  it('matches a known value to guard against accidental algorithm changes', async () => {
-    // hex( HMAC-SHA256( key=Uint8Array(32).fill(1), msg='metamask:fingerprint' ) )
-    const fp = await toEntropyFingerprint(SECRET);
-    expect(fp).toBe(
-      '29b2273601c75096dae59f735d55b5a24384e06ff17496130d059b1bd5915560',
-    );
-  });
-});
-
-describe('toEntropyId', () => {
-  it('returns the full entropy:category:implementation:uuid format', async () => {
-    const id = await toEntropyId('bip44', 'mnemonic', SECRET);
+describe('toEntropySourceId', () => {
+  it('returns the full entropy:type:uuid format', async () => {
+    const id = await toEntropySourceId('mnemonic', SECRET);
     expect(id).toMatch(
-      /^entropy:bip44:mnemonic:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
+      /^entropy:mnemonic:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u,
     );
   });
 
   it('is deterministic — same inputs always produce the same ID', async () => {
-    const first = await toEntropyId('bip44', 'mnemonic', SECRET);
-    const second = await toEntropyId('bip44', 'mnemonic', SECRET);
+    const first = await toEntropySourceId('mnemonic', SECRET);
+    const second = await toEntropySourceId('mnemonic', SECRET);
     expect(first).toBe(second);
   });
 
   it('produces different IDs for different secrets', async () => {
     const otherSecret = new Uint8Array(32).fill(2);
-    const first = await toEntropyId('bip44', 'mnemonic', SECRET);
-    const second = await toEntropyId('bip44', 'mnemonic', otherSecret);
+    const first = await toEntropySourceId('mnemonic', SECRET);
+    const second = await toEntropySourceId('mnemonic', otherSecret);
     expect(first).not.toBe(second);
   });
 
   it('produces different IDs for different category:implementation combinations', async () => {
-    const mnemonicId = await toEntropyId('bip44', 'mnemonic', SECRET);
-    const privateKeyId = await toEntropyId('raw', 'private-key', SECRET);
+    const mnemonicId = await toEntropySourceId('mnemonic', SECRET);
+    const privateKeyId = await toEntropySourceId('private-key', SECRET);
     expect(mnemonicId).not.toBe(privateKeyId);
   });
 
   it("uses '_' as the UUID segment when no material is provided (hardware wallets)", async () => {
-    const id = await toEntropyId('bip44', 'ledger');
-    expect(id).toBe('entropy:bip44:ledger:_');
+    const id = await toEntropySourceId('ledger');
+    expect(id).toBe('entropy:ledger:_');
   });
 
   it('matches a known value to guard against accidental algorithm changes', async () => {
-    const id = await toEntropyId('bip44', 'mnemonic', SECRET);
+    const id = await toEntropySourceId('mnemonic', SECRET);
     expect(id).toBe(
-      'entropy:bip44:mnemonic:29b22736-01c7-4096-9ae5-9f735d55b5a2',
+      'entropy:mnemonic:29b22736-01c7-4096-9ae5-9f735d55b5a2',
     );
   });
 });

--- a/packages/keyring-sdk/src/entropy.test.ts
+++ b/packages/keyring-sdk/src/entropy.test.ts
@@ -64,8 +64,6 @@ describe('toEntropySourceId', () => {
 
   it('matches a known value to guard against accidental algorithm changes', async () => {
     const id = await toEntropySourceId('mnemonic', SECRET);
-    expect(id).toBe(
-      'entropy:mnemonic:29b22736-01c7-4096-9ae5-9f735d55b5a2',
-    );
+    expect(id).toBe('entropy:mnemonic:29b22736-01c7-4096-9ae5-9f735d55b5a2');
   });
 });

--- a/packages/keyring-sdk/src/entropy.ts
+++ b/packages/keyring-sdk/src/entropy.ts
@@ -9,6 +9,7 @@ export type EntropySourceType =
   | 'mnemonic'
   | 'ledger'
   | 'trezor'
+  | 'qr'
   | 'private-key'
   | 'mpc';
 

--- a/packages/keyring-sdk/src/entropy.ts
+++ b/packages/keyring-sdk/src/entropy.ts
@@ -19,8 +19,7 @@ export type EntropySourceType =
  * deterministic fingerprint of the underlying secret, or `'_'` for entropies
  * that cannot be uniquely identified.
  */
-export type EntropySourceId =
-  `entropy:${EntropySourceType}:${string}`;
+export type EntropySourceId = `entropy:${EntropySourceType}:${string}`;
 
 /**
  * Computes a deterministic, non-reversible fingerprint for a piece of entropy.

--- a/packages/keyring-sdk/src/entropy.ts
+++ b/packages/keyring-sdk/src/entropy.ts
@@ -27,16 +27,15 @@ export type EntropySourceId = `entropy:${EntropySourceType}:${string}`;
  * The fingerprint is a UUID v4 seeded from the first 16 bytes of
  * `HMAC-SHA256(key=material, msg='metamask:fingerprint')`.
  *
- * `@noble/hashes` is synchronous today, but the async signature is kept as a
- * forward-compatible seam: a future migration to the Web Crypto API (or any
- * other async primitive) won't require changes at every call site.
- *
  * @param material - The raw entropy bytes (e.g. BIP-39 mnemonic bytes).
  * @returns A deterministic UUID v4 string that uniquely identifies the entropy
  * without exposing it.
  */
 export async function fingerprint(material: Uint8Array): Promise<string> {
   const message = new TextEncoder().encode('metamask:fingerprint');
+ // `@noble/hashes` is synchronous today, but the async signature is kept as a
+ // forward-compatible seam: a future migration to the Web Crypto API (or any
+ // other async primitive) won't require changes at every call site.
   const digest = hmac(sha256, material, message);
   return uuid({ random: digest.slice(0, 16) });
 }

--- a/packages/keyring-sdk/src/entropy.ts
+++ b/packages/keyring-sdk/src/entropy.ts
@@ -1,22 +1,11 @@
 import { hmac } from '@noble/hashes/hmac';
-import { sha256 } from '@noble/hashes/sha256';
-import { bytesToHex } from '@noble/hashes/utils';
+import { sha256 } from '@noble/hashes/sha2';
 import { v4 as uuid } from 'uuid';
 
 /**
- * The category of an entropy source.
- *
- * - `'bip44'` — Entropy that uses BIP-44 to derive signers (e.g. SRP, hardware
- *   wallets).
- * - `'raw'` — Entropy that exposes a single key directly, without derivation
- *   (e.g. imported private keys, MPC).
+ * The type of an entropy source.
  */
-export type EntropyCategory = 'bip44' | 'raw';
-
-/**
- * The implementation of an entropy source within its category.
- */
-export type EntropyImplementation =
+export type EntropySourceType =
   | 'mnemonic'
   | 'ledger'
   | 'trezor'
@@ -24,36 +13,14 @@ export type EntropyImplementation =
   | 'mpc';
 
 /**
- * The type of an entropy source, expressed as `category:implementation`.
- *
- * @example `'bip44:mnemonic'`, `'bip44:ledger'`, `'raw:private-key'`, `'raw:mpc'`
- */
-export type EntropyType = `${EntropyCategory}:${EntropyImplementation}`;
-
-/**
  * Unique identifier for an entropy source.
  *
- * Format: `entropy:{category}:{implementation}:{uuid}` where the UUID is a
- * deterministic fingerprint of the underlying secret, or `'_'` for hardware
- * wallets whose secret never leaves the device.
+ * Format: `entropy:{type}:{uuid}` where the UUID is a
+ * deterministic fingerprint of the underlying secret, or `'_'` for entropies
+ * that cannot be uniquely identified.
  */
-export type EntropyId =
-  `entropy:${EntropyCategory}:${EntropyImplementation}:${string}`;
-
-/**
- * Represents a source of entropy.
- */
-export type Entropy = {
-  /**
-   * The unique identifier for this entropy source.
-   */
-  id: EntropyId;
-
-  /**
-   * The type of this entropy source.
-   */
-  type: EntropyType;
-};
+export type EntropySourceId =
+  `entropy:${EntropySourceType}:${string}`;
 
 /**
  * Computes a deterministic, non-reversible fingerprint for a piece of entropy.
@@ -76,40 +43,23 @@ export async function fingerprint(material: Uint8Array): Promise<string> {
 }
 
 /**
- * Computes a deterministic, non-reversible hex fingerprint for a piece of
- * entropy. Suitable for comparison and auditing.
+ * Computes a stable {@link EntropySourceId} for an entropy source.
  *
- * @param material - The raw entropy bytes.
- * @returns The lowercase hex-encoded 32-byte HMAC-SHA256 digest.
- */
-export async function toEntropyFingerprint(
-  material: Uint8Array,
-): Promise<string> {
-  const message = new TextEncoder().encode('metamask:fingerprint');
-  const digest = hmac(sha256, material, message);
-  return bytesToHex(digest);
-}
-
-/**
- * Computes a stable {@link EntropyId} for an entropy source.
- *
- * The ID is formatted as `entropy:{category}:{implementation}:{uuid}`, where
+ * The ID is formatted as `entropy:{type}:{uuid}`, where
  * the UUID segment is the {@link fingerprint} of `material` when provided, or
  * `'_'` for entropy sources whose secret never leaves the device (e.g. hardware
  * wallets).
  *
- * @param category - The entropy category (e.g. `'bip44'`, `'raw'`).
- * @param implementation - The entropy implementation (e.g. `'mnemonic'`,
+ * @param type - The entropy source type (e.g. `'mnemonic'`,
  * `'ledger'`, `'private-key'`).
  * @param material - The raw entropy bytes. Omit for hardware wallets or any
  * entropy source where the secret is not directly accessible.
- * @returns A stable {@link EntropyId} string.
+ * @returns A stable {@link EntropySourceId} string.
  */
-export async function toEntropyId(
-  category: EntropyCategory,
-  implementation: EntropyImplementation,
+export async function toEntropySourceId(
+  type: EntropySourceType,
   material?: Uint8Array,
-): Promise<EntropyId> {
-  const uuidSegment = material ? await fingerprint(material) : '_';
-  return `entropy:${category}:${implementation}:${uuidSegment}`;
+): Promise<EntropySourceId> {
+  const entropyFingerprint = material ? await fingerprint(material) : '_';
+  return `entropy:${type}:${entropyFingerprint}`;
 }

--- a/packages/keyring-sdk/src/entropy.ts
+++ b/packages/keyring-sdk/src/entropy.ts
@@ -1,0 +1,115 @@
+import { hmac } from '@noble/hashes/hmac';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+import { v4 as uuid } from 'uuid';
+
+/**
+ * The category of an entropy source.
+ *
+ * - `'bip44'` — Entropy that uses BIP-44 to derive signers (e.g. SRP, hardware
+ *   wallets).
+ * - `'raw'` — Entropy that exposes a single key directly, without derivation
+ *   (e.g. imported private keys, MPC).
+ */
+export type EntropyCategory = 'bip44' | 'raw';
+
+/**
+ * The implementation of an entropy source within its category.
+ */
+export type EntropyImplementation =
+  | 'mnemonic'
+  | 'ledger'
+  | 'trezor'
+  | 'private-key'
+  | 'mpc';
+
+/**
+ * The type of an entropy source, expressed as `category:implementation`.
+ *
+ * @example `'bip44:mnemonic'`, `'bip44:ledger'`, `'raw:private-key'`, `'raw:mpc'`
+ */
+export type EntropyType = `${EntropyCategory}:${EntropyImplementation}`;
+
+/**
+ * Unique identifier for an entropy source.
+ *
+ * Format: `entropy:{category}:{implementation}:{uuid}` where the UUID is a
+ * deterministic fingerprint of the underlying secret, or `'_'` for hardware
+ * wallets whose secret never leaves the device.
+ */
+export type EntropyId =
+  `entropy:${EntropyCategory}:${EntropyImplementation}:${string}`;
+
+/**
+ * Represents a source of entropy.
+ */
+export type Entropy = {
+  /**
+   * The unique identifier for this entropy source.
+   */
+  id: EntropyId;
+
+  /**
+   * The type of this entropy source.
+   */
+  type: EntropyType;
+};
+
+/**
+ * Computes a deterministic, non-reversible fingerprint for a piece of entropy.
+ *
+ * The fingerprint is a UUID v4 seeded from the first 16 bytes of
+ * `HMAC-SHA256(key=material, msg='metamask:fingerprint')`.
+ *
+ * `@noble/hashes` is synchronous today, but the async signature is kept as a
+ * forward-compatible seam: a future migration to the Web Crypto API (or any
+ * other async primitive) won't require changes at every call site.
+ *
+ * @param material - The raw entropy bytes (e.g. BIP-39 mnemonic bytes).
+ * @returns A deterministic UUID v4 string that uniquely identifies the entropy
+ * without exposing it.
+ */
+export async function fingerprint(material: Uint8Array): Promise<string> {
+  const message = new TextEncoder().encode('metamask:fingerprint');
+  const digest = hmac(sha256, material, message);
+  return uuid({ random: digest.slice(0, 16) });
+}
+
+/**
+ * Computes a deterministic, non-reversible hex fingerprint for a piece of
+ * entropy. Suitable for comparison and auditing.
+ *
+ * @param material - The raw entropy bytes.
+ * @returns The lowercase hex-encoded 32-byte HMAC-SHA256 digest.
+ */
+export async function toEntropyFingerprint(
+  material: Uint8Array,
+): Promise<string> {
+  const message = new TextEncoder().encode('metamask:fingerprint');
+  const digest = hmac(sha256, material, message);
+  return bytesToHex(digest);
+}
+
+/**
+ * Computes a stable {@link EntropyId} for an entropy source.
+ *
+ * The ID is formatted as `entropy:{category}:{implementation}:{uuid}`, where
+ * the UUID segment is the {@link fingerprint} of `material` when provided, or
+ * `'_'` for entropy sources whose secret never leaves the device (e.g. hardware
+ * wallets).
+ *
+ * @param category - The entropy category (e.g. `'bip44'`, `'raw'`).
+ * @param implementation - The entropy implementation (e.g. `'mnemonic'`,
+ * `'ledger'`, `'private-key'`).
+ * @param material - The raw entropy bytes. Omit for hardware wallets or any
+ * entropy source where the secret is not directly accessible.
+ * @returns A stable {@link EntropyId} string.
+ */
+export async function toEntropyId(
+  category: EntropyCategory,
+  implementation: EntropyImplementation,
+  material?: Uint8Array,
+): Promise<EntropyId> {
+  const uuidSegment = material ? await fingerprint(material) : '_';
+  return `entropy:${category}:${implementation}:${uuidSegment}`;
+}

--- a/packages/keyring-sdk/src/entropy.ts
+++ b/packages/keyring-sdk/src/entropy.ts
@@ -33,9 +33,9 @@ export type EntropySourceId = `entropy:${EntropySourceType}:${string}`;
  */
 export async function fingerprint(material: Uint8Array): Promise<string> {
   const message = new TextEncoder().encode('metamask:fingerprint');
- // `@noble/hashes` is synchronous today, but the async signature is kept as a
- // forward-compatible seam: a future migration to the Web Crypto API (or any
- // other async primitive) won't require changes at every call site.
+  // `@noble/hashes` is synchronous today, but the async signature is kept as a
+  // forward-compatible seam: a future migration to the Web Crypto API (or any
+  // other async primitive) won't require changes at every call site.
   const digest = hmac(sha256, material, message);
   return uuid({ random: digest.slice(0, 16) });
 }

--- a/packages/keyring-sdk/src/index.ts
+++ b/packages/keyring-sdk/src/index.ts
@@ -1,4 +1,5 @@
 export * from './keyring-account-registry';
 export * from './migration';
 export * from './mnemonic';
+export * from './entropy';
 export * from './eth';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2349,6 +2349,7 @@ __metadata:
     "@metamask/scure-bip39": "npm:^2.1.1"
     "@metamask/superstruct": "npm:^3.4.1"
     "@metamask/utils": "npm:^11.11.0"
+    "@noble/hashes": "npm:^1.8.0"
     "@ts-bridge/cli": "npm:^0.6.3"
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:^20.12.12"


### PR DESCRIPTION
Temporarily add the new entropy support in our `keyring-sdk` package.

We might re-consider this choice and put that somewhere else, but for now that will do.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a cryptographic fingerprint algorithm tied to seed material; accidental algorithm changes would break stable wallet/entropy IDs across clients.
> 
> **Overview**
> Adds **deterministic entropy source IDs** in `@metamask/keyring-sdk` so wallets can refer to a seed without exposing it.
> 
> New `entropy` module defines `fingerprint` (HMAC-SHA256 → UUID v4) and `toEntropySourceId`, producing strings like `entropy:mnemonic:{uuid}` or `entropy:ledger:_` when no secret material is available. The module is re-exported from the SDK and depends on `@noble/hashes`.
> 
> **`HdKeyring` (v2)** gains `toEntropySourceId()`, which hashes the keyring seed via the SDK helper and throws if the keyring is uninitialized. Tests cover determinism, mnemonic separation, SDK parity, and the uninitialized case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5df25e5d77a306b5e84ae57fb0f0e7dc91924e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->