### PR TITLE
fix: update `eth-sig-util` to `9.0.0`

### DIFF
--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
-- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#626](https://github.com/MetaMask/accounts/pull/626))
 
 ## [15.0.0]
 

--- a/packages/keyring-eth-hd/CHANGELOG.md
+++ b/packages/keyring-eth-hd/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
 
 ## [15.0.0]
 

--- a/packages/keyring-eth-hd/package.json
+++ b/packages/keyring-eth-hd/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",
-    "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/key-tree": "^10.0.2",
     "@metamask/keyring-api": "^24.1.0",
     "@metamask/keyring-sdk": "^3.1.0",

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 ## [13.1.0]
 
 ### Changed

--- a/packages/keyring-eth-ledger-bridge/CHANGELOG.md
+++ b/packages/keyring-eth-ledger-bridge/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#626](https://github.com/MetaMask/accounts/pull/626))
 
 ## [13.1.0]
 

--- a/packages/keyring-eth-ledger-bridge/package.json
+++ b/packages/keyring-eth-ledger-bridge/package.json
@@ -77,7 +77,7 @@
     "@ledgerhq/device-signer-kit-ethereum": "^1.16.0",
     "@ledgerhq/hw-app-eth": "^6.42.0",
     "@ledgerhq/hw-transport": "^6.31.3",
-    "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/hw-wallet-sdk": "^1.0.0",
     "@metamask/keyring-api": "^24.1.0",
     "@metamask/keyring-sdk": "^3.1.0",

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
 
 ## [4.0.0]
 

--- a/packages/keyring-eth-money/CHANGELOG.md
+++ b/packages/keyring-eth-money/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
-- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#626](https://github.com/MetaMask/accounts/pull/626))
 
 ## [4.0.0]
 

--- a/packages/keyring-eth-money/package.json
+++ b/packages/keyring-eth-money/package.json
@@ -77,7 +77,7 @@
     "@lavamoat/allow-scripts": "^3.2.1",
     "@lavamoat/preinstall-always-fail": "^2.1.0",
     "@metamask/auto-changelog": "^6.1.0",
-    "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/key-tree": "^10.0.2",
     "@metamask/utils": "^11.11.0",
     "@ts-bridge/cli": "^0.6.3",

--- a/packages/keyring-eth-qr/CHANGELOG.md
+++ b/packages/keyring-eth-qr/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
 
 ## [3.0.0]
 

--- a/packages/keyring-eth-qr/CHANGELOG.md
+++ b/packages/keyring-eth-qr/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
-- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#626](https://github.com/MetaMask/accounts/pull/626))
 
 ## [3.0.0]
 

--- a/packages/keyring-eth-qr/package.json
+++ b/packages/keyring-eth-qr/package.json
@@ -74,7 +74,7 @@
     "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",
     "@keystonehq/bc-ur-registry-eth": "^0.19.1",
-    "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/keyring-api": "^24.1.0",
     "@metamask/keyring-sdk": "^3.1.0",
     "@metamask/keyring-utils": "^5.0.0",

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
 
 ## [13.0.0]
 

--- a/packages/keyring-eth-simple/CHANGELOG.md
+++ b/packages/keyring-eth-simple/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
-- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#626](https://github.com/MetaMask/accounts/pull/626))
 
 ## [13.0.0]
 

--- a/packages/keyring-eth-simple/package.json
+++ b/packages/keyring-eth-simple/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@ethereumjs/util": "^9.1.0",
-    "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/keyring-api": "^24.1.0",
     "@metamask/keyring-sdk": "^3.1.0",
     "@metamask/utils": "^11.11.0",

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
 
 ## [11.0.0]
 

--- a/packages/keyring-eth-trezor/CHANGELOG.md
+++ b/packages/keyring-eth-trezor/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bump `@metamask/keyring-sdk` from `^3.0.0` to `^3.1.0` ([#614](https://github.com/MetaMask/accounts/pull/614))
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
-- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#626](https://github.com/MetaMask/accounts/pull/626))
 
 ## [11.0.0]
 

--- a/packages/keyring-eth-trezor/package.json
+++ b/packages/keyring-eth-trezor/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@ethereumjs/tx": "^5.4.0",
     "@ethereumjs/util": "^9.1.0",
-    "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/hw-wallet-sdk": "^1.0.0",
     "@metamask/keyring-api": "^24.1.0",
     "@metamask/keyring-sdk": "^3.1.0",

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The envelope made it harder to integrate with existing state.
   - We still keep the requirement of having a `version` field to be declared, but the state can be "flatten" instead of living inside the `data` (envelope) field.
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
-- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#626](https://github.com/MetaMask/accounts/pull/626))
 
 ## [3.1.0]
 

--- a/packages/keyring-sdk/CHANGELOG.md
+++ b/packages/keyring-sdk/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The envelope made it harder to integrate with existing state.
   - We still keep the requirement of having a `version` field to be declared, but the state can be "flatten" instead of living inside the `data` (envelope) field.
 - Bump `@metamask/keyring-api` from `^24.0.0` to `^24.1.0` ([#620](https://github.com/MetaMask/accounts/pull/620))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
 
 ## [3.1.0]
 

--- a/packages/keyring-sdk/package.json
+++ b/packages/keyring-sdk/package.json
@@ -67,7 +67,7 @@
   },
   "dependencies": {
     "@ethereumjs/tx": "^5.4.0",
-    "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/keyring-api": "^24.1.0",
     "@metamask/keyring-utils": "^5.0.0",
     "@metamask/scure-bip39": "^2.1.1",

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#626](https://github.com/MetaMask/accounts/pull/626))
 
 ## [24.1.0]
 

--- a/packages/keyring-snap-bridge/CHANGELOG.md
+++ b/packages/keyring-snap-bridge/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 ## [24.1.0]
 
 ### Added

--- a/packages/keyring-snap-bridge/package.json
+++ b/packages/keyring-snap-bridge/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@ethereumjs/tx": "^5.4.0",
-    "@metamask/eth-sig-util": "^8.2.0",
+    "@metamask/eth-sig-util": "^9.0.0",
     "@metamask/keyring-internal-api": "^12.1.0",
     "@metamask/keyring-internal-snap-client": "^11.1.0",
     "@metamask/keyring-sdk": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1897,7 +1897,7 @@ __metadata:
     "@metamask/account-api": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/bip39": "npm:^4.0.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/key-tree": "npm:^10.0.2"
     "@metamask/keyring-api": "npm:^24.1.0"
     "@metamask/keyring-sdk": "npm:^3.1.0"
@@ -1935,7 +1935,7 @@ __metadata:
     "@ledgerhq/types-live": "npm:^6.52.0"
     "@metamask/account-api": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/hw-wallet-sdk": "npm:^1.0.0"
     "@metamask/keyring-api": "npm:^24.1.0"
     "@metamask/keyring-sdk": "npm:^3.1.0"
@@ -1970,7 +1970,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
     "@metamask/eth-hd-keyring": "npm:^15.0.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/key-tree": "npm:^10.0.2"
     "@metamask/keyring-api": "npm:^24.1.0"
     "@metamask/keyring-sdk": "npm:^3.1.0"
@@ -2000,7 +2000,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/account-api": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/keyring-api": "npm:^24.1.0"
     "@metamask/keyring-sdk": "npm:^3.1.0"
     "@metamask/keyring-utils": "npm:^5.0.0"
@@ -2044,9 +2044,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-sig-util@npm:^8.2.0":
-  version: 8.2.0
-  resolution: "@metamask/eth-sig-util@npm:8.2.0"
+"@metamask/eth-sig-util@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@metamask/eth-sig-util@npm:9.0.0"
   dependencies:
     "@ethereumjs/rlp": "npm:^4.0.1"
     "@ethereumjs/util": "npm:^8.1.0"
@@ -2055,7 +2055,7 @@ __metadata:
     "@scure/base": "npm:~1.1.3"
     ethereum-cryptography: "npm:^2.1.2"
     tweetnacl: "npm:^1.0.3"
-  checksum: 10/385df1ec541116e1bd725a1df1a519996bad167f99d1b2677126e398cdfda6fc3f03d2ff8f1ca523966bc0aae3ea92a9050953a45d5a7711f4128aacf9242bfc
+  checksum: 10/b4e0bc59fd306ee7d6308e9a21920ade79efbb2d157af06a71cf3fab2621e7373ea5e14159a18e28b21208ef5b949fef68e98ae54874ed07cef728f3a38f7d46
   languageName: node
   linkType: hard
 
@@ -2068,7 +2068,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/keyring-api": "npm:^24.1.0"
     "@metamask/keyring-sdk": "npm:^3.1.0"
     "@metamask/keyring-utils": "npm:^5.0.0"
@@ -2099,7 +2099,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/keyring-api": "npm:^24.0.0"
     "@metamask/keyring-internal-api": "npm:^12.1.0"
     "@metamask/keyring-internal-snap-client": "npm:^11.1.0"
@@ -2143,7 +2143,7 @@ __metadata:
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/account-api": "npm:^2.0.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/hw-wallet-sdk": "npm:^1.0.0"
     "@metamask/keyring-api": "npm:^24.1.0"
     "@metamask/keyring-sdk": "npm:^3.1.0"
@@ -2342,7 +2342,7 @@ __metadata:
     "@lavamoat/allow-scripts": "npm:^3.2.1"
     "@lavamoat/preinstall-always-fail": "npm:^2.1.0"
     "@metamask/auto-changelog": "npm:^6.1.0"
-    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/eth-sig-util": "npm:^9.0.0"
     "@metamask/keyring-api": "npm:^24.1.0"
     "@metamask/keyring-utils": "npm:^5.0.0"
     "@metamask/scure-bip39": "npm:^2.1.1"


### PR DESCRIPTION
## Explanation

Bumps `@metamask/eth-sig-util` from `^8.2.0` to `^9.0.0` across the eight packages that depend on it (`keyring-eth-simple`, `keyring-eth-hd`, `keyring-eth-trezor`, `keyring-eth-qr`, `keyring-eth-ledger-bridge`, `keyring-snap-bridge`, `keyring-eth-money`, `keyring-sdk`).

`v9.0.0` contains two breaking changes:

- Drops Node.js 18 and 20 support (minimum is now Node.js 22) — this repo already runs on Node.js 22+, so no impact.
- `signTypedData` now rejects ambiguous `bool` values (e.g. `0`, `1`, `'0'`, `''`) instead of coercing them via `Boolean()`. None of the affected packages pass non-boolean values to `bool` fields, so no code changes were required.

**Dependency update cascade:**
- `eth-sig-util@9.0.0` update: [MetaMask/eth-sig-util CHANGELOG](https://github.com/MetaMask/eth-sig-util/blob/main/CHANGELOG.md#900)
- Core controllers: [MetaMask/core#9999](https://github.com/MetaMask/core/pull/9999)
- Keyring updates: this PR
- Mobile resolution: [MetaMask/metamask-mobile#35410](https://github.com/MetaMask/metamask-mobile/pull/35410)
- Extension resolution: [MetaMask/metamask-extension#45854](https://github.com/MetaMask/metamask-extension/pull/45854)

## References

- [`@metamask/eth-sig-util` v9.0.0 changelog](https://github.com/MetaMask/eth-sig-util/blob/main/CHANGELOG.md#900)
- See: [fix: Update `eth-sig-util` to latest core#9999](https://github.com/MetaMask/core/pull/9999)

## Checklist

- [ ] I've updated the test suite for new or updated code as appropriate
- [ ] I've updated documentation (JSDoc, Markdown, etc.) for new or updated code as appropriate
- [ ] I've communicated my changes to consumers by updating changelogs for packages I've changed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signing-related dependency used across all Ethereum keyrings; v9’s stricter typed-data validation could surface new errors for ambiguous bool payloads even though this PR does not change local code.
> 
> **Overview**
> This PR upgrades **`@metamask/eth-sig-util`** from **`^8.2.0`** to **`^9.0.0`** in eight workspace packages (`keyring-sdk`, `keyring-eth-hd`, `keyring-eth-simple`, `keyring-eth-trezor`, `keyring-eth-qr`, `keyring-eth-ledger-bridge`, `keyring-snap-bridge`, and `keyring-eth-money` as a devDependency), updates each package’s **Unreleased** changelog entry, and refreshes **`yarn.lock`** to resolve **`9.0.0`**.
> 
> There are **no TypeScript or runtime code changes**—only dependency and documentation updates. Consumers of these packages will transitively pick up **`eth-sig-util` v9**, including stricter EIP-712 **`bool`** handling in **`signTypedData`** and the library’s Node 22+ requirement (already aligned with this monorepo’s **`engines`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddc5f5cd01b0065587e11de33005773c6bb9bc21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->