### PR TITLE
feat(keyring-sdk): add `decodeMnemonic{,Words}`

### DIFF
--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `decodeMnemonic` and `decodeMnemonicWords` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 ## [3.0.0]
 
 ### Added

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `decodeMnemonic` and `decodeMnemonicWords` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Add `decodeMnemonic` and `decodeMnemonicWords` ([#612](https://github.com/MetaMask/accounts/pull/612))
 
 ## [3.0.0]
 

--- a/packages/keyring-sdk/src/mnemonic.test.ts
+++ b/packages/keyring-sdk/src/mnemonic.test.ts
@@ -1,4 +1,9 @@
-import { encodeMnemonic, encodeMnemonicWords } from './mnemonic';
+import {
+  decodeMnemonic,
+  decodeMnemonicWords,
+  encodeMnemonic,
+  encodeMnemonicWords,
+} from './mnemonic';
 
 const toIndicesBytes = (indices: number[]): Uint8Array =>
   new Uint8Array(new Uint16Array(indices).buffer);
@@ -55,5 +60,61 @@ describe('encodeMnemonic', () => {
   it('returns number[] (not a Uint8Array)', () => {
     const result = encodeMnemonic(toIndicesBytes([0]));
     expect(Array.isArray(result)).toBe(true);
+  });
+});
+
+describe('decodeMnemonicWords', () => {
+  it('returns an empty array for empty input', () => {
+    expect(decodeMnemonicWords('')).toStrictEqual(toIndicesBytes([]));
+  });
+
+  it('decodes a single word ("abandon" -> index 0)', () => {
+    expect(decodeMnemonicWords('abandon')).toStrictEqual(toIndicesBytes([0]));
+  });
+
+  it('decodes two words separated by a space', () => {
+    expect(decodeMnemonicWords('abandon ability')).toStrictEqual(
+      toIndicesBytes([0, 1]),
+    );
+  });
+
+  it('decodes a standard 12-word mnemonic (all "abandon")', () => {
+    expect(
+      decodeMnemonicWords(new Array(12).fill('abandon').join(' ')),
+    ).toStrictEqual(toIndicesBytes(new Array(12).fill(0)));
+  });
+
+  it('throws if a word is not in the English BIP-39 wordlist', () => {
+    expect(() => decodeMnemonicWords('abandon invalid')).toThrow(
+      'Invalid mnemonic word: "invalid"',
+    );
+  });
+});
+
+describe('decodeMnemonic', () => {
+  it('returns an empty array for empty input', () => {
+    expect(decodeMnemonic(new Uint8Array())).toStrictEqual(toIndicesBytes([]));
+  });
+
+  it('decodes UTF-8 mnemonic bytes', () => {
+    const mnemonicBytes = new TextEncoder().encode('abandon ability');
+
+    expect(decodeMnemonic(mnemonicBytes)).toStrictEqual(toIndicesBytes([0, 1]));
+  });
+
+  it('round trips encoded mnemonic indices', () => {
+    const mnemonicIndicesBytes = toIndicesBytes([0, 1, 2, 2047]);
+
+    expect(
+      decodeMnemonic(new Uint8Array(encodeMnemonic(mnemonicIndicesBytes))),
+    ).toStrictEqual(mnemonicIndicesBytes);
+  });
+
+  it('throws if the mnemonic contains an invalid word', () => {
+    const mnemonicBytes = new TextEncoder().encode('abandon invalid');
+
+    expect(() => decodeMnemonic(mnemonicBytes)).toThrow(
+      'Invalid mnemonic word: "invalid"',
+    );
   });
 });

--- a/packages/keyring-sdk/src/mnemonic.ts
+++ b/packages/keyring-sdk/src/mnemonic.ts
@@ -27,3 +27,40 @@ export function encodeMnemonic(mnemonicIndicesBytes: Uint8Array): number[] {
     new TextEncoder().encode(encodeMnemonicWords(mnemonicIndicesBytes)),
   );
 }
+
+/**
+ * Decodes a string of mnemonic words as an array of bytes (16-bit unsigned
+ * integers) representing the indices of the words in the mnemonic.
+ *
+ * @param mnemonic - A string representing the mnemonic.
+ * @returns An array of bytes representing the indices of the words in the mnemonic.
+ * @throws If the mnemonic contains a word that is not in the English BIP-39 wordlist.
+ */
+export function decodeMnemonicWords(mnemonic: string): Uint8Array {
+  if (mnemonic === '') {
+    return new Uint8Array();
+  }
+
+  const mnemonicIndices = mnemonic.split(' ').map((word) => {
+    const index = wordlist.indexOf(word);
+    if (index === -1) {
+      throw new Error(`Invalid mnemonic word: "${word}"`);
+    }
+    return index;
+  });
+
+  return new Uint8Array(new Uint16Array(mnemonicIndices).buffer);
+}
+
+/**
+ * Decodes an array of bytes (UTF-8) representing a mnemonic as an array of
+ * bytes (16-bit unsigned integers) representing the indices of the words in
+ * the mnemonic.
+ *
+ * @param mnemonicBytes - An array of bytes (UTF-8) representing the mnemonic.
+ * @returns An array of bytes representing the indices of the words in the mnemonic.
+ * @throws If the mnemonic contains a word that is not in the English BIP-39 wordlist.
+ */
+export function decodeMnemonic(mnemonicBytes: Uint8Array): Uint8Array {
+  return decodeMnemonicWords(new TextDecoder().decode(mnemonicBytes));
+}


### PR DESCRIPTION
Decoding helpers for mnemonics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK API with tests and no changes to existing encode behavior; mnemonic handling is sensitive in principle but this only adds parsing helpers consistent with existing encoders.
> 
> **Overview**
> Adds **decode** helpers in `keyring-sdk` that mirror the existing `encodeMnemonic` / `encodeMnemonicWords` APIs, turning BIP-39 English mnemonics back into 16-bit word-index byte buffers.
> 
> `decodeMnemonicWords` splits a space-separated phrase and maps each word through the English wordlist; `decodeMnemonic` UTF-8-decodes bytes first, then delegates to `decodeMnemonicWords`. Both reject unknown words with `Invalid mnemonic word: "…"`. Tests cover empty input, round-trip with `encodeMnemonic`, and invalid-word errors. The unreleased changelog entry documents the new exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 914f87ead9b4a07c0fa7e92a2581e4f317dfdb44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->