### PR TITLE
fix(keyring-eth-ledger-bridge): stop using pinned version

### DIFF
--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Use `@ledgerhq/context-module@^2.1.0` instead of pinned version ([#616](https://github.com/MetaMask/accounts/pull/616))
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 
 ## [13.0.1]

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -72,7 +72,7 @@
     "@ethereumjs/rlp": "^5.0.2",
     "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",
-    "@ledgerhq/context-module": "2.1.0",
+    "@ledgerhq/context-module": "^2.1.0",
     "@ledgerhq/device-management-kit": "^1.7.1",
     "@ledgerhq/device-signer-kit-ethereum": "^1.16.0",
     "@ledgerhq/hw-app-eth": "^6.42.0",

--- a/yarn.config.cjs
+++ b/yarn.config.cjs
@@ -26,6 +26,16 @@ const { inspect } = require('util');
 const ALLOWED_INCONSISTENT_DEPENDENCIES = {};
 
 /**
+ * These packages are allowed to use a pinned (exact) version rather than a
+ * `^`-prefixed range in `dependencies` or `devDependencies`. Add a package
+ * here only when pinning is intentional and necessary; include a comment
+ * explaining why.
+ *
+ * @type {string[]}
+ */
+const PINNED_VERSION_EXCEPTIONS = [];
+
+/**
  * Aliases for the Yarn type definitions, to make the code more readable.
  *
  * @typedef {import('@yarnpkg/types').Yarn.Constraints.Yarn} Yarn
@@ -264,6 +274,10 @@ module.exports = defineConfig({
     // All version ranges in `dependencies` and `devDependencies` for the same
     // non-workspace dependency across the monorepo must be the same.
     expectConsistentDependenciesAndDevDependencies(Yarn);
+
+    // All non-workspace dependencies in `dependencies` and `devDependencies`
+    // must use a `^`-prefixed version range rather than a pinned exact version.
+    expectNoPinnedExternalDependencies(Yarn);
   },
 });
 
@@ -790,6 +804,45 @@ function getInconsistentDependenciesAndDevDependencies(
       ([range]) => !ignoredRanges.includes(range),
     ),
   );
+}
+
+/**
+ * Expect that all non-workspace entries in `dependencies` and
+ * `devDependencies` across the monorepo use a `^`-prefixed version range
+ * rather than a pinned exact version. Packages listed in
+ * `PINNED_VERSION_EXCEPTIONS` are exempt.
+ *
+ * @param {Yarn} Yarn - The Yarn "global".
+ */
+function expectNoPinnedExternalDependencies(Yarn) {
+  for (const dependency of Yarn.dependencies()) {
+    if (dependency.type === 'peerDependencies') {
+      continue;
+    }
+
+    if (PINNED_VERSION_EXCEPTIONS.includes(dependency.ident)) {
+      continue;
+    }
+
+    const dependencyWorkspace = Yarn.workspace({ ident: dependency.ident });
+    if (dependencyWorkspace) {
+      continue;
+    }
+
+    const isRangeAllowed =
+      dependency.range.startsWith('^') ||
+      dependency.range.startsWith('~') ||
+      dependency.range.startsWith('>=') ||
+      dependency.range.startsWith('>') ||
+      dependency.range.startsWith('workspace:') ||
+      dependency.range.startsWith('npm:');
+
+    if (!isRangeAllowed) {
+      dependency.error(
+        `Expected version range for ${dependency.ident} to use a range prefix such as \`^\` (got "${dependency.range}"). Pinned exact versions are not allowed. If this is intentional, add the package to PINNED_VERSION_EXCEPTIONS in yarn.config.cjs.`,
+      );
+    }
+  }
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1385,9 +1385,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ledgerhq/context-module@npm:2.1.0":
-  version: 2.1.0
-  resolution: "@ledgerhq/context-module@npm:2.1.0"
+"@ledgerhq/context-module@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "@ledgerhq/context-module@npm:2.3.1"
   dependencies:
     bs58: "npm:^6.0.0"
     crypto-js: "npm:^4.2.0"
@@ -1396,8 +1396,8 @@ __metadata:
     purify-ts: "npm:2.1.0"
     reflect-metadata: "npm:0.2.2"
   peerDependencies:
-    "@ledgerhq/device-management-kit": ^1.5.1
-  checksum: 10/b641272c78b2e7b35d5547122e32521473f5e37c1140d61c3b0f52688b63e23eab41f30b084e0448d5722abd202999847ebc3a8bb0e97e89aa54e186d73a484e
+    "@ledgerhq/device-management-kit": ^1.7.1
+  checksum: 10/e299adb1fa147b23ea8b080b4509c03833ed6eb310e3ae401c9fcc6f32c96118b2ed97b80716e072746f7382a0488070bed13d219adcacf17a1f3a341a546eb6
   languageName: node
   linkType: hard
 
@@ -1925,7 +1925,7 @@ __metadata:
     "@ethereumjs/util": "npm:^9.1.0"
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
-    "@ledgerhq/context-module": "npm:2.1.0"
+    "@ledgerhq/context-module": "npm:^2.1.0"
     "@ledgerhq/device-management-kit": "npm:^1.7.1"
     "@ledgerhq/device-signer-kit-ethereum": "npm:^1.16.0"
     "@ledgerhq/hw-app-eth": "npm:^6.42.0"


### PR DESCRIPTION
Not sure why, but this version got pinned, which makes it much hard to dedupe valid version ranges.

Also updated our `yarn.config.cjs` to prevent this from happening again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and tooling-only changes with no application logic edits; the main effect is resolving a newer compatible `@ledgerhq/context-module` via the lockfile.
> 
> **Overview**
> Replaces the accidentally **pinned** `@ledgerhq/context-module` dependency (`2.1.0`) in `@metamask/eth-ledger-bridge-keyring` with **`^2.1.0`**, so Yarn can align it with other compatible ranges in the monorepo. The lockfile refresh pulls **`@ledgerhq/context-module@2.3.1`** (still satisfying `^2.1.0`).
> 
> Adds a **Yarn constraints** check (`expectNoPinnedExternalDependencies`) that fails on exact external versions in `dependencies` / `devDependencies`, with an empty **`PINNED_VERSION_EXCEPTIONS`** list for intentional pins. The unreleased changelog notes the dependency change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5801acd4be7bc800b827bb5f247532926fb71a7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->