### PR TITLE
feat: use bearer token in requests

### DIFF
--- a/packages/keyring-eth-mpc/src/cloud.test.ts
+++ b/packages/keyring-eth-mpc/src/cloud.test.ts
@@ -50,7 +50,11 @@ describe('cloud helpers', () => {
       'https://cloud.example/net-id',
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer token-1',
+        },
+        body: '{}',
       }),
     );
   });
@@ -145,10 +149,14 @@ describe('cloud helpers', () => {
       data,
     });
 
-    const body = JSON.parse(
-      (fetchSpy.mock.calls[0]?.[1] as { body: string }).body,
-    ) as { data: string };
+    const init = fetchSpy.mock.calls[0]?.[1] as {
+      body: string;
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBe('Bearer token-1');
+    const body = JSON.parse(init.body) as { data: string; token?: string };
     expect(body.data).toBe('aGk=');
+    expect(body.token).toBeUndefined();
   });
 
   it('throws when cloud sign initialization fails', async () => {
@@ -213,11 +221,19 @@ describe('cloud helpers', () => {
       encryptedKeyShare,
     });
 
-    const body = JSON.parse(
-      (fetchSpy.mock.calls[0]?.[1] as { body: string }).body,
-    ) as { encryptedKeyShare: string; backupId: string };
+    const init = fetchSpy.mock.calls[0]?.[1] as {
+      body: string;
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBe('Bearer token-1');
+    const body = JSON.parse(init.body) as {
+      encryptedKeyShare: string;
+      backupId: string;
+      token?: string;
+    };
     expect(body.backupId).toBe('backup-1');
     expect(body.encryptedKeyShare).toBe(bytesToBase64(encryptedKeyShare));
+    expect(body.token).toBeUndefined();
   });
 
   it('throws when storing a key share backup fails', async () => {

--- a/packages/keyring-eth-mpc/src/cloud.ts
+++ b/packages/keyring-eth-mpc/src/cloud.ts
@@ -10,12 +10,14 @@ export type LoadKeyShareBackupResult = {
  * Fetch JSON from the MPC backend, throwing on non-OK responses.
  *
  * @param url - The request URL.
+ * @param token - Profile token sent as a Bearer header.
  * @param body - The JSON request body.
  * @param errorPrefix - Prefix for the thrown error message.
  * @returns The parsed JSON body, or `undefined` when the response is empty.
  */
 async function postJson<Response>(
   url: string,
+  token: string,
   body: Record<string, unknown>,
   errorPrefix: string,
 ): Promise<Response> {
@@ -23,6 +25,7 @@ async function postJson<Response>(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(body),
   });
@@ -52,7 +55,8 @@ export async function getNetId(opts: {
 }): Promise<PartyId> {
   const data = await postJson<{ netId: string }>(
     `${opts.baseURL}/net-id`,
-    { token: opts.token },
+    opts.token,
+    {},
     'Failed to get server network id',
   );
   return data.netId;
@@ -75,8 +79,8 @@ export async function createKey(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/create-key`,
+    opts.token,
     {
-      token: opts.token,
       clientNetId: opts.clientNetId,
       nonce: opts.nonce,
     },
@@ -99,8 +103,8 @@ export async function registerClient(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/register-client`,
+    opts.token,
     {
-      token: opts.token,
       clientNetId: opts.clientNetId,
     },
     'Failed to register client',
@@ -126,8 +130,8 @@ export async function sign(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/sign`,
+    opts.token,
     {
-      token: opts.token,
       data: bytesToBase64(opts.data),
       clientNetId: opts.clientNetId,
       nonce: opts.nonce,
@@ -153,8 +157,8 @@ export async function rotateKeyShares(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/rotate-key-shares`,
+    opts.token,
     {
-      token: opts.token,
       clientNetId: opts.clientNetId,
       nonce: opts.nonce,
     },
@@ -179,8 +183,8 @@ export async function storeKeyShareBackup(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/store-key-share-backup`,
+    opts.token,
     {
-      token: opts.token,
       backupId: opts.backupId,
       encryptedKeyShare: bytesToBase64(opts.encryptedKeyShare),
     },
@@ -202,7 +206,8 @@ export async function checkKeyShareBackupId(opts: {
 }): Promise<string | null> {
   const data = await postJson<{ backupId?: string | null }>(
     `${opts.baseURL}/check-key-share-backup-id`,
-    { token: opts.token },
+    opts.token,
+    {},
     'Failed to check key share backup id',
   );
   return typeof data.backupId === 'string' ? data.backupId : null;
@@ -225,7 +230,8 @@ export async function loadKeyShareBackup(opts: {
     backupId: string;
   }>(
     `${opts.baseURL}/load-key-share-backup`,
-    { token: opts.token },
+    opts.token,
+    {},
     'Failed to load key share backup',
   );
   return {


### PR DESCRIPTION
## Summary

- MPC cloud HTTP calls now send the profile token in an `Authorization: Bearer <token>` header instead of including `token` in JSON request bodies.
- The shared `postJson` helper accepts the token as a separate argument and applies it consistently across all MPC backend requests.
- Token-only endpoints (`getNetId`, `checkKeyShareBackupId`, `loadKeyShareBackup`) still use POST but now send an empty JSON body (`{}`).

## Test plan

- [x] Run `packages/keyring-eth-mpc` unit tests (`cloud.test.ts`)
- [x] Verify `getNetId` requests include the Bearer header and send `{}` as the body
- [x] Verify sign and backup helpers include the Bearer header and omit `token` from the JSON payload
- [ ] Confirm MPC backend accepts Bearer authentication for affected endpoints before merge