### PR TITLE
chore(keyring-snap-sdk): bump keyring api to 23.7.0

### DIFF
--- a/packages/keyring-snap-sdk/CHANGELOG.md
+++ b/packages/keyring-snap-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/keyring-api` from `^23.0.0` to `^23.7.0` ([#605](https://github.com/MetaMask/accounts/pull/605))
+
 ## [9.2.1]
 
 ### Changed

--- a/packages/keyring-snap-sdk/package.json
+++ b/packages/keyring-snap-sdk/package.json
@@ -76,7 +76,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^6.1.0",
-    "@metamask/keyring-api": "^23.0.1",
+    "@metamask/keyring-api": "^23.7.0",
     "@metamask/providers": "^19.0.0",
     "@ts-bridge/cli": "^0.6.3",
     "@types/jest": "^29.5.12",
@@ -93,7 +93,7 @@
     "typescript": "~5.3.3"
   },
   "peerDependencies": {
-    "@metamask/keyring-api": "^23.0.0",
+    "@metamask/keyring-api": "^23.7.0",
     "@metamask/providers": "^19.0.0"
   },
   "tsd": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2409,7 +2409,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/keyring-api": "npm:^23.0.1"
+    "@metamask/keyring-api": "npm:^23.7.0"
     "@metamask/keyring-utils": "npm:^4.0.0"
     "@metamask/providers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"
@@ -2430,7 +2430,7 @@ __metadata:
     typescript: "npm:~5.3.3"
     webextension-polyfill: "npm:^0.12.0"
   peerDependencies:
-    "@metamask/keyring-api": ^23.0.0
+    "@metamask/keyring-api": ^23.7.0
     "@metamask/providers": ^19.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

This PR bump `keyring api` in  `keyring-snap-sdk ` to 23.7.0
it is require for this ticket
See: https://consensyssoftware.atlassian.net/browse/MUL-1996

## Examples

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and peer-range bump with no implementation changes; consumers must use keyring-api ≥23.7.0 but behavior of this SDK is unchanged.
> 
> **Overview**
> Updates **`@metamask/keyring-snap-sdk`** to depend on **`@metamask/keyring-api` `^23.7.0`** (from `^23.0.0` / `^23.0.1`), including the **peer dependency** range so Snap consumers align on the newer API types.
> 
> The **[Unreleased]** changelog entry and **`yarn.lock`** are updated; there are **no source or runtime logic changes** in this package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc28fb470692f70e4144349841e45684350b9092. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->