### PR TITLE
build(keyring-eth-ledger-bridge): exclude `__testhelpers__`

### DIFF
--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -19,7 +19,8 @@
   },
   "files": [
     "dist/",
-    "v2.js"
+    "v2.js",
+    "!dist/**/__testhelpers__"
   ],
   "sideEffects": false,
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Excluding the folder `__testhelpers__` from the dist files packed for NPM.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only change with no runtime or API impact for consumers.
> 
> **Overview**
> Adds a negated `files` entry (`!dist/**/__testhelpers__`) in `@metamask/eth-ledger-bridge-keyring` so **test-only helpers under `dist` are not included in the published npm tarball**, while still shipping `dist/` and `v2.js` as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb8faa6b49de0fa3f914abe414ee4dbc85b7700e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->