### PR TITLE
feat(keyring-sdk): add `encodeMnemonicWords`

### DIFF
--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `encodeMnemonicWords` ([#606](https://github.com/MetaMask/accounts/pull/606))
+
 ### Changed
 
 - Bump `@metamask/keyring-api` from `^23.6.0` to `^23.7.0` ([#604](https://github.com/MetaMask/accounts/pull/604))

--- a/packages/keyring-sdk/src/mnemonic.test.ts
+++ b/packages/keyring-sdk/src/mnemonic.test.ts
@@ -1,20 +1,45 @@
-import { encodeMnemonic } from './mnemonic';
+import { encodeMnemonic, encodeMnemonicWords } from './mnemonic';
 
 const toIndicesBytes = (indices: number[]): Uint8Array =>
   new Uint8Array(new Uint16Array(indices).buffer);
+
+describe('encodeMnemonicWords', () => {
+  it('returns an empty string for empty input', () => {
+    expect(encodeMnemonicWords(toIndicesBytes([]))).toBe('');
+  });
+
+  it('encodes a single word (index 0 -> "abandon")', () => {
+    expect(encodeMnemonicWords(toIndicesBytes([0]))).toBe('abandon');
+  });
+
+  it('encodes two words separated by a space (index 0 -> "abandon", index 1 -> "ability")', () => {
+    expect(encodeMnemonicWords(toIndicesBytes([0, 1]))).toBe('abandon ability');
+  });
+
+  it('encodes a standard 12-word mnemonic (all "abandon")', () => {
+    const indices = new Array(12).fill(0);
+    expect(encodeMnemonicWords(toIndicesBytes(indices))).toBe(
+      new Array(12).fill('abandon').join(' '),
+    );
+  });
+
+  it('returns a string', () => {
+    expect(typeof encodeMnemonicWords(toIndicesBytes([0]))).toBe('string');
+  });
+});
 
 describe('encodeMnemonic', () => {
   it('returns an empty array for empty input', () => {
     expect(encodeMnemonic(toIndicesBytes([]))).toStrictEqual([]);
   });
 
-  it('encodes a single word (index 0 → "abandon")', () => {
+  it('encodes a single word (index 0 -> "abandon")', () => {
     const expected = Array.from(new TextEncoder().encode('abandon'));
     expect(encodeMnemonic(toIndicesBytes([0]))).toStrictEqual(expected);
   });
 
   it('encodes two words separated by a space', () => {
-    // index 0 → "abandon", index 1 → "ability"
+    // index 0 -> "abandon", index 1 -> "ability"
     const expected = Array.from(new TextEncoder().encode('abandon ability'));
     expect(encodeMnemonic(toIndicesBytes([0, 1]))).toStrictEqual(expected);
   });

--- a/packages/keyring-sdk/src/mnemonic.ts
+++ b/packages/keyring-sdk/src/mnemonic.ts
@@ -1,18 +1,27 @@
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 
 /**
- * Encodes a mnemonic as an array of bytes (UTF-8).
+ * Encodes a mnemonic as a string of words.
  *
  * @param mnemonicIndicesBytes - An array of bytes (16-bit unsigned integers) representing the indices of the words in the mnemonic.
- * @returns An array of bytes (UTF-8) representing the mnemonic.
+ * @returns A string representing the mnemonic.
  */
-export function encodeMnemonic(mnemonicIndicesBytes: Uint8Array): number[] {
+export function encodeMnemonicWords(mnemonicIndicesBytes: Uint8Array): string {
   const mnemonicIndices = Array.from(
     // Create a new `Uint8Array` to ensure we have a proper view on the buffer
     // without having to worry about `byteOffset` and `byteLength` of
     // the inner buffer.
     new Uint16Array(new Uint8Array(mnemonicIndicesBytes).buffer),
   );
-  const mnemonic = mnemonicIndices.map((i) => wordlist[i]).join(' ');
-  return Array.from(new TextEncoder().encode(mnemonic));
+  return mnemonicIndices.map((i) => wordlist[i]).join(' ');
+}
+
+/**
+ * Encodes a mnemonic as an array of bytes (UTF-8).
+ *
+ * @param mnemonicIndicesBytes - An array of bytes (16-bit unsigned integers) representing the indices of the words in the mnemonic.
+ * @returns An array of bytes (UTF-8) representing the mnemonic.
+ */
+export function encodeMnemonic(mnemonicIndicesBytes: Uint8Array): number[] {
+  return Array.from(new TextEncoder().encode(encodeMnemonicWords(mnemonicIndicesBytes)));
 }

--- a/packages/keyring-sdk/src/mnemonic.ts
+++ b/packages/keyring-sdk/src/mnemonic.ts
@@ -23,5 +23,7 @@ export function encodeMnemonicWords(mnemonicIndicesBytes: Uint8Array): string {
  * @returns An array of bytes (UTF-8) representing the mnemonic.
  */
 export function encodeMnemonic(mnemonicIndicesBytes: Uint8Array): number[] {
-  return Array.from(new TextEncoder().encode(encodeMnemonicWords(mnemonicIndicesBytes)));
+  return Array.from(
+    new TextEncoder().encode(encodeMnemonicWords(mnemonicIndicesBytes)),
+  );
 }


### PR DESCRIPTION
Adding a new `encodeMnemonicWords` helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive export plus a small internal refactor of `encodeMnemonic` with existing tests unchanged; no new security or storage behavior.
> 
> **Overview**
> Adds **`encodeMnemonicWords`**, which maps 16-bit BIP39 word indices (as `Uint8Array`) to a space-separated mnemonic **string**, exported from the main `@metamask/keyring-sdk` entry via `./mnemonic`.
> 
> **`encodeMnemonic`** is refactored to call `encodeMnemonicWords` and then UTF-8-encode the result to `number[]`, so existing byte-array behavior should stay the same while callers can use the string helper directly.
> 
> Unit tests cover `encodeMnemonicWords` (empty, single/multi-word, 12-word cases); the changelog documents the new export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83d78433e50c7c3189e5aaa724e719ec2acf4d0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->