### PR TITLE
fix: revert `originMetadata` addition to `EthKeyringV1Adapter`

### DIFF
--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- `EthKeyringV1Adapter` now passes `originMetadata: null` when submitting requests ([#615](https://github.com/MetaMask/accounts/pull/615))
-
 ## [3.1.0]
 
 ### Added

--- a/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
+++ b/packages/keyring-sdk/src/v2/eth/eth-keyring-v1-adapter.ts
@@ -522,7 +522,6 @@ export class EthKeyringV1Adapter<InnerKeyring extends KeyringV2 = KeyringV2>
     return (await this.inner.submitRequest({
       id: uuid(),
       origin: METAMASK_ORIGIN,
-      originMetadata: null,
       scope,
       account: account.id,
       request: {


### PR DESCRIPTION
Revert addition of `originMetadata`  to `EthKeyringV1Adapter`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small revert of request-shape metadata with no auth or vault changes; restores prior adapter behavior for internal MetaMask-origin requests.
> 
> **Overview**
> Reverts a recent change that added **`originMetadata: null`** to the payload passed to **`inner.submitRequest`** inside **`EthKeyringV1Adapter`**. Legacy ETH signing/export paths through the v1 adapter again submit requests with only **`id`**, **`origin`**, **`scope`**, **`account`**, and **`request`**—no explicit **`originMetadata`** field.
> 
> The **[Unreleased]** changelog note documenting that behavior is removed so the release notes no longer advertise it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bce76ea5cd079c6bc71743035257ae68bac2ba1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->