### PR TITLE
release: 125.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/accounts-monorepo",
-  "version": "124.0.0",
+  "version": "125.0.0",
   "private": true,
   "description": "Monorepo for MetaMask accounts related packages",
   "repository": {

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.0.2]
+
 ### Changed
 
 - Use `@ledgerhq/context-module@^2.1.0` instead of pinned version ([#616](https://github.com/MetaMask/accounts/pull/616))
@@ -506,7 +508,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support new versions of ethereumjs/tx ([#68](https://github.com/MetaMask/eth-ledger-bridge-keyring/pull/68))
 
-[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@13.0.1...HEAD
+[Unreleased]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@13.0.2...HEAD
+[13.0.2]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@13.0.1...@metamask/eth-ledger-bridge-keyring@13.0.2
 [13.0.1]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@13.0.0...@metamask/eth-ledger-bridge-keyring@13.0.1
 [13.0.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@12.4.0...@metamask/eth-ledger-bridge-keyring@13.0.0
 [12.4.0]: https://github.com/MetaMask/accounts/compare/@metamask/eth-ledger-bridge-keyring@12.3.0...@metamask/eth-ledger-bridge-keyring@12.4.0

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/eth-ledger-bridge-keyring",
-  "version": "13.0.1",
+  "version": "13.0.2",
   "description": "A MetaMask compatible keyring, for ledger hardware wallets",
   "keywords": [
     "ethereum",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and changelog-only release; dependency bumps in the Ledger keyring package may affect hardware-wallet consumers but carry no direct code changes in this PR.
> 
> **Overview**
> **Release 125.0.0** bumps the accounts monorepo from `124.0.0` to **`125.0.0`** and publishes **`@metamask/eth-ledger-bridge-keyring@13.0.2`** (from `13.0.1`).
> 
> The **13.0.2** changelog records dependency updates only: `@ledgerhq/context-module` is now `^2.1.0` (replacing a pinned version) and `@metamask/keyring-sdk` is bumped to `^3.1.0`. No application source changes appear in this diff—only version fields and changelog/compare links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01d9c2270a53fccda8dc193b585eb791090d2d38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->