### PR TITLE
refactor(keyring-sdk)!: remove envelope from the migration framework

### DIFF
--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
+### Changed
 
 - **BREAKING:** Remove envelope from migration framework ([#619](https://github.com/MetaMask/accounts/pull/619))
   - The envelope made it harder to integrate with existing state.

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -12,9 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING:** Remove envelope from migration framework ([#619](https://github.com/MetaMask/accounts/pull/619))
   - The envelope made it harder to integrate with existing state.
   - We still keep the requirement of having a `version` field to be declared, but the state can be "flatten" instead of living inside the `data` (envelope) field.
-
-### Changed
-
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
 
 ## [3.1.0]

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **BREAKING:** Remove envelope from migration framework ([#619](https://github.com/MetaMask/accounts/pull/619))
+  - The envelope made it harder to integrate with existing state.
+  - We still keep the requirement of having a `version` field to be declared, but the state can be "flatten" instead of living inside the `data` (envelope) field.
+
 ## [3.1.0]
 
 ### Added

--- a/packages/keyring-sdk/src/migration.test-d.ts
+++ b/packages/keyring-sdk/src/migration.test-d.ts
@@ -48,7 +48,9 @@ createMigrations()
   .add({
     // @ts-expect-error [test] `inputSchema`'s inferred type doesn't extend `{ count: number }`.
     inputSchema: object({ label: string() }),
-    migrate: (data) => ({ label: (data as unknown as { label: string }).label }),
+    migrate: (data) => ({
+      label: (data as unknown as { label: string }).label,
+    }),
   });
 
 // `apply()` resolves to the final step's output type.

--- a/packages/keyring-sdk/src/migration.test-d.ts
+++ b/packages/keyring-sdk/src/migration.test-d.ts
@@ -1,12 +1,11 @@
 import { object, number, string } from '@metamask/superstruct';
-import type { Json } from '@metamask/utils';
 import { expectType } from 'tsd';
 
 import { createMigrations } from './migration';
-import type { MigrationChain, MigrationResult } from './migration';
+import type { JsonObject, MigrationChain, MigrationResult } from './migration';
 
-// `createMigrations()` starts an empty chain typed to accept `Json`.
-expectType<MigrationChain<Json>>(createMigrations());
+// `createMigrations()` starts an empty chain typed to accept `JsonObject`.
+expectType<MigrationChain<JsonObject>>(createMigrations());
 
 // A step's `migrate` receives the previous step's output shape, with no cast needed.
 createMigrations()
@@ -22,9 +21,9 @@ createMigrations()
 createMigrations()
   .add({ migrate: (): { count: number } => ({ count: 1 }) })
   // @ts-expect-error [test] `data` is `{ count: number }`, not `{ label: string }`.
-  .add({ migrate: (data: { label: string }) => data.label });
+  .add({ migrate: (data: { label: string }) => ({ label: data.label }) });
 
-// A step's inferred `migrate` parameter is the previous step's output shape, not `Json`.
+// A step's inferred `migrate` parameter is the previous step's output shape, not `JsonObject`.
 createMigrations()
   .add({ migrate: (): { count: number } => ({ count: 1 }) })
   .add({
@@ -34,8 +33,7 @@ createMigrations()
     },
   });
 
-// `inputSchema` narrows `migrate`'s input to the schema's inferred type, with no cast
-// needed.
+// `inputSchema` narrows `migrate`'s input to the schema's inferred type, with no cast needed.
 createMigrations().add({
   inputSchema: object({ oldCount: number() }),
   migrate: (data) => {
@@ -44,14 +42,13 @@ createMigrations().add({
   },
 });
 
-// `inputSchema` must be compatible with the chain's current data type, just like
-// `migrate`.
+// `inputSchema` must be compatible with the chain's current data type, just like `migrate`.
 createMigrations()
   .add({ migrate: (): { count: number } => ({ count: 1 }) })
   .add({
     // @ts-expect-error [test] `inputSchema`'s inferred type doesn't extend `{ count: number }`.
     inputSchema: object({ label: string() }),
-    migrate: () => 'x',
+    migrate: (data) => ({ label: (data as unknown as { label: string }).label }),
   });
 
 // `apply()` resolves to the final step's output type.

--- a/packages/keyring-sdk/src/migration.test.ts
+++ b/packages/keyring-sdk/src/migration.test.ts
@@ -126,6 +126,17 @@ describe('apply', () => {
         'Unversioned state must be a plain object',
       );
     });
+
+    it('overrides a version field returned by a step with the framework version', async () => {
+      const migrations = createMigrations().add({
+        migrate: () => ({ version: 99, foo: 'bar' }),
+      });
+
+      const result = await migrations.apply({});
+
+      expect(result.state.version).toBe(1);
+      expect(result.version).toBe(1);
+    });
   });
 
   describe('when given versioned state', () => {

--- a/packages/keyring-sdk/src/migration.test.ts
+++ b/packages/keyring-sdk/src/migration.test.ts
@@ -3,6 +3,7 @@ import type { Infer } from '@metamask/superstruct';
 import type { Json } from '@metamask/utils';
 
 import { createMigrations, isVersionedState } from './migration';
+import type { JsonObject } from './migration';
 
 describe('isVersionedState', () => {
   it('returns true for a flat state with only a version field', () => {
@@ -22,11 +23,11 @@ describe('isVersionedState', () => {
   });
 
   it('returns false for an array', () => {
-    expect(isVersionedState(['a', 'b'] as unknown as Json)).toBe(false);
+    expect(isVersionedState(['a', 'b'] as unknown as JsonObject)).toBe(false);
   });
 
   it('returns false for null', () => {
-    expect(isVersionedState(null)).toBe(false);
+    expect(isVersionedState(null as unknown as JsonObject)).toBe(false);
   });
 
   it('returns false when version is not an integer', () => {

--- a/packages/keyring-sdk/src/migration.test.ts
+++ b/packages/keyring-sdk/src/migration.test.ts
@@ -122,9 +122,9 @@ describe('apply', () => {
     });
 
     it('throws when given null as unversioned state', async () => {
-      await expect(
-        createMigrations().apply(null),
-      ).rejects.toThrow('Unversioned state must be a plain object');
+      await expect(createMigrations().apply(null)).rejects.toThrow(
+        'Unversioned state must be a plain object',
+      );
     });
   });
 

--- a/packages/keyring-sdk/src/migration.test.ts
+++ b/packages/keyring-sdk/src/migration.test.ts
@@ -5,16 +5,16 @@ import type { Json } from '@metamask/utils';
 import { createMigrations, isVersionedState } from './migration';
 
 describe('isVersionedState', () => {
-  it('returns true for a valid versioned state', () => {
-    expect(isVersionedState({ version: 1, data: { foo: 'bar' } })).toBe(true);
+  it('returns true for a flat state with only a version field', () => {
+    expect(isVersionedState({ version: 1 })).toBe(true);
   });
 
-  it('returns true when data is an array', () => {
-    expect(isVersionedState({ version: 0, data: ['a', 'b'] })).toBe(true);
+  it('returns true for a flat state with version and extra fields', () => {
+    expect(isVersionedState({ version: 1, foo: 'bar' })).toBe(true);
   });
 
-  it('returns true when data is null', () => {
-    expect(isVersionedState({ version: 0, data: null })).toBe(true);
+  it('returns true when version is 0', () => {
+    expect(isVersionedState({ version: 0, accounts: [] })).toBe(true);
   });
 
   it('returns false for a plain object without version', () => {
@@ -29,12 +29,12 @@ describe('isVersionedState', () => {
     expect(isVersionedState(null)).toBe(false);
   });
 
-  it('returns false when version is not a number', () => {
-    expect(isVersionedState({ version: '1', data: {} })).toBe(false);
+  it('returns false when version is not an integer', () => {
+    expect(isVersionedState({ version: '1', foo: {} })).toBe(false);
   });
 
-  it('returns false when data is missing', () => {
-    expect(isVersionedState({ version: 1 })).toBe(false);
+  it('returns false when version is a float', () => {
+    expect(isVersionedState({ version: 1.5, foo: {} })).toBe(false);
   });
 });
 
@@ -95,58 +95,36 @@ describe('apply', () => {
 
       expect(result).toStrictEqual({
         version: 2,
-        data: {
+        state: {
+          version: 2,
           existing: true,
           newField: 'added',
           renamedField: 'value',
-        } satisfies HdStateV2,
+        } satisfies { version: number } & HdStateV2,
         migrated: true,
       });
     });
 
-    it('applies all steps to an unversioned array', async () => {
-      type PrivateKeysV1 = { keys: string[]; format: string };
-
-      const migrations = createMigrations().add({
-        migrate: (data: string[]): PrivateKeysV1 => ({
-          keys: data,
-          format: 'v1',
-        }),
-      });
-
-      const result = await migrations.apply([
-        'key1',
-        'key2',
-      ] as unknown as Json);
-
-      expect(result).toStrictEqual({
-        version: 1,
-        data: { keys: ['key1', 'key2'], format: 'v1' } satisfies PrivateKeysV1,
-        migrated: true,
-      });
-    });
-
-    it('wraps in envelope at version 0 when the chain has no steps', async () => {
+    it('wraps in flat versioned state at version 0 when the chain has no steps', async () => {
       const result = await createMigrations().apply({ foo: 'bar' });
 
       expect(result).toStrictEqual({
         version: 0,
-        data: { foo: 'bar' },
+        state: { version: 0, foo: 'bar' },
         migrated: false,
       });
     });
 
-    it('wraps array state in envelope at version 0 when the chain has no steps', async () => {
-      const result = await createMigrations().apply([
-        'a',
-        'b',
-      ] as unknown as Json);
+    it('throws when given an array as unversioned state', async () => {
+      await expect(
+        createMigrations().apply(['a', 'b'] as unknown as Json),
+      ).rejects.toThrow('Unversioned state must be a plain object');
+    });
 
-      expect(result).toStrictEqual({
-        version: 0,
-        data: ['a', 'b'],
-        migrated: false,
-      });
+    it('throws when given null as unversioned state', async () => {
+      await expect(
+        createMigrations().apply(null),
+      ).rejects.toThrow('Unversioned state must be a plain object');
     });
   });
 
@@ -165,13 +143,17 @@ describe('apply', () => {
 
       const result = await migrations.apply({
         version: 1,
-        data: { existing: true },
+        existing: true,
       });
 
       expect(migrateFn).toHaveBeenCalledWith({ existing: true });
       expect(result).toStrictEqual({
         version: 2,
-        data: { existing: true, v2: true } satisfies StateV2,
+        state: {
+          version: 2,
+          existing: true,
+          v2: true,
+        } satisfies { version: number } & StateV2,
         migrated: true,
       });
     });
@@ -183,19 +165,19 @@ describe('apply', () => {
 
       const result = await migrations.apply({
         version: 1,
-        data: { foo: 'bar' },
+        foo: 'bar',
       });
 
       expect(migrateFn).not.toHaveBeenCalled();
       expect(result).toStrictEqual({
         version: 1,
-        data: { foo: 'bar' },
+        state: { version: 1, foo: 'bar' },
         migrated: false,
       });
     });
 
     it('applies multiple pending steps in order', async () => {
-      type StateV3 = { original: boolean; migrated: boolean };
+      type StateV3 = { original: boolean; extra: boolean };
 
       const order: number[] = [];
 
@@ -215,24 +197,28 @@ describe('apply', () => {
         .add({
           migrate: (data: { original: boolean }): StateV3 => {
             order.push(3);
-            return { ...data, migrated: true };
+            return { ...data, extra: true };
           },
         });
 
       const result = await migrations.apply({
         version: 1,
-        data: { original: true },
+        original: true,
       });
 
       expect(order).toStrictEqual([2, 3]);
       expect(result).toStrictEqual({
         version: 3,
-        data: { original: true, migrated: true } satisfies StateV3,
+        state: {
+          version: 3,
+          original: true,
+          extra: true,
+        } satisfies { version: number } & StateV3,
         migrated: true,
       });
     });
 
-    it('treats explicitly versioned state at version 0 as unversioned', async () => {
+    it('treats explicitly versioned state at version 0 as the start of the chain', async () => {
       type UnversionedHdState = { oldField: string; existing: boolean };
       type HdStateV1 = {
         oldField: string;
@@ -249,16 +235,18 @@ describe('apply', () => {
 
       const result = await migrations.apply({
         version: 0,
-        data: { oldField: 'value', existing: true },
+        oldField: 'value',
+        existing: true,
       });
 
       expect(result).toStrictEqual({
         version: 1,
-        data: {
+        state: {
+          version: 1,
           oldField: 'value',
           existing: true,
           newField: 'added',
-        } satisfies HdStateV1,
+        } satisfies { version: number } & HdStateV1,
         migrated: true,
       });
     });
@@ -266,7 +254,7 @@ describe('apply', () => {
     it('throws when state version is newer than the chain', async () => {
       const migrations = createMigrations().add({ migrate: (data) => data });
 
-      await expect(migrations.apply({ version: 5, data: {} })).rejects.toThrow(
+      await expect(migrations.apply({ version: 5 })).rejects.toThrow(
         'State version 5 is newer than the latest migration version 1',
       );
     });
@@ -274,7 +262,7 @@ describe('apply', () => {
     it('throws when state version is negative', async () => {
       const migrations = createMigrations().add({ migrate: (data) => data });
 
-      await expect(migrations.apply({ version: -1, data: {} })).rejects.toThrow(
+      await expect(migrations.apply({ version: -1 })).rejects.toThrow(
         'State version -1 is invalid; it cannot be negative',
       );
     });
@@ -295,7 +283,7 @@ describe('apply', () => {
 
       expect(result).toStrictEqual({
         version: 1,
-        data: { foo: 'bar', async: true } satisfies StateV1,
+        state: { version: 1, foo: 'bar', async: true },
         migrated: true,
       });
     });
@@ -326,7 +314,7 @@ describe('apply', () => {
 
       expect(result).toStrictEqual({
         version: 1,
-        data: { name: 'test', count: 42 },
+        state: { version: 1, name: 'test', count: 42 },
         migrated: true,
       });
     });
@@ -365,7 +353,11 @@ describe('apply', () => {
 
       expect(result).toStrictEqual({
         version: 2,
-        data: { items: ['a', 'b'], total: 2 } satisfies StateV2,
+        state: {
+          version: 2,
+          items: ['a', 'b'],
+          total: 2,
+        } satisfies { version: number } & StateV2,
         migrated: true,
       });
     });
@@ -384,7 +376,7 @@ describe('apply', () => {
 
       expect(result).toStrictEqual({
         version: 1,
-        data: { count: 7 },
+        state: { version: 1, count: 7 },
         migrated: true,
       });
     });
@@ -404,17 +396,15 @@ describe('apply', () => {
       expect(migrateFn).not.toHaveBeenCalled();
     });
 
-    it('validates input as JSON even when inputSchema is omitted', async () => {
-      const migrateFn = jest.fn();
-      const migrations = createMigrations().add({ migrate: migrateFn });
+    it('throws when migrate returns undefined (caught by outputSchema fallback)', async () => {
+      const migrateFn = jest.fn(() => undefined);
+      const migrations = createMigrations().add({
+        migrate: migrateFn as unknown as () => Record<string, never>,
+      });
 
-      // undefined is not valid JSON
-      await expect(
-        migrations.apply(undefined as unknown as Json),
-      ).rejects.toThrow(
+      await expect(migrations.apply({})).rejects.toThrow(
         'Expected a value of type `JSON`, but received: `undefined`',
       );
-      expect(migrateFn).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/keyring-sdk/src/migration.test.ts
+++ b/packages/keyring-sdk/src/migration.test.ts
@@ -403,7 +403,7 @@ describe('apply', () => {
       });
 
       await expect(migrations.apply({})).rejects.toThrow(
-        'Expected a value of type `JSON`, but received: `undefined`',
+        'Expected an object, but received: undefined',
       );
     });
   });

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -1,5 +1,5 @@
 import type { Struct } from '@metamask/superstruct';
-import { assert, integer, object } from '@metamask/superstruct';
+import { assert, integer, type } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
 
@@ -17,7 +17,7 @@ export type JsonObject = Record<string, Json>;
  * whether arbitrary flat state carries a version field, use
  * {@link isVersionedState} instead.
  */
-export const VersionedStateStruct = object({
+export const VersionedStateStruct = type({
   version: integer(),
 });
 

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -60,6 +60,16 @@ export type MigrationResult<Data extends JsonObject = JsonObject> = {
 };
 
 /**
+ * Type guard to check if a value is a plain JSON object.
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value is a non-null, non-array object.
+ */
+function isJsonObject(value: Json): value is JsonObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
  * Type guard to check if a value is a {@link VersionedState}.
  *
  * Returns `true` for any plain object that carries a `version: integer` field,
@@ -69,12 +79,7 @@ export type MigrationResult<Data extends JsonObject = JsonObject> = {
  * @returns `true` if the value has a `version: integer` field.
  */
 export function isVersionedState(state: Json): state is VersionedState {
-  return (
-    typeof state === 'object' &&
-    state !== null &&
-    !Array.isArray(state) &&
-    Number.isInteger(state.version)
-  );
+  return isJsonObject(state) && Number.isInteger(state.version);
 }
 
 /**
@@ -87,15 +92,13 @@ export function isVersionedState(state: Json): state is VersionedState {
  * @param state - The state to decompose.
  * @returns The version number and the inner data object.
  */
-function getVersionAndData(
-  state: Json,
-): { version: number; data: JsonObject } {
+function getVersionAndData(state: Json): { version: number; data: JsonObject } {
   if (isVersionedState(state)) {
     const { version, ...rest } = state;
     return { version, data: rest };
   }
 
-  if (typeof state !== 'object' || state === null || Array.isArray(state)) {
+  if (!isJsonObject(state)) {
     throw new Error('Unversioned state must be a plain object');
   }
 

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -94,8 +94,8 @@ export function isVersionedState(state: Json): state is VersionedState {
  */
 function getVersionAndData(state: Json): { version: number; data: JsonObject } {
   if (isVersionedState(state)) {
-    const { version, ...rest } = state;
-    return { version, data: rest };
+    const { version, ...data } = state;
+    return { version, data };
   }
 
   if (!isJsonObject(state)) {

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -240,8 +240,8 @@ async function applySteps<Data extends JsonObject>(
   return {
     version: latestVersion,
     state: {
-      version: latestVersion,
       ...data,
+      version: latestVersion,
     },
     migrated: pendingSteps.length > 0,
   } as MigrationResult<Data>;

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -1,5 +1,5 @@
 import type { Struct } from '@metamask/superstruct';
-import { assert, integer, type } from '@metamask/superstruct';
+import { assert, integer, record, string, type } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
 
@@ -8,6 +8,17 @@ import type { Json } from '@metamask/utils';
  * `version` field can be inlined alongside its other fields.
  */
 export type JsonObject = Record<string, Json>;
+
+/**
+ * Superstruct schema for a plain JSON object (`Record<string, Json>`).
+ *
+ * Used as the default fallback schema for step input/output validation when no
+ * explicit schema is provided.
+ */
+export const JsonObjectStruct: Struct<JsonObject> = record(
+  string(),
+  JsonStruct,
+);
 
 /**
  * Superstruct schema for an exact `{ version: integer }` object with no other
@@ -209,15 +220,9 @@ async function applySteps<Data extends JsonObject>(
   let data: JsonObject = initialData;
 
   for (const step of pendingSteps) {
-    if (step.inputSchema) {
-      assert(data, step.inputSchema);
-    }
+    assert(data, step.inputSchema ?? JsonObjectStruct);
     data = await step.migrate(data);
-    if (step.outputSchema) {
-      assert(data, step.outputSchema);
-    } else {
-      assert(data, JsonStruct);
-    }
+    assert(data, step.outputSchema ?? JsonObjectStruct);
   }
 
   const migratedState = {

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -220,7 +220,10 @@ async function applySteps<Data extends JsonObject>(
     }
   }
 
-  const migratedState = { ...data, version: latestVersion } as VersionedState<Data>;
+  const migratedState = {
+    ...data,
+    version: latestVersion,
+  } as VersionedState<Data>;
   return {
     version: latestVersion,
     state: migratedState,

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -1,92 +1,130 @@
-import type { Infer, Struct } from '@metamask/superstruct';
-import { assert, integer, is, object } from '@metamask/superstruct';
+import type { Struct } from '@metamask/superstruct';
+import { assert, integer, object } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
 
 /**
- * Superstruct schema for the versioned state envelope.
+ * Constraint for flat migration state: must be a plain JSON object so that the
+ * `version` field can be inlined alongside its other fields.
+ */
+export type JsonObject = Record<string, Json>;
+
+/**
+ * Superstruct schema for an exact `{ version: integer }` object with no other
+ * fields.
+ *
+ * Use this struct when you need to validate a pure version token. To check
+ * whether arbitrary flat state carries a version field, use
+ * {@link isVersionedState} instead.
  */
 export const VersionedStateStruct = object({
   version: integer(),
-  data: JsonStruct,
 });
 
 /**
- * Versioned state envelope wrapping the actual keyring data.
+ * Flat versioned state: the keyring state with `version` inlined alongside its
+ * own fields.
  *
- * After migrations are applied, state is always wrapped in this format. `serialize()`
- * should produce this envelope so that subsequent `deserialize()` calls can detect the
- * version.
+ * This is the format that `serialize()` should produce and `deserialize()` will
+ * consume. The `version` field is managed by the migration framework; every
+ * other field belongs to the keyring.
+ *
+ * Do not use `version` or `migrated` as field names in keyring state, as the
+ * framework writes both at the top level when constructing a
+ * {@link MigrationResult}.
+ *
+ * @example
+ * const state: VersionedState<{ accounts: string[] }> = {
+ *   version: 3,
+ *   accounts: [],
+ * };
  */
-export type VersionedState<Data extends Json = Json> = Omit<
-  Infer<typeof VersionedStateStruct>,
-  'data'
-> & {
-  data: Data;
+export type VersionedState<Data extends JsonObject = JsonObject> = Data & {
+  version: number;
 };
 
 /**
  * Return value of {@link MigrationChain.apply}.
  *
- * Extends {@link VersionedState} with a `migrated` flag that is `true` when at least
- * one step was applied during the call. Callers can use this to detect that the
- * in-memory state has been upgraded and schedule a persist so the new version is
- * written to storage, even when no other state change happens in the session.
+ * `state` is the flat {@link VersionedState} to persist. `migrated` is a
+ * runtime-only flag that is never written to storage. `version` duplicates
+ * `state.version` for convenience.
  */
-export type MigrationResult<Data extends Json = Json> = VersionedState<Data> & {
+export type MigrationResult<Data extends JsonObject = JsonObject> = {
+  /** Convenience alias for `state.version`. */
+  version: number;
+  /** The migrated flat state to persist. */
+  state: VersionedState<Data>;
+  /** `true` when at least one migration step was applied during this call. */
   migrated: boolean;
 };
 
 /**
- * Type guard to check if a value is a {@link VersionedState} envelope.
+ * Type guard to check if a value is a {@link VersionedState}.
+ *
+ * Returns `true` for any plain object that carries a `version: integer` field,
+ * regardless of what other fields are present.
  *
  * @param state - The value to check.
- * @returns `true` if the value is a versioned state envelope.
+ * @returns `true` if the value has a `version: integer` field.
  */
-export function isVersionedState<State extends Json = Json>(
-  state: State | VersionedState<State>,
-): state is VersionedState<State> {
-  return is(state, VersionedStateStruct);
+export function isVersionedState(state: Json): state is VersionedState {
+  return (
+    typeof state === 'object' &&
+    state !== null &&
+    !Array.isArray(state) &&
+    Number.isInteger((state as Record<string, Json>).version)
+  );
 }
 
 /**
- * Get the version and data from state, treating unversioned state as version 0.
+ * Extract the version and inner data from state.
  *
- * @param state - The state to check.
- * @returns The version and data.
+ * For versioned state (`isVersionedState` returns true), strips the `version`
+ * field and returns the rest as data. For unversioned legacy state (plain
+ * object with no `version` field), returns version 0 and the object as-is.
+ *
+ * @param state - The state to decompose.
+ * @returns The version number and the inner data object.
  */
-function getVersionAndData<State extends Json = Json>(
-  state: State | VersionedState<State>,
-): VersionedState<State> {
-  return isVersionedState(state)
-    ? { version: state.version, data: state.data }
-    : { version: 0, data: state };
+function getVersionAndData(
+  state: Json,
+): { version: number; data: JsonObject } {
+  if (isVersionedState(state)) {
+    const { version, ...rest } = state as VersionedState;
+    return { version, data: rest as JsonObject };
+  }
+
+  if (typeof state !== 'object' || state === null || Array.isArray(state)) {
+    throw new Error('Unversioned state must be a plain object');
+  }
+
+  return { version: 0, data: state as JsonObject };
 }
 
 /**
  * A single migration step, added to a {@link MigrationChain} via `.add()`.
  *
- * `Input` is bound automatically to the chain's current data type when the step is
- * passed to `.add()`, so `migrate` receives a correctly typed argument with no manual
- * cast.
+ * `Input` is bound automatically to the chain's current data type when the
+ * step is passed to `.add()`, so `migrate` receives a correctly typed argument
+ * with no manual cast.
  */
 export type MigrationStep<
-  Input extends Json = Json,
-  Output extends Json = Json,
+  Input extends JsonObject = JsonObject,
+  Output extends JsonObject = JsonObject,
 > = {
   /**
    * Transform state from the previous step's output to this step's output.
    *
-   * Receives the raw inner data (not the versioned envelope). May be sync or async to
-   * support complex operations like re-deriving data from secrets.
+   * Receives the raw inner data (not the versioned envelope). May be sync or
+   * async to support complex operations like re-deriving data from secrets.
    *
    * @param data - The state data from the previous step.
    * @returns The migrated data.
    */
   migrate(data: Input): Output | Promise<Output>;
   /**
-   * Optional schema validating this step's input before `migrate` is called. Defaults
-   * to a generic JSON-shape check when omitted.
+   * Optional schema validating this step's input before `migrate` is called.
    */
   inputSchema?: Struct<Input>;
   /**
@@ -96,45 +134,42 @@ export type MigrationStep<
 };
 
 /**
- * A chain of migration steps for evolving keyring serialized state across versions.
+ * A chain of migration steps for evolving keyring serialized state across
+ * versions.
  *
- * Steps are versioned by position: the first `.add()` call produces version 1, the
- * second version 2, and so on. Create one with {@link createMigrations}.
+ * Steps are versioned by position: the first `.add()` call produces version 1,
+ * the second version 2, and so on. Create one with {@link createMigrations}.
  */
-export type MigrationChain<Data extends Json = Json> = {
+export type MigrationChain<Data extends JsonObject = JsonObject> = {
   /**
-   * The number of steps added so far. Since steps are versioned by position starting at
-   * 1, this also doubles as "the latest version" (use it in `serialize()`).
+   * The number of steps added so far. Also the latest version number (use it
+   * in `serialize()`).
    */
   readonly version: number;
   /**
    * Append a step to the chain.
    *
-   * Returns a new chain typed to `Output`. It does not mutate the chain it's called on,
-   * so branching from a shared base chain is safe.
-   *
-   * `Input` defaults to the chain's current `Data` type. Providing `inputSchema` lets
-   * TypeScript infer a narrower `Input` (bounded to extend `Data`), so `migrate`
-   * receives a schema-typed argument when narrowing raw state into a specific shape,
-   * typically on a chain's first step, where `Data` is `Json`.
+   * Returns a new chain typed to `Output`. Does not mutate the chain it is
+   * called on, so branching from a shared base chain is safe.
    *
    * @param step - The migration step to append.
    * @returns A new chain whose data type is the step's `Output`.
    */
-  add<Input extends Data = Data, Output extends Json = Json>(
+  add<Input extends Data = Data, Output extends JsonObject = JsonObject>(
     step: MigrationStep<Input, Output>,
   ): MigrationChain<Output>;
   /**
    * Apply all pending steps to `state`.
    *
-   * Handles both versioned state (wrapped in `{ version, data }` envelope) and
-   * unversioned legacy state (treated as version 0).
+   * Handles both flat versioned state (with a `version` field) and unversioned
+   * legacy state (plain object without `version`, treated as version 0).
    *
-   * @param state - The serialized keyring state (from vault or previous serialize).
-   * @returns The migrated state wrapped in a versioned envelope, plus a `migrated`
-   * flag.
-   * @throws If `state`'s version is newer than this chain's latest version, or if a
-   * step's `inputSchema`/`outputSchema` validation fails.
+   * @param state - The serialized keyring state (from vault or previous
+   * serialize).
+   * @returns The migrated state wrapped in a {@link MigrationResult}.
+   * @throws If `state` is not a plain object, if its version is newer than the
+   * chain's latest version, or if a step's `inputSchema`/`outputSchema`
+   * validation fails.
    */
   apply(state: Json): Promise<MigrationResult<Data>>;
 };
@@ -146,9 +181,9 @@ export type MigrationChain<Data extends Json = Json> = {
  *
  * @param steps - All steps of the chain.
  * @param state - The serialized keyring state.
- * @returns The migrated state wrapped in a versioned envelope, plus a `migrated` flag.
+ * @returns The migrated state in a {@link MigrationResult}.
  */
-async function applySteps<Data extends Json>(
+async function applySteps<Data extends JsonObject>(
   steps: readonly MigrationStep[],
   state: Json,
 ): Promise<MigrationResult<Data>> {
@@ -168,19 +203,26 @@ async function applySteps<Data extends Json>(
   }
 
   const pendingSteps = steps.slice(version);
-  let data = initialData;
+  let data: JsonObject = initialData;
 
   for (const step of pendingSteps) {
-    assert(data, step.inputSchema ?? JsonStruct);
+    if (step.inputSchema) {
+      assert(data, step.inputSchema);
+    }
     data = await step.migrate(data);
-    assert(data, step.outputSchema ?? JsonStruct);
+    if (step.outputSchema) {
+      assert(data, step.outputSchema);
+    } else {
+      assert(data as Json, JsonStruct);
+    }
   }
 
+  const migratedState = { ...data, version: latestVersion } as VersionedState<Data>;
   return {
     version: latestVersion,
-    data,
+    state: migratedState,
     migrated: pendingSteps.length > 0,
-  } as MigrationResult<Data>;
+  };
 }
 
 /**
@@ -189,12 +231,12 @@ async function applySteps<Data extends Json>(
  * @param steps - The steps accumulated so far.
  * @returns A chain exposing `add`, `version`, and `apply`.
  */
-function buildChain<Data extends Json>(
+function buildChain<Data extends JsonObject>(
   steps: readonly MigrationStep[],
 ): MigrationChain<Data> {
   return {
     version: steps.length,
-    add: <Input extends Data, Output extends Json>(
+    add: <Input extends Data, Output extends JsonObject>(
       step: MigrationStep<Input, Output>,
     ) => buildChain<Output>([...steps, step as unknown as MigrationStep]),
     apply: async (state) => applySteps<Data>(steps, state),
@@ -208,12 +250,13 @@ function buildChain<Data extends Json>(
  * ```typescript
  * const migrations = createMigrations()
  *   .add({ migrate: (data) => ({ count: data.numberOfItems }) })
- *   .add({ migrate: (data) => ({ ...data, createdAt: Date.now() }) }); // data typed as the first step's output, no cast
+ *   .add({ migrate: (data) => ({ ...data, createdAt: Date.now() }) });
  *
- * const { data } = await migrations.apply(state);
+ * const { state, migrated } = await migrations.apply(serializedState);
+ * // Persist `state`; re-save if `migrated` is true.
  * ```
- * @returns An empty chain, typed to accept `Json` as its first step's input.
+ * @returns An empty chain typed to `JsonObject`.
  */
-export function createMigrations(): MigrationChain<Json> {
-  return buildChain<Json>([]);
+export function createMigrations(): MigrationChain<JsonObject> {
+  return buildChain<JsonObject>([]);
 }

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -225,15 +225,14 @@ async function applySteps<Data extends JsonObject>(
     assert(data, step.outputSchema ?? JsonObjectStruct);
   }
 
-  const migratedState = {
-    ...data,
-    version: latestVersion,
-  } as VersionedState<Data>;
   return {
     version: latestVersion,
-    state: migratedState,
+    state: {
+      version: latestVersion,
+      ...data,
+    },
     migrated: pendingSteps.length > 0,
-  };
+  } as MigrationResult<Data>;
 }
 
 /**

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -101,7 +101,9 @@ function isJsonObject(value: Json): value is JsonObject {
  * @param state - The value to check.
  * @returns `true` if the value has a `version: integer` field.
  */
-export function isVersionedState(state: Json): state is VersionedState {
+export function isVersionedState<State extends JsonObject = JsonObject>(
+  state: State | VersionedState<State>,
+): state is VersionedState<State> {
   return is(state, VersionedStateStruct);
 }
 
@@ -116,13 +118,13 @@ export function isVersionedState(state: Json): state is VersionedState {
  * @returns The version number and the inner data object.
  */
 function getVersionAndData(state: Json): { version: number; data: JsonObject } {
+  if (!isJsonObject(state)) {
+    throw new Error('Unversioned state must be a plain object');
+  }
+
   if (isVersionedState(state)) {
     const { version, ...data } = state;
     return { version, data };
-  }
-
-  if (!isJsonObject(state)) {
-    throw new Error('Unversioned state must be a plain object');
   }
 
   return { version: 0, data: state };

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -73,7 +73,7 @@ export function isVersionedState(state: Json): state is VersionedState {
     typeof state === 'object' &&
     state !== null &&
     !Array.isArray(state) &&
-    Number.isInteger((state as Record<string, Json>).version)
+    Number.isInteger(state.version)
   );
 }
 
@@ -91,15 +91,15 @@ function getVersionAndData(
   state: Json,
 ): { version: number; data: JsonObject } {
   if (isVersionedState(state)) {
-    const { version, ...rest } = state as VersionedState;
-    return { version, data: rest as JsonObject };
+    const { version, ...rest } = state;
+    return { version, data: rest };
   }
 
   if (typeof state !== 'object' || state === null || Array.isArray(state)) {
     throw new Error('Unversioned state must be a plain object');
   }
 
-  return { version: 0, data: state as JsonObject };
+  return { version: 0, data: state };
 }
 
 /**
@@ -213,7 +213,7 @@ async function applySteps<Data extends JsonObject>(
     if (step.outputSchema) {
       assert(data, step.outputSchema);
     } else {
-      assert(data as Json, JsonStruct);
+      assert(data, JsonStruct);
     }
   }
 

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -1,5 +1,13 @@
 import type { Infer, Struct } from '@metamask/superstruct';
-import { assert, integer, is, record, refine, string, type } from '@metamask/superstruct';
+import {
+  assert,
+  integer,
+  is,
+  record,
+  refine,
+  string,
+  type,
+} from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
 
@@ -21,7 +29,8 @@ export type JsonObject = Record<string, Json>;
 export const JsonObjectStruct: Struct<JsonObject> = refine(
   record(string(), JsonStruct),
   'JsonObject',
-  (value) => typeof value === 'object' && value !== null && !Array.isArray(value),
+  (value) =>
+    typeof value === 'object' && value !== null && !Array.isArray(value),
 );
 
 /**

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -1,5 +1,5 @@
 import type { Infer, Struct } from '@metamask/superstruct';
-import { assert, integer, record, string, type } from '@metamask/superstruct';
+import { assert, integer, is, record, refine, string, type } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
 
@@ -15,9 +15,13 @@ export type JsonObject = Record<string, Json>;
  * Used as the default fallback schema for step input/output validation when no
  * explicit schema is provided.
  */
-export const JsonObjectStruct: Struct<JsonObject> = record(
-  string(),
-  JsonStruct,
+// `record(string(), JsonStruct)` alone would accept arrays: `typeof [] === 'object'`
+// satisfies superstruct's `isObject` check, and `Object.entries(['a', 'b'])` yields
+// valid string keys with JSON values. The refinement makes the array rejection explicit.
+export const JsonObjectStruct: Struct<JsonObject> = refine(
+  record(string(), JsonStruct),
+  'JsonObject',
+  (value) => typeof value === 'object' && value !== null && !Array.isArray(value),
 );
 
 /**
@@ -76,7 +80,7 @@ export type MigrationResult<Data extends JsonObject = JsonObject> = {
  * @returns `true` if the value is a non-null, non-array object.
  */
 function isJsonObject(value: Json): value is JsonObject {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  return is(value, JsonObjectStruct);
 }
 
 /**
@@ -89,7 +93,7 @@ function isJsonObject(value: Json): value is JsonObject {
  * @returns `true` if the value has a `version: integer` field.
  */
 export function isVersionedState(state: Json): state is VersionedState {
-  return isJsonObject(state) && Number.isInteger(state.version);
+  return is(state, VersionedStateStruct);
 }
 
 /**

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -261,7 +261,7 @@ function buildChain<Data extends JsonObject>(
  * ```typescript
  * const migrations = createMigrations()
  *   .add({ migrate: (data) => ({ count: data.numberOfItems }) })
- *   .add({ migrate: (data) => ({ ...data, createdAt: Date.now() }) });
+ *   .add({ migrate: (data) => ({ ...data, createdAt: Date.now() }) }); // data typed as the first step's output, no cast
  *
  * const { state, migrated } = await migrations.apply(serializedState);
  * // Persist `state`; re-save if `migrated` is true.

--- a/packages/keyring-sdk/src/migration.ts
+++ b/packages/keyring-sdk/src/migration.ts
@@ -1,4 +1,4 @@
-import type { Struct } from '@metamask/superstruct';
+import type { Infer, Struct } from '@metamask/superstruct';
 import { assert, integer, record, string, type } from '@metamask/superstruct';
 import { JsonStruct } from '@metamask/utils';
 import type { Json } from '@metamask/utils';
@@ -50,9 +50,8 @@ export const VersionedStateStruct = type({
  *   accounts: [],
  * };
  */
-export type VersionedState<Data extends JsonObject = JsonObject> = Data & {
-  version: number;
-};
+export type VersionedState<Data extends JsonObject = JsonObject> = Data &
+  Infer<typeof VersionedStateStruct>;
 
 /**
  * Return value of {@link MigrationChain.apply}.


### PR DESCRIPTION
Remove the use of the envelope for the migration's states. This allows more flexibility for systems/data that already uses a `version` field with a flat shape, making it more natural too.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Breaking API and on-disk/vault serialization shape for any consumer of `createMigrations`; integrators must migrate deserialize/serialize and stored state from envelope to flat form.
> 
> **Overview**
> **Breaking change:** The keyring migration framework no longer wraps state in `{ version, data }`. Serialized state is **flat**—`version` sits next to keyring fields—and `apply()` returns `{ version, state, migrated }` instead of putting payload on `data`.
> 
> Migration steps still receive and return inner data without `version`; the framework strips `version` before running steps and sets `state.version` to the chain version after (overriding any `version` a step returns). `isVersionedState` now means any plain object with an integer `version`, not an envelope with required `data`.
> 
> State must be a **plain JSON object** (`JsonObject`): unversioned `null` or arrays throw, and default step validation uses `JsonObjectStruct` rather than generic JSON. Typed chains and tests were updated for the new shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00307a3b9bc3217d44efd66a80296b41b9cf06f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->