### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -15,7 +15,7 @@ jobs:
           - constraints
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
           node-version: ${{ matrix.node-version }}
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
           node-version: 24.x
@@ -57,7 +57,7 @@ jobs:
         node-version: [22.x, 24.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
           node-version: ${{ matrix.node-version }}
@@ -78,7 +78,7 @@ jobs:
         node-version: [22.x]
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check changelog
-        uses: MetaMask/github-tools/.github/actions/check-changelog@v1
+        uses: MetaMask/github-tools/.github/actions/check-changelog@8a343dd29c95b8478e0e92d8eed915ad50dcfaf0 # v1.18.0
         with:
           base-branch: ${{ github.event.pull_request.base.ref }}
           head-ref: ${{ github.head_ref }}

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close stale issues and PRs
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           stale-issue-message: This issue is marked as stale because it has been open for 60 days with no activity. Please remove the stale label or leave a comment, or it will be closed in 14 days.
           close-issue-message: This issue was closed due to no follow-up activity in the last 14 days. If you believe it was closed in error, please reopen it and provide evidence that it is still relevant. Thank you for your contributions.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.6.23
@@ -59,7 +59,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     steps:
       - id: is-release
-        uses: MetaMask/action-is-release@v2
+        uses: MetaMask/action-is-release@3cd51b98fa98d1347d06f5961299b0172ee31ae8 # v2.3.0
         with:
           commit-starts-with: 'release: [version]'
 

--- a/.github/workflows/publish-preview.yml
+++ b/.github/workflows/publish-preview.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Determine whether this PR is from a fork
         id: is-fork
         run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
@@ -29,14 +29,14 @@ jobs:
     if: ${{ needs.is-fork-pull-request.outputs.IS_FORK == 'false' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Check out pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@392abd40aa6a0600a3c0ef4af75851662587e6ec # v1.4.0
         with:
           is-high-risk-environment: true
       - name: Get commit SHA

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
+        uses: MetaMask/action-checkout-and-setup@0543b5929698c71e3ccc6ed24eac87825669b5de # v3.5.0
         with:
           is-high-risk-environment: true
-      - uses: MetaMask/action-publish-release@v3
+      - uses: MetaMask/action-publish-release@f01f1be110d60fb07d86c880ce3d6bdb353524d3 # v3.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn build
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: publish-release-artifacts-${{ github.sha }}
           include-hidden-files: true
@@ -41,15 +41,15 @@ jobs:
     needs: publish-release
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
+        uses: MetaMask/action-checkout-and-setup@0543b5929698c71e3ccc6ed24eac87825669b5de # v3.5.0
         with:
           is-high-risk-environment: true
       - name: Restore build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry run publish to NPM
-        uses: MetaMask/action-npm-publish@v6
+        uses: MetaMask/action-npm-publish@18df42148c35aabb98e00f9fda127d421af141df # v6.5.0
         with:
           dry-run: true
           # No need for `NPM_TOKEN` for dry-runs.
@@ -66,16 +66,16 @@ jobs:
       id-token: write
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
+        uses: MetaMask/action-checkout-and-setup@0543b5929698c71e3ccc6ed24eac87825669b5de # v3.5.0
         with:
           is-high-risk-environment: true
           ref: ${{ github.sha }}
       - name: Restore build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish to NPM
-        uses: MetaMask/action-npm-publish@v6
+        uses: MetaMask/action-npm-publish@18df42148c35aabb98e00f9fda127d421af141df # v6.5.0
         with:
           dry-run: false
           npm-token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -18,7 +18,7 @@ jobs:
       security-events: write
     steps:
       - name: MetaMask Security Code Scanner
-        uses: MetaMask/action-security-code-scanner@v1
+        uses: MetaMask/action-security-code-scanner@234d72bd10c689bdf09a58bcc96b367fb00f9ee8 # v1.1.0
         with:
           repo: ${{ github.repository }}
           paths_ignored: |


### PR DESCRIPTION
## Summary

Pin every `uses:` ref in `.github/workflows/` (and any composite action
files) to a full 40-character commit SHA, with the original tag
preserved as a `# vX` comment.

## Why

Tags and branches are mutable, so a compromised action can replace what
runs in our pipelines without changing the tag we reference. Pinning to
a SHA closes that supply-chain vector. See GitHub's hardening guide:
<https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions>.

## Deadline

**TechOps is enforcing SHA-pinned GitHub Actions across the org.**
Merging this PR brings the repo into compliance; workflows that still
reference mutable tags or branches may be blocked from running.

## How

Generated mechanically with [`pinact run`](https://github.com/suzuki-shunsuke/pinact).
No version bumps were applied (strict pin); follow-up upgrades can come
from Renovate or a separate `pinact run -u` PR.

## Test plan

- [ ] CI green on this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only reference updates with no version bumps or application code changes; CI behavior should match the previously referenced tags.
> 
> **Overview**
> Replaces every mutable `uses:` tag or branch in `.github/workflows/` with a **full 40-character commit SHA**, keeping the original version in a `# vX` comment. Coverage spans CI (lint/build/test), changelog checks, stale-issue automation, release and NPM publish, preview builds, workflow linting, and the security scanner.
> 
> This is a **supply-chain hardening** change only: workflow step inputs and job logic are unchanged. It aligns the repo with org policy ahead of the July 2026 enforcement deadline for SHA-pinned actions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67d13386bf0ae38ca3660fa4f7fa5bf044ac6a20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->