### PR TITLE
feat(keyring-snap-bridge): add `isSnapKeyringV1Adapter`

### DIFF
--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `isSnapKeyringV1Adapter` ([#618](https://github.com/MetaMask/accounts/pull/618))
+  - This helper ensure we can safely identify the adapter if multiple versions/variants of that same class exists.
+
 ### Changed
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
@@ -159,13 +159,13 @@ describe('isSnapKeyringV1Adapter', () => {
     expect(isSnapKeyringV1Adapter({ type: KeyringType.Snap })).toBe(false);
   });
 
-  it('returns false when unwrap returns undefined', () => {
+  it('returns true even when unwrap returns undefined (only presence of the method is checked)', () => {
     expect(
       isSnapKeyringV1Adapter({
         type: KeyringType.Snap,
         unwrap: () => undefined,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('returns true for a duck-typed object with matching type and non-undefined unwrap', () => {

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
@@ -8,7 +8,10 @@ import type { SnapId } from '@metamask/snaps-sdk';
 import type { SnapKeyringMessenger } from '../SnapKeyringMessenger';
 import { SnapKeyring } from './SnapKeyring';
 import type { SnapKeyringCallbacks, SnapKeyringState } from './SnapKeyring';
-import { SnapKeyringV1Adapter } from './SnapKeyringV1Adapter';
+import {
+  isSnapKeyringV1Adapter,
+  SnapKeyringV1Adapter,
+} from './SnapKeyringV1Adapter';
 
 const ACCOUNT_ID = 'f2b88e0e-82a4-4e93-8c60-4fe59c6892d7';
 const ACCOUNT_ADDRESS = '0xdeadbeef00000000000000000000000000000000';
@@ -130,6 +133,47 @@ function buildMessenger(): SnapKeyringMessenger {
     publish: jest.fn(),
   } as unknown as SnapKeyringMessenger;
 }
+
+describe('isSnapKeyringV1Adapter', () => {
+  it('returns true for a real SnapKeyringV1Adapter instance', async () => {
+    const { adapter } = await setup();
+
+    expect(isSnapKeyringV1Adapter(adapter)).toBe(true);
+  });
+
+  it('returns false for null', () => {
+    expect(isSnapKeyringV1Adapter(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isSnapKeyringV1Adapter(undefined)).toBe(false);
+  });
+
+  it('returns false when type does not match', () => {
+    expect(
+      isSnapKeyringV1Adapter({ type: 'HD Key Tree', unwrap: () => ({}) }),
+    ).toBe(false);
+  });
+
+  it('returns false when unwrap is missing', () => {
+    expect(isSnapKeyringV1Adapter({ type: KeyringType.Snap })).toBe(false);
+  });
+
+  it('returns false when unwrap returns undefined', () => {
+    expect(
+      isSnapKeyringV1Adapter({
+        type: KeyringType.Snap,
+        unwrap: () => undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true for a duck-typed object with matching type and non-undefined unwrap', () => {
+    expect(
+      isSnapKeyringV1Adapter({ type: KeyringType.Snap, unwrap: () => ({}) }),
+    ).toBe(true);
+  });
+});
 
 describe('SnapKeyringV1Adapter', () => {
   it('inherits generic v1 adapter behavior', async () => {

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.test.ts
@@ -173,6 +173,12 @@ describe('isSnapKeyringV1Adapter', () => {
       isSnapKeyringV1Adapter({ type: KeyringType.Snap, unwrap: () => ({}) }),
     ).toBe(true);
   });
+
+  it('returns false for a raw SnapKeyring (v2) that lacks unwrap', async () => {
+    const { inner } = await setup();
+
+    expect(isSnapKeyringV1Adapter(inner)).toBe(false);
+  });
 });
 
 describe('SnapKeyringV1Adapter', () => {

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.ts
@@ -22,7 +22,7 @@ export function isSnapKeyringV1Adapter(
 
   const adapter = keyring as { type?: KeyringType; unwrap?: () => Keyring };
 
-  return adapter.type === KeyringType.Snap && adapter.unwrap?.() !== undefined;
+  return adapter.type === KeyringType.Snap && typeof adapter.unwrap === 'function';
 }
 
 /**

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.ts
@@ -22,7 +22,9 @@ export function isSnapKeyringV1Adapter(
 
   const adapter = keyring as { type?: KeyringType; unwrap?: () => Keyring };
 
-  return adapter.type === KeyringType.Snap && typeof adapter.unwrap === 'function';
+  return (
+    adapter.type === KeyringType.Snap && typeof adapter.unwrap === 'function'
+  );
 }
 
 /**

--- a/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.ts
+++ b/packages/keyring-snap-bridge/src/v2/SnapKeyringV1Adapter.ts
@@ -1,6 +1,29 @@
+import { Keyring, KeyringType } from '@metamask/keyring-api/v2';
 import { EthKeyringV1Adapter } from '@metamask/keyring-sdk/v2';
 
 import type { SnapKeyring } from './SnapKeyring';
+
+/**
+ * Check if a given keyring instance is a SnapKeyringV1Adapter.
+ *
+ * @param keyring - The keyring to check.
+ * @returns True if the keyring is a SnapKeyringV1Adapter, false otherwise.
+ */
+export function isSnapKeyringV1Adapter(
+  keyring: unknown,
+): keyring is SnapKeyringV1Adapter {
+  // Uses duck-typing to determine if a given keyring is a SnapKeyringV1Adapter (which wraps a SnapKeyringV2).
+  //
+  // This avoids relying on `instanceof` checks, which can fail in certain module resolution scenarios (e.g.
+  // when multiple versions of the same class exist).
+  if (keyring === null || keyring === undefined) {
+    return false;
+  }
+
+  const adapter = keyring as { type?: KeyringType; unwrap?: () => Keyring };
+
+  return adapter.type === KeyringType.Snap && adapter.unwrap?.() !== undefined;
+}
 
 /**
  * Adapts a v2 Snap keyring to the legacy v1 keyring API.


### PR DESCRIPTION
Adding this helper since I have faced some issue with the error "Keyring not found" on the extension.

That's probably because of the same issue we had with the `KeyringControllerError` a while ago that was also using `instanceof`, if multiple majors are in the dep-tree, the classes could be seen as different and make the test fail!

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only identification helper with no changes to keyring behavior or account operations.
> 
> **Overview**
> Adds **`isSnapKeyringV1Adapter`**, a type guard so callers can recognize a Snap v1 adapter without **`instanceof`**, which can fail when multiple copies of the same class are loaded (e.g. extension dependency trees).
> 
> The check is duck-typed: **`type === KeyringType.Snap`** and **`unwrap`** is a function. **`null`/`undefined`**, wrong types, plain v2 **`SnapKeyring`**, and objects missing **`unwrap`** return false. Unit tests cover these cases; the unreleased changelog documents the export.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0f000a01af618deb8e73c9559df9a56847e8d1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->