### PR TITLE
feat: loadKeyShare use getJson 

### DIFF
--- a/packages/keyring-eth-mpc/CHANGELOG.md
+++ b/packages/keyring-eth-mpc/CHANGELOG.md
@@ -16,4 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bind key-share backups to the DKG attempt nonce so a delayed backup cannot attach to a retried share.
   - Serialize sign, rotate, and sync on one op queue to avoid stale local state overwrites.
 
+### Changed
+
+- Send the MPC profile token as an `Authorization: Bearer` header instead of in the JSON request body ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+
 [Unreleased]: https://github.com/MetaMask/accounts/

--- a/packages/keyring-eth-mpc/CHANGELOG.md
+++ b/packages/keyring-eth-mpc/CHANGELOG.md
@@ -18,6 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Send the MPC profile token as an `Authorization: Bearer` header instead of in the JSON request body ([#TODO](https://github.com/MetaMask/accounts/pull/TODO))
+- Send the MPC profile token as an `Authorization: Bearer` header instead of in the JSON request body ([#630](https://github.com/MetaMask/accounts/pull/630))
 
 [Unreleased]: https://github.com/MetaMask/accounts/

--- a/packages/keyring-eth-mpc/CHANGELOG.md
+++ b/packages/keyring-eth-mpc/CHANGELOG.md
@@ -11,9 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of `@metamask/eth-mpc-keyring` ([#627](https://github.com/MetaMask/accounts/pull/627))
 
-### Changed
-
-- Send the MPC profile token as an `Authorization: Bearer` header instead of in the JSON request body ([#630](https://github.com/MetaMask/accounts/pull/630))
-- Load key-share backups with `GET /load-key-share-backup` instead of `POST` ([#631](https://github.com/MetaMask/accounts/pull/631))
-
 [Unreleased]: https://github.com/MetaMask/accounts/

--- a/packages/keyring-eth-mpc/CHANGELOG.md
+++ b/packages/keyring-eth-mpc/CHANGELOG.md
@@ -19,5 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Send the MPC profile token as an `Authorization: Bearer` header instead of in the JSON request body ([#630](https://github.com/MetaMask/accounts/pull/630))
+- Load key-share backups with `GET /load-key-share-backup` instead of `POST` ([#631](https://github.com/MetaMask/accounts/pull/631))
 
 [Unreleased]: https://github.com/MetaMask/accounts/

--- a/packages/keyring-eth-mpc/src/cloud.test.ts
+++ b/packages/keyring-eth-mpc/src/cloud.test.ts
@@ -353,6 +353,14 @@ describe('cloud helpers', () => {
       encryptedKeyShare,
       epoch: 3,
     });
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      'https://cloud.example/load-key-share-backup',
+      expect.objectContaining({
+        method: 'GET',
+        headers: { Authorization: 'Bearer token-1' },
+      }),
+    );
   });
 
   it('throws when loading a key share backup fails', async () => {

--- a/packages/keyring-eth-mpc/src/cloud.test.ts
+++ b/packages/keyring-eth-mpc/src/cloud.test.ts
@@ -51,7 +51,11 @@ describe('cloud helpers', () => {
       'https://cloud.example/net-id',
       expect.objectContaining({
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer token-1',
+        },
+        body: '{}',
       }),
     );
   });
@@ -147,11 +151,19 @@ describe('cloud helpers', () => {
       shareEpoch: 1,
     });
 
-    const body = JSON.parse(
-      (fetchSpy.mock.calls[0]?.[1] as { body: string }).body,
-    ) as { data: string; shareEpoch: number };
+    const init = fetchSpy.mock.calls[0]?.[1] as {
+      body: string;
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBe('Bearer token-1');
+    const body = JSON.parse(init.body) as {
+      data: string;
+      shareEpoch: number;
+      token?: string;
+    };
     expect(body.data).toBe('aGk=');
     expect(body.shareEpoch).toBe(1);
+    expect(body.token).toBeUndefined();
   });
 
   it('throws when cloud sign initialization fails', async () => {
@@ -224,12 +236,21 @@ describe('cloud helpers', () => {
       encryptedKeyShare,
     });
 
-    const body = JSON.parse(
-      (fetchSpy.mock.calls[0]?.[1] as { body: string }).body,
-    ) as { encryptedKeyShare: string; epoch: number; attemptNonce: string };
+    const init = fetchSpy.mock.calls[0]?.[1] as {
+      body: string;
+      headers: Record<string, string>;
+    };
+    expect(init.headers.Authorization).toBe('Bearer token-1');
+    const body = JSON.parse(init.body) as {
+      encryptedKeyShare: string;
+      epoch: number;
+      attemptNonce: string;
+      token?: string;
+    };
     expect(body.epoch).toBe(2);
     expect(body.attemptNonce).toBe('0xnonce');
     expect(body.encryptedKeyShare).toBe(bytesToBase64(encryptedKeyShare));
+    expect(body.token).toBeUndefined();
   });
 
   it('throws when storing a key share backup fails', async () => {

--- a/packages/keyring-eth-mpc/src/cloud.ts
+++ b/packages/keyring-eth-mpc/src/cloud.ts
@@ -16,12 +16,14 @@ export type CheckKeyShareResult = {
  * Fetch JSON from the MPC backend, throwing on non-OK responses.
  *
  * @param url - The request URL.
+ * @param token - Profile token sent as a Bearer header.
  * @param body - The JSON request body.
  * @param errorPrefix - Prefix for the thrown error message.
  * @returns The parsed JSON body, or `undefined` when the response is empty.
  */
 async function postJson<Response>(
   url: string,
+  token: string,
   body: Record<string, unknown>,
   errorPrefix: string,
 ): Promise<Response> {
@@ -29,6 +31,7 @@ async function postJson<Response>(
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
     },
     body: JSON.stringify(body),
   });
@@ -58,7 +61,8 @@ export async function getNetId(opts: {
 }): Promise<PartyId> {
   const data = await postJson<{ netId: string }>(
     `${opts.baseURL}/net-id`,
-    { token: opts.token },
+    opts.token,
+    {},
     'Failed to get server network id',
   );
   return data.netId;
@@ -81,8 +85,8 @@ export async function createKey(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/create-key`,
+    opts.token,
     {
-      token: opts.token,
       clientNetId: opts.clientNetId,
       nonce: opts.nonce,
     },
@@ -105,8 +109,8 @@ export async function registerClient(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/register-client`,
+    opts.token,
     {
-      token: opts.token,
       clientNetId: opts.clientNetId,
     },
     'Failed to register client',
@@ -134,8 +138,8 @@ export async function sign(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/sign`,
+    opts.token,
     {
-      token: opts.token,
       data: bytesToBase64(opts.data),
       clientNetId: opts.clientNetId,
       nonce: opts.nonce,
@@ -164,8 +168,8 @@ export async function rotateKeyShares(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/rotate-key-shares`,
+    opts.token,
     {
-      token: opts.token,
       clientNetId: opts.clientNetId,
       nonce: opts.nonce,
       expectedActiveEpoch: opts.expectedActiveEpoch,
@@ -193,8 +197,8 @@ export async function storeKeyShareBackup(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/store-key-share-backup`,
+    opts.token,
     {
-      token: opts.token,
       epoch: opts.epoch,
       attemptNonce: opts.attemptNonce,
       encryptedKeyShare: bytesToBase64(opts.encryptedKeyShare),
@@ -217,7 +221,8 @@ export async function checkKeyShare(opts: {
 }): Promise<CheckKeyShareResult> {
   return await postJson<CheckKeyShareResult>(
     `${opts.baseURL}/check-key-share`,
-    { token: opts.token },
+    opts.token,
+    {},
     'Failed to check key share',
   );
 }
@@ -237,8 +242,8 @@ export async function setActiveEpoch(opts: {
 }): Promise<void> {
   await postJson(
     `${opts.baseURL}/set-active-epoch`,
+    opts.token,
     {
-      token: opts.token,
       epoch: opts.epoch,
     },
     'Failed to set active epoch',
@@ -262,7 +267,8 @@ export async function loadKeyShareBackup(opts: {
     epoch: number;
   }>(
     `${opts.baseURL}/load-key-share-backup`,
-    { token: opts.token },
+    opts.token,
+    {},
     'Failed to load key share backup',
   );
   return {

--- a/packages/keyring-eth-mpc/src/cloud.ts
+++ b/packages/keyring-eth-mpc/src/cloud.ts
@@ -13,7 +13,51 @@ export type CheckKeyShareResult = {
 };
 
 /**
- * Fetch JSON from the MPC backend, throwing on non-OK responses.
+ * Parse a fetch response as JSON, throwing on non-OK status.
+ *
+ * @param response - The fetch response.
+ * @param errorPrefix - Prefix for the thrown error message.
+ * @returns The parsed JSON body, or `undefined` when the response is empty.
+ */
+async function parseJsonResponse<Result>(
+  response: Response,
+  errorPrefix: string,
+): Promise<Result> {
+  if (!response.ok) {
+    throw new Error(`${errorPrefix}: ${response.statusText}`);
+  }
+
+  const text = await response.text();
+  if (text.length === 0) {
+    return undefined as Result;
+  }
+  return JSON.parse(text) as Result;
+}
+
+/**
+ * GET JSON from the MPC backend, throwing on non-OK responses.
+ *
+ * @param url - The request URL.
+ * @param token - Profile token sent as a Bearer header.
+ * @param errorPrefix - Prefix for the thrown error message.
+ * @returns The parsed JSON body, or `undefined` when the response is empty.
+ */
+async function getJson<Result>(
+  url: string,
+  token: string,
+  errorPrefix: string,
+): Promise<Result> {
+  const response = await fetch(url, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+  return parseJsonResponse(response, errorPrefix);
+}
+
+/**
+ * POST JSON to the MPC backend, throwing on non-OK responses.
  *
  * @param url - The request URL.
  * @param token - Profile token sent as a Bearer header.
@@ -21,12 +65,12 @@ export type CheckKeyShareResult = {
  * @param errorPrefix - Prefix for the thrown error message.
  * @returns The parsed JSON body, or `undefined` when the response is empty.
  */
-async function postJson<Response>(
+async function postJson<Result>(
   url: string,
   token: string,
   body: Record<string, unknown>,
   errorPrefix: string,
-): Promise<Response> {
+): Promise<Result> {
   const response = await fetch(url, {
     method: 'POST',
     headers: {
@@ -35,16 +79,7 @@ async function postJson<Response>(
     },
     body: JSON.stringify(body),
   });
-
-  if (!response.ok) {
-    throw new Error(`${errorPrefix}: ${response.statusText}`);
-  }
-
-  const text = await response.text();
-  if (text.length === 0) {
-    return undefined as Response;
-  }
-  return JSON.parse(text) as Response;
+  return parseJsonResponse(response, errorPrefix);
 }
 
 /**
@@ -262,13 +297,12 @@ export async function loadKeyShareBackup(opts: {
   baseURL: string;
   token: string;
 }): Promise<LoadKeyShareBackupResult> {
-  const data = await postJson<{
+  const data = await getJson<{
     encryptedKeyShare: string;
     epoch: number;
   }>(
     `${opts.baseURL}/load-key-share-backup`,
     opts.token,
-    {},
     'Failed to load key share backup',
   );
   return {


### PR DESCRIPTION
<!--
Thanks for your contribution! Take a moment to answer these questions so that reviewers have the information they need to properly understand your changes:

* What is the current state of things and why does it need to change?
* What is the solution your changes offer and how does it work?

Are there any issues or other links reviewers should consult to understand this pull request better? For instance:

* Fixes #12345
* See: #67890
-->

## Summary

- Add a shared `parseJsonResponse` helper in `packages/keyring-eth-mpc/src/cloud.ts` to centralize JSON parsing and non-OK error handling for cloud API responses.
- Introduce `getJson` for Bearer-authenticated GET requests and refactor `postJson` to reuse `parseJsonResponse`.
- Update `loadKeyShareBackup` to call `getJson` with GET instead of POST with an empty body.

<!--
Are there any examples of this change being used in another repository?

When considering changes to the MetaMask module template, it's strongly preferred that the change be experimented with in another repository first. This gives reviewers a better sense of how the change works, making it less likely the change will need to be reverted or adjusted later.
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the HTTP method for loading encrypted key-share backups; behavior depends on the MPC backend accepting GET on that route.
> 
> **Overview**
> Refactors MPC cloud HTTP helpers and fixes how encrypted key-share backups are fetched.
> 
> **`cloud.ts`** adds **`parseJsonResponse`** for shared non-OK handling and JSON/empty-body parsing, introduces **`getJson`** for Bearer-authenticated GETs, and routes **`postJson`** through the same parser (generic renamed to **`Result`**). **`loadKeyShareBackup`** now calls **`getJson`** on `/load-key-share-backup` instead of **`postJson`** with an empty body.
> 
> **`cloud.test.ts`** asserts the backup load uses **GET** with **`Authorization: Bearer`** and no POST body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2690e548a50e64fc378a92293bb89daa93e69030. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->