### PR TITLE
feat: loadKeyShare use getJson

### DIFF
--- a/packages/keyring-eth-mpc/src/cloud.test.ts
+++ b/packages/keyring-eth-mpc/src/cloud.test.ts
@@ -304,6 +304,14 @@ describe('cloud helpers', () => {
       encryptedKeyShare,
       backupId: 'backup-1',
     });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://cloud.example/load-key-share-backup',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Authorization: 'Bearer token-1' },
+      }),
+    );
   });
 
   it('throws when loading a key share backup fails', async () => {

--- a/packages/keyring-eth-mpc/src/cloud.ts
+++ b/packages/keyring-eth-mpc/src/cloud.ts
@@ -7,7 +7,51 @@ export type LoadKeyShareBackupResult = {
 };
 
 /**
- * Fetch JSON from the MPC backend, throwing on non-OK responses.
+ * Parse a fetch response as JSON, throwing on non-OK status.
+ *
+ * @param response - The fetch response.
+ * @param errorPrefix - Prefix for the thrown error message.
+ * @returns The parsed JSON body, or `undefined` when the response is empty.
+ */
+async function parseJsonResponse<Result>(
+  response: Response,
+  errorPrefix: string,
+): Promise<Result> {
+  if (!response.ok) {
+    throw new Error(`${errorPrefix}: ${response.statusText}`);
+  }
+
+  const text = await response.text();
+  if (text.length === 0) {
+    return undefined as Result;
+  }
+  return JSON.parse(text) as Result;
+}
+
+/**
+ * GET JSON from the MPC backend, throwing on non-OK responses.
+ *
+ * @param url - The request URL.
+ * @param token - Profile token sent as a Bearer header.
+ * @param errorPrefix - Prefix for the thrown error message.
+ * @returns The parsed JSON body, or `undefined` when the response is empty.
+ */
+async function getJson<Result>(
+  url: string,
+  token: string,
+  errorPrefix: string,
+): Promise<Result> {
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return parseJsonResponse(response, errorPrefix);
+}
+
+/**
+ * POST JSON to the MPC backend, throwing on non-OK responses.
  *
  * @param url - The request URL.
  * @param token - Profile token sent as a Bearer header.
@@ -15,12 +59,12 @@ export type LoadKeyShareBackupResult = {
  * @param errorPrefix - Prefix for the thrown error message.
  * @returns The parsed JSON body, or `undefined` when the response is empty.
  */
-async function postJson<Response>(
+async function postJson<Result>(
   url: string,
   token: string,
   body: Record<string, unknown>,
   errorPrefix: string,
-): Promise<Response> {
+): Promise<Result> {
   const response = await fetch(url, {
     method: 'POST',
     headers: {
@@ -29,16 +73,7 @@ async function postJson<Response>(
     },
     body: JSON.stringify(body),
   });
-
-  if (!response.ok) {
-    throw new Error(`${errorPrefix}: ${response.statusText}`);
-  }
-
-  const text = await response.text();
-  if (text.length === 0) {
-    return undefined as Response;
-  }
-  return JSON.parse(text) as Response;
+  return parseJsonResponse(response, errorPrefix);
 }
 
 /**
@@ -225,13 +260,12 @@ export async function loadKeyShareBackup(opts: {
   baseURL: string;
   token: string;
 }): Promise<LoadKeyShareBackupResult> {
-  const data = await postJson<{
+  const data = await getJson<{
     encryptedKeyShare: string;
     backupId: string;
   }>(
     `${opts.baseURL}/load-key-share-backup`,
     opts.token,
-    {},
     'Failed to load key share backup',
   );
   return {


### PR DESCRIPTION
## Summary

- Add a shared `parseJsonResponse` helper in `packages/keyring-eth-mpc/src/cloud.ts` to centralize JSON parsing and non-OK error handling for cloud API responses.
- Introduce `getJson` for Bearer-authenticated GET requests and refactor `postJson` to reuse `parseJsonResponse`.
- Update `loadKeyShareBackup` to call `getJson` with GET instead of POST with an empty body.

## Test plan

- [ ] Run `yarn test` in `packages/keyring-eth-mpc` and confirm all tests pass.
- [ ] Confirm the `loadKeyShareBackup` test asserts a GET request with an `Authorization: Bearer <token>` header.