### PR TITLE
fix: eip712 domains not being valid for gen 5 devices

### DIFF
--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix Ledger Gen5 EIP-712 signing for payloads that omit the `EIP712Domain` type by deriving it from the `domain` object keys before sending to the device and before signature verification ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Fix Ledger Gen5 EIP-712 signing for payloads that omit the `EIP712Domain` type by deriving it from the `domain` object keys before sending to the device and before signature verification ([#624](https://github.com/MetaMask/accounts/pull/624))
 
 ## [13.0.2]
 

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
 
+### Fixed
+
+- Fix Ledger Gen5 EIP-712 signing for payloads that omit the `EIP712Domain` type by deriving it from the `domain` object keys before sending to the device and before signature verification ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 ## [13.0.2]
 
 ### Changed

--- a/packages/keyring-eth-ledger-bridge/src/eip712.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/eip712.test.ts
@@ -1,0 +1,221 @@
+import type { MessageTypes, TypedMessage } from '@metamask/eth-sig-util';
+import { SignTypedDataVersion, TypedDataUtils } from '@metamask/eth-sig-util';
+
+import { withDerivedEip712Domain } from './eip712';
+
+type TestTypedMessage = TypedMessage<MessageTypes>;
+
+describe('withDerivedEip712Domain', () => {
+  const uniswapV3Domain = {
+    name: 'Uniswap V3 Positions NFT-V1',
+    version: '1',
+    chainId: 1,
+    verifyingContract: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
+  };
+
+  const permitTypes = {
+    Permit: [
+      { name: 'spender', type: 'address' },
+      { name: 'tokenId', type: 'uint256' },
+      { name: 'nonce', type: 'uint256' },
+      { name: 'deadline', type: 'uint256' },
+    ],
+  };
+
+  const permitMessage = {
+    spender: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+    tokenId: 57,
+    nonce: 5,
+    deadline: 1755555555,
+  };
+
+  const fourFieldEip712Domain = [
+    { name: 'name', type: 'string' },
+    { name: 'version', type: 'string' },
+    { name: 'chainId', type: 'uint256' },
+    { name: 'verifyingContract', type: 'address' },
+  ];
+
+  it('derives a four-field EIP712Domain when types.EIP712Domain is missing and all four domain values are present', () => {
+    const data = {
+      domain: uniswapV3Domain,
+      types: permitTypes,
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    const result = withDerivedEip712Domain(data);
+
+    expect(result.types.EIP712Domain).toStrictEqual(fourFieldEip712Domain);
+  });
+
+  it('derives a five-field EIP712Domain when salt is also present', () => {
+    const data = {
+      domain: {
+        ...uniswapV3Domain,
+        salt: '0x0000000000000000000000000000000000000000000000000000000000000001',
+      },
+      types: permitTypes,
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    const result = withDerivedEip712Domain(data);
+
+    expect(result.types.EIP712Domain).toStrictEqual([
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+      { name: 'salt', type: 'bytes32' },
+    ]);
+  });
+
+  it('treats an empty EIP712Domain array as missing and derives it', () => {
+    const data = {
+      domain: uniswapV3Domain,
+      types: { EIP712Domain: [], ...permitTypes },
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    const result = withDerivedEip712Domain(data);
+
+    expect(result.types.EIP712Domain).toStrictEqual(fourFieldEip712Domain);
+  });
+
+  it('omits domain fields whose value is undefined or null', () => {
+    const data = {
+      domain: {
+        name: null,
+        version: '1',
+        chainId: 1,
+        verifyingContract: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
+      },
+      types: permitTypes,
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    const result = withDerivedEip712Domain(data);
+
+    expect(result.types.EIP712Domain).toStrictEqual([
+      { name: 'version', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ]);
+  });
+
+  it('ignores domain keys that are not in the canonical EIP-712 field set', () => {
+    const data = {
+      domain: {
+        name: 'My NFT',
+        chainId: 1,
+        verifyingContract: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
+        customField: 'not-a-canonical-field',
+      },
+      types: permitTypes,
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    const result = withDerivedEip712Domain(data);
+
+    expect(result.types.EIP712Domain).toStrictEqual([
+      { name: 'name', type: 'string' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' },
+    ]);
+  });
+
+  it('returns the input untouched when EIP712Domain is a non-empty array', () => {
+    const data = {
+      domain: uniswapV3Domain,
+      types: { EIP712Domain: fourFieldEip712Domain, ...permitTypes },
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    expect(withDerivedEip712Domain(data)).toBe(data);
+  });
+
+  it('returns the input untouched when no derivable domain fields are present', () => {
+    const data = {
+      domain: {},
+      types: permitTypes,
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    expect(withDerivedEip712Domain(data)).toBe(data);
+  });
+
+  it('tolerates payloads whose types or domain object is missing', () => {
+    const dataWithoutTypes = {
+      domain: uniswapV3Domain,
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    expect(
+      withDerivedEip712Domain(dataWithoutTypes).types.EIP712Domain,
+    ).toStrictEqual(fourFieldEip712Domain);
+
+    const dataWithoutDomain = {
+      types: permitTypes,
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    expect(withDerivedEip712Domain(dataWithoutDomain)).toBe(dataWithoutDomain);
+  });
+
+  it('preserves the other entries of types and the top-level keys when deriving', () => {
+    const mailType = [{ name: 'from', type: 'Person' }];
+    const data = {
+      domain: uniswapV3Domain,
+      types: { Mail: mailType, ...permitTypes },
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    const result = withDerivedEip712Domain(data);
+
+    expect(result.types.EIP712Domain).toStrictEqual(fourFieldEip712Domain);
+    expect(result.types.Permit).toBe(data.types.Permit);
+    expect(result.types.Mail).toBe(mailType);
+    expect(result.domain).toBe(data.domain);
+    expect(result.message).toBe(data.message);
+    expect(result.primaryType).toBe('Permit');
+  });
+
+  it('pins the derived domain separator to the Uniswap V3 NFT on-chain DOMAIN_SEPARATOR', () => {
+    const payload = {
+      domain: uniswapV3Domain,
+      types: permitTypes,
+      primaryType: 'Permit',
+      message: permitMessage,
+    } as unknown as TestTypedMessage;
+
+    const normalized = withDerivedEip712Domain(payload);
+
+    // The spec-correct separator for these domain values, matching the
+    // contract's on-chain DOMAIN_SEPARATOR.
+    expect(
+      TypedDataUtils.eip712DomainHash(
+        normalized,
+        SignTypedDataVersion.V4,
+      ).toString('hex'),
+    ).toBe('24ea63bbfcb16de2524c7c24322b6cbc39cb2d08881bce770af4771e6b1ad117');
+
+    // Documents the broken behavior: without derivation, eth-sig-util hashes
+    // the empty domain struct that sanitizeData injects for a missing
+    // EIP712Domain type.
+    expect(
+      TypedDataUtils.eip712DomainHash(
+        payload,
+        SignTypedDataVersion.V4,
+      ).toString('hex'),
+    ).toBe('6192106f129ce05c9075d319c1fa6ea9b3ae37cbd0c1ef92e2be7137bb07baa1');
+  });
+});

--- a/packages/keyring-eth-ledger-bridge/src/eip712.ts
+++ b/packages/keyring-eth-ledger-bridge/src/eip712.ts
@@ -1,0 +1,84 @@
+import type {
+  MessageTypeProperty,
+  MessageTypes,
+  TypedMessage,
+} from '@metamask/eth-sig-util';
+
+/**
+ * The canonical order in which EIP-712 domain fields are encoded when a
+ * contract builds its `DOMAIN_SEPARATOR`. The derived `EIP712Domain` type
+ * must list fields in this order for the host-computed domain separator to
+ * match the contract's on-chain value.
+ */
+const CANONICAL_EIP712_DOMAIN_FIELD_ORDER = [
+  'name',
+  'version',
+  'chainId',
+  'verifyingContract',
+  'salt',
+] as const;
+
+type Eip712DomainField = (typeof CANONICAL_EIP712_DOMAIN_FIELD_ORDER)[number];
+
+/**
+ * The EIP-712 ABI type of each canonical domain field.
+ */
+const EIP712_DOMAIN_FIELD_TYPES: Record<Eip712DomainField, string> = {
+  name: 'string',
+  version: 'string',
+  chainId: 'uint256',
+  verifyingContract: 'address',
+  salt: 'bytes32',
+};
+
+/**
+ * Returns typed data with a concrete `EIP712Domain` type derived from the
+ * keys of the `domain` object (ethers-style), when the payload omits or
+ * empties it. Payloads that already declare it are returned untouched.
+ *
+ * This is needed because `@metamask/eth-sig-util`'s `sanitizeData` defaults a
+ * missing `types.EIP712Domain` to an empty array, which produces a zero-field
+ * domain struct. The domain separator is then computed from
+ * `keccak256("EIP712Domain()")` instead of the actual domain values, and the
+ * Ledger device (whose Gen5 Ethereum app diverges on the zero-field domain
+ * case) receives an undefined-behavior payload. Deriving the field list up
+ * front makes both the device payload and the local signature verification
+ * use the real domain values.
+ *
+ * @param data - The typed data payload to normalize.
+ * @returns The normalized typed data, or the input untouched when its
+ * `EIP712Domain` type is already declared or when there is nothing to derive.
+ * @see {@link https://github.com/MetaMask/metamask-extension/issues/42625}
+ */
+export function withDerivedEip712Domain<Types extends MessageTypes>(
+  data: TypedMessage<Types>,
+): TypedMessage<Types> {
+  const declared = data.types?.EIP712Domain;
+  if (declared && declared.length > 0) {
+    // Well-formed payload — zero behavior change.
+    return data;
+  }
+
+  const present = CANONICAL_EIP712_DOMAIN_FIELD_ORDER.filter(
+    (field) =>
+      data.domain?.[field] !== undefined && data.domain?.[field] !== null,
+  );
+
+  if (present.length === 0) {
+    // Nothing to derive from.
+    return data;
+  }
+
+  return {
+    ...data,
+    types: {
+      ...data.types,
+      EIP712Domain: present.map(
+        (field): MessageTypeProperty => ({
+          name: field,
+          type: EIP712_DOMAIN_FIELD_TYPES[field],
+        }),
+      ),
+    },
+  } as TypedMessage<Types>;
+}

--- a/packages/keyring-eth-ledger-bridge/src/index.ts
+++ b/packages/keyring-eth-ledger-bridge/src/index.ts
@@ -1,4 +1,5 @@
 export * from './ledger-keyring';
+export * from './eip712';
 export * from './ledger-iframe-bridge';
 export * from './ledger-mobile-bridge';
 export * from './dmk/ledger-dmk-bridge';

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.test.ts
@@ -9,6 +9,7 @@ import { bytesToHex, Hex, remove0x } from '@metamask/utils';
 import EthereumTx from 'ethereumjs-tx';
 import HDKey from 'hdkey';
 
+import { withDerivedEip712Domain } from './eip712';
 import { LedgerBridge, LedgerBridgeOptions } from './ledger-bridge';
 import { LedgerIframeBridge } from './ledger-iframe-bridge';
 import { AccountDetails, LedgerKeyring } from './ledger-keyring';
@@ -1456,6 +1457,197 @@ describe('LedgerKeyring', function () {
             version: sigUtil.SignTypedDataVersion.V4,
           }),
         ).rejects.toThrow('Some other transport error');
+      });
+
+      // Matches the shape of the test dapp's `getNFTMsgParams()` payload from
+      // metamask-extension#42625: `domain` carries real values, but `types`
+      // omits the `EIP712Domain` entry.
+      const nftPermitData = {
+        domain: {
+          name: 'My NFT',
+          version: '1',
+          chainId: 1,
+          verifyingContract: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
+        },
+        message: {
+          spender: '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826',
+          tokenId: 57,
+          nonce: 5,
+          deadline: 1755555555,
+        },
+        primaryType: 'Permit' as const,
+        types: {
+          Permit: [
+            { name: 'spender', type: 'address' },
+            { name: 'tokenId', type: 'uint256' },
+            { name: 'nonce', type: 'uint256' },
+            { name: 'deadline', type: 'uint256' },
+          ],
+        },
+      };
+
+      const testPrivateKey = Buffer.from(
+        '4c0883a69102937d6231471b5dbb6204fe5129617082792ae468d01a3f362318',
+        'hex',
+      );
+
+      it('derives the EIP712Domain type and sends it to the device when the payload omits it', async function () {
+        const derivedAddress = bytesToHex(
+          ethUtil.privateToAddress(testPrivateKey),
+        );
+
+        const normalized = withDerivedEip712Domain(
+          nftPermitData as unknown as sigUtil.TypedMessage<sigUtil.MessageTypes>,
+        );
+        const signature = sigUtil.signTypedData({
+          privateKey: testPrivateKey,
+          data: normalized,
+          version: sigUtil.SignTypedDataVersion.V4,
+        });
+
+        const deviceSignTypedDataSpy = jest
+          .spyOn(keyring.bridge, 'deviceSignTypedData')
+          .mockImplementation(async () => ({
+            v: parseInt(signature.slice(130, 132), 16),
+            r: signature.slice(2, 66),
+            s: signature.slice(66, 130),
+          }));
+        const recoverTypedSignatureSpy = jest.spyOn(
+          sigUtil,
+          'recoverTypedSignature',
+        );
+
+        const result = await keyring.signTypedData(
+          derivedAddress,
+          nftPermitData as unknown as sigUtil.TypedMessage<sigUtil.MessageTypes>,
+          { version: sigUtil.SignTypedDataVersion.V4 },
+        );
+
+        expect(result).toBe(signature);
+        expect(deviceSignTypedDataSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            hdPath: "m/44'/60'/15'",
+            message: expect.objectContaining({
+              types: expect.objectContaining({
+                EIP712Domain: [
+                  { name: 'name', type: 'string' },
+                  { name: 'version', type: 'string' },
+                  { name: 'chainId', type: 'uint256' },
+                  { name: 'verifyingContract', type: 'address' },
+                ],
+              }),
+            }),
+          }),
+        );
+        expect(recoverTypedSignatureSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ data: normalized }),
+        );
+      });
+
+      it('treats an empty EIP712Domain array as missing and derives it', async function () {
+        const derivedAddress = bytesToHex(
+          ethUtil.privateToAddress(testPrivateKey),
+        );
+
+        const dataWithEmptyDomain = {
+          ...nftPermitData,
+          types: {
+            EIP712Domain: [],
+            Permit: nftPermitData.types.Permit,
+          },
+        } as unknown as sigUtil.TypedMessage<sigUtil.MessageTypes>;
+
+        const normalized = withDerivedEip712Domain(dataWithEmptyDomain);
+        const signature = sigUtil.signTypedData({
+          privateKey: testPrivateKey,
+          data: normalized,
+          version: sigUtil.SignTypedDataVersion.V4,
+        });
+
+        const deviceSignTypedDataSpy = jest
+          .spyOn(keyring.bridge, 'deviceSignTypedData')
+          .mockImplementation(async () => ({
+            v: parseInt(signature.slice(130, 132), 16),
+            r: signature.slice(2, 66),
+            s: signature.slice(66, 130),
+          }));
+
+        const result = await keyring.signTypedData(
+          derivedAddress,
+          dataWithEmptyDomain,
+          { version: sigUtil.SignTypedDataVersion.V4 },
+        );
+
+        expect(result).toBe(signature);
+        expect(deviceSignTypedDataSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            hdPath: "m/44'/60'/15'",
+            message: expect.objectContaining({
+              types: expect.objectContaining({
+                EIP712Domain: [
+                  { name: 'name', type: 'string' },
+                  { name: 'version', type: 'string' },
+                  { name: 'chainId', type: 'uint256' },
+                  { name: 'verifyingContract', type: 'address' },
+                ],
+              }),
+            }),
+          }),
+        );
+      });
+
+      it('leaves payloads with a declared EIP712Domain untouched for both device and verification', async function () {
+        const derivedAddress = bytesToHex(
+          ethUtil.privateToAddress(testPrivateKey),
+        );
+
+        const normalized = withDerivedEip712Domain(
+          fixtureData as unknown as sigUtil.TypedMessage<sigUtil.MessageTypes>,
+        );
+        const signature = sigUtil.signTypedData({
+          privateKey: testPrivateKey,
+          data: normalized,
+          version: sigUtil.SignTypedDataVersion.V4,
+        });
+
+        const deviceSignTypedDataSpy = jest
+          .spyOn(keyring.bridge, 'deviceSignTypedData')
+          .mockImplementation(async () => ({
+            v: parseInt(signature.slice(130, 132), 16),
+            r: signature.slice(2, 66),
+            s: signature.slice(66, 130),
+          }));
+        const recoverTypedSignatureSpy = jest.spyOn(
+          sigUtil,
+          'recoverTypedSignature',
+        );
+
+        const result = await keyring.signTypedData(
+          derivedAddress,
+          fixtureData as unknown as sigUtil.TypedMessage<sigUtil.MessageTypes>,
+          { version: sigUtil.SignTypedDataVersion.V4 },
+        );
+
+        expect(result).toBe(signature);
+        expect(deviceSignTypedDataSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            hdPath: "m/44'/60'/15'",
+            message: expect.objectContaining({
+              types: expect.objectContaining({
+                EIP712Domain: fixtureData.types.EIP712Domain,
+              }),
+            }),
+          }),
+        );
+        expect(recoverTypedSignatureSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              types: expect.objectContaining({
+                EIP712Domain: fixtureData.types.EIP712Domain,
+              }),
+            }),
+          }),
+        );
       });
     });
 

--- a/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
+++ b/packages/keyring-eth-ledger-bridge/src/ledger-keyring.ts
@@ -25,6 +25,7 @@ import { Buffer } from 'buffer';
 import type OldEthJsTransaction from 'ethereumjs-tx';
 import HDKey from 'hdkey';
 
+import { withDerivedEip712Domain } from './eip712';
 import { createKeyringStateError } from './errors';
 import {
   AppConfigurationResponse,
@@ -540,8 +541,13 @@ export class LedgerKeyring implements Keyring {
       throw createKeyringStateError(ErrorCode.DeviceStateOnlyV4Supported);
     }
 
+    // Normalize before `sanitizeData` injects an empty `EIP712Domain` type:
+    // derive it from the `domain` object keys when the payload omits it, so
+    // the device and the verification below both use the real domain values.
+    const normalizedData = withDerivedEip712Domain(data);
+
     const { domain, types, primaryType, message } =
-      TypedDataUtils.sanitizeData(data);
+      TypedDataUtils.sanitizeData(normalizedData);
 
     const hdPath = await this.unlockAccountByAddress(withAccount);
 
@@ -581,7 +587,7 @@ export class LedgerKeyring implements Keyring {
     );
     const signature = `0x${payload.r}${payload.s}${recoveryId}`;
     const addressSignedWith = recoverTypedSignature({
-      data,
+      data: normalizedData,
       signature,
       version: SignTypedDataVersion.V4,
     });


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->
**Description**

EIP-712 signing fails on Ledger Gen5 devices with "the signature doesn't match the right address" when the payload omits the EIP712Domain type (common — ethers-style dapps infer it from the domain object keys).
The missing type gets defaulted to an empty list, so both the device and local verification hash an empty domain struct instead of the real domain values. Gen5 devices handle this undefined case differently than older devices, causing the signature check to fail.

Fix: derive the EIP712Domain type from the domain object keys before signing and verification. Payloads that already declare it are untouched — zero behavior change for well-formed input.

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes EIP-712 normalization and signature recovery for payloads missing EIP712Domain; well-formed payloads are untouched, but incorrect derivation could affect permit/NFT signing on hardware wallets.
> 
> **Overview**
> Fixes **Ledger Gen5** failures when dapps send EIP-712 payloads with a populated `domain` but no `types.EIP712Domain` (common ethers-style shape). Without this, `@metamask/eth-sig-util` sanitization treats the domain type as empty, so the host hashes a zero-field domain while the device behaves differently—leading to **“The signature doesn't match the right address”**.
> 
> Adds **`withDerivedEip712Domain`**, which builds `EIP712Domain` from canonical domain keys (in contract order, skipping null/undefined and non-standard keys) when the type is missing or empty; payloads that already declare it are returned unchanged. **`LedgerKeyring.signTypedData`** runs this normalization before `sanitizeData`, sends the derived types to the device, and verifies with the same normalized data. The helper is **re-exported** from the package entry; unit and keyring tests cover NFT permit-style payloads and on-chain domain separator alignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c99a1a16d2b3f862c3202f89193b431d7936d995. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->